### PR TITLE
[FEATURE] Active directory authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ Ein User hat immer eine oder mehrere folgender Berechtigungen inne:
 * **Boss**:	darf Urlaubsanträge von Mitarbeitern einsehen, genehmigen und ablehnen
 * **Office**: darf Mitarbeiterdaten verwalten, Urlaub für Mitarbeiter beantragen und Urlaubsanträge stornieren
 
+### Active Directory
+
+Um Die Anbindung an ein Active Directory Server zu ermöglichen, muss der Verwendete Authentifizierungs-Provider geändert werden.
+Dazu muss die Umgebungsvariable `AUTHENTICATION_PROVIDER` auf den Wert `activeDirectoryAuthProvider` gesetzt werden.
+
+Die erforderlichen Optionen für die Konfiguration der Active Directory Authentifizierung sind:
+
+* `AD_DOMAIN` - Der Name der Active Directory Domain, z.B: mydomain.tld
+* `AD_DOMAINCONTROLLER_URL` - Die URL zum LDAP Server / Domaincontroller, z.B: ldap://domaincontroller.mydomain.tld/
+
+Die Konfiguration der Authentifizierung kann in folgenden Dateien gefunden werden:
+
+* `src/main/resources/config.properties`
+* `src/main/resources/META-INF/spring-security.xml`
+
 ## Development
 
 Die Anwendung basiert auf dem [Spring](http://www.springsource.org/) MVC Framework. Zur Ermittlung von Feiertagen wird das Framework [Jollyday](http://jollyday.sourceforge.net/) benutzt. Das Frontend beinhaltet Elemente von [Bootstrap](http://getbootstrap.com/) gewürzt mit einer Prise [jQuery](http://jquery.com/) und [Font Awesome](http://fontawesome.io/).

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryAuthenticationExceptionCustom.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryAuthenticationExceptionCustom.java
@@ -16,15 +16,18 @@ import org.springframework.security.core.AuthenticationException;
 
 /**
  * <p>
- * Thrown as a translation of an {@link javax.naming.AuthenticationException} when attempting to authenticate against
- * Active Directory using {@link ActiveDirectoryLdapAuthenticationProvider}. Typically this error is wrapped by an
- * {@link AuthenticationException} since it does not provide a user friendly message. When wrapped, the original
- * Exception can be caught and {@link ActiveDirectoryAuthenticationException} can be accessed using
+ * Thrown as a translation of an {@link javax.naming.AuthenticationException}
+ * when attempting to authenticate against Active Directory using
+ * {@link ActiveDirectoryLdapAuthenticationProvider}. Typically this error is
+ * wrapped by an {@link AuthenticationException} since it does not provide a
+ * user friendly message. When wrapped, the original Exception can be caught and
+ * {@link ActiveDirectoryAuthenticationException} can be accessed using
  * {@link AuthenticationException#getCause()} for custom error handling.
  * </p>
  * <p>
- * The {@link #getDataCode()} will return the error code associated with the data portion of the error message. For
- * example, the following error message would return 773 for {@link #getDataCode()}.
+ * The {@link #getDataCode()} will return the error code associated with the
+ * data portion of the error message. For example, the following error message
+ * would return 773 for {@link #getDataCode()}.
  * </p>
  *
  * <pre>
@@ -35,6 +38,7 @@ import org.springframework.security.core.AuthenticationException;
  */
 @SuppressWarnings("serial")
 public final class ActiveDirectoryAuthenticationExceptionCustom extends AuthenticationException {
+
     private final String dataCode;
 
     ActiveDirectoryAuthenticationExceptionCustom(String dataCode, String message, Throwable cause) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryAuthenticationExceptionCustom.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryAuthenticationExceptionCustom.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.synyx.urlaubsverwaltung.security;
+
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * <p>
+ * Thrown as a translation of an {@link javax.naming.AuthenticationException} when attempting to authenticate against
+ * Active Directory using {@link ActiveDirectoryLdapAuthenticationProvider}. Typically this error is wrapped by an
+ * {@link AuthenticationException} since it does not provide a user friendly message. When wrapped, the original
+ * Exception can be caught and {@link ActiveDirectoryAuthenticationException} can be accessed using
+ * {@link AuthenticationException#getCause()} for custom error handling.
+ * </p>
+ * <p>
+ * The {@link #getDataCode()} will return the error code associated with the data portion of the error message. For
+ * example, the following error message would return 773 for {@link #getDataCode()}.
+ * </p>
+ *
+ * <pre>
+ * javax.naming.AuthenticationException: [LDAP: error code 49 - 80090308: LdapErr: DSID-0C090334, comment: AcceptSecurityContext error, data 775, vece ]
+ * </pre>
+ *
+ * @author Rob Winch
+ */
+@SuppressWarnings("serial")
+public final class ActiveDirectoryAuthenticationExceptionCustom extends AuthenticationException {
+    private final String dataCode;
+
+    ActiveDirectoryAuthenticationExceptionCustom(String dataCode, String message, Throwable cause) {
+        super(message, cause);
+        this.dataCode = dataCode;
+    }
+
+    public String getDataCode() {
+        return dataCode;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryLdapAuthenticationProviderCustom.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryLdapAuthenticationProviderCustom.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.synyx.urlaubsverwaltung.security;
+
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.support.LdapUtils;
+import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
+import org.springframework.security.ldap.authentication.AbstractLdapAuthenticationProvider;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import javax.naming.AuthenticationException;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.ldap.InitialLdapContext;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Specialized LDAP authentication provider which uses Active Directory
+ * configuration conventions.
+ * <p>
+ * It will authenticate using the Active Directory
+ * <a
+ * href="http://msdn.microsoft.com/en-us/library/ms680857%28VS.85%29.aspx">{@code userPrincipalName}</a>
+ * (in the form {@code username@domain}). If the username does not already end
+ * with the domain name, the {@code userPrincipalName} will be built by
+ * appending the configured domain name to the username supplied in the
+ * authentication request. If no domain name is configured, it is assumed that
+ * the username will always contain the domain name.
+ * <p>
+ * The user authorities are obtained from the data contained in the
+ * {@code memberOf} attribute.
+ *
+ * <h3>Active Directory Sub-Error Codes</h3>
+ *
+ * When an authentication fails, resulting in a standard LDAP 49 error code,
+ * Active Directory also supplies its own sub-error codes within the error
+ * message. These will be used to provide additional log information on why an
+ * authentication has failed. Typical examples are
+ *
+ * <ul>
+ * <li>525 - user not found</li>
+ * <li>52e - invalid credentials</li>
+ * <li>530 - not permitted to logon at this time</li>
+ * <li>532 - password expired</li>
+ * <li>533 - account disabled</li>
+ * <li>701 - account expired</li>
+ * <li>773 - user must reset password</li>
+ * <li>775 - account locked</li>
+ * </ul>
+ *
+ * If you set the
+ * {@link #setConvertSubErrorCodesToExceptions(boolean) convertSubErrorCodesToExceptions}
+ * property to {@code true}, the codes will also be used to control the
+ * exception raised.
+ *
+ * @author Luke Taylor
+ * @author Rob Winch
+ * @since 3.1
+ */
+public class ActiveDirectoryLdapAuthenticationProviderCustom extends AbstractLdapAuthenticationProvider {
+
+    private static final Pattern SUB_ERROR_CODE = Pattern.compile(".*data\\s([0-9a-f]{3,4}).*");
+
+    // Error codes
+    private static final int USERNAME_NOT_FOUND = 0x525;
+    private static final int INVALID_PASSWORD = 0x52e;
+    private static final int NOT_PERMITTED = 0x530;
+    private static final int PASSWORD_EXPIRED = 0x532;
+    private static final int ACCOUNT_DISABLED = 0x533;
+    private static final int ACCOUNT_EXPIRED = 0x701;
+    private static final int PASSWORD_NEEDS_RESET = 0x773;
+    private static final int ACCOUNT_LOCKED = 0x775;
+
+    private final String domain;
+    private final String rootDn;
+    private final String url;
+    private boolean convertSubErrorCodesToExceptions;
+
+    // Only used to allow tests to substitute a mock LdapContext
+    ContextFactory contextFactory = new ContextFactory();
+
+    private final LdapAuthoritiesPopulator authoritiesPopulator;
+
+    /**
+     * @param domain the domain name (may be null or empty)
+     * @param url an LDAP url (or multiple URLs)
+     * @param authoritiesPopulator 
+     */
+    public ActiveDirectoryLdapAuthenticationProviderCustom(String domain, String url, LdapAuthoritiesPopulator authoritiesPopulator) {
+        Assert.isTrue(StringUtils.hasText(url), "Url cannot be empty");
+        this.domain = StringUtils.hasText(domain) ? domain.toLowerCase() : null;
+        //this.url = StringUtils.hasText(url) ? url : null;
+        this.url = url;
+        rootDn = this.domain == null ? null : rootDnFromDomain(this.domain);
+        this.authoritiesPopulator = authoritiesPopulator;
+    }
+
+    @Override
+    protected DirContextOperations doAuthentication(UsernamePasswordAuthenticationToken auth) {
+        String username = auth.getName();
+        String password = (String) auth.getCredentials();
+
+        DirContext ctx = bindAsUser(username, password);
+
+        try {
+            return searchForUser(ctx, username);
+
+        } catch (NamingException e) {
+            logger.error("Failed to locate directory entry for authenticated user: " + username, e);
+            throw badCredentials(e);
+        } finally {
+            LdapUtils.closeContext(ctx);
+        }
+    }
+
+    /**
+     * Creates the user authority list from the values of the {@code memberOf}
+     * attribute obtained from the user's Active Directory entry.
+     *
+     * @param userData
+     * @param username
+     * @param password
+     * @return
+     */
+    @Override
+    protected Collection<? extends GrantedAuthority> loadUserAuthorities(DirContextOperations userData, String username, String password) {
+        return authoritiesPopulator.getGrantedAuthorities(userData, username);
+    }
+
+    private DirContext bindAsUser(String username, String password) {
+        // TODO. add DNS lookup based on domain
+        final String bindUrl = url;
+
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        String bindPrincipal = createBindPrincipal(username);
+        env.put(Context.SECURITY_PRINCIPAL, bindPrincipal);
+        env.put(Context.PROVIDER_URL, bindUrl);
+        env.put(Context.SECURITY_CREDENTIALS, password);
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+
+        try {
+            return contextFactory.createContext(env);
+        } catch (NamingException e) {
+            if ((e instanceof AuthenticationException) || (e instanceof OperationNotSupportedException)) {
+                handleBindException(bindPrincipal, e);
+                throw badCredentials(e);
+            } else {
+                throw LdapUtils.convertLdapException(e);
+            }
+        }
+    }
+
+    void handleBindException(String bindPrincipal, NamingException exception) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Authentication for " + bindPrincipal + " failed:" + exception);
+        }
+
+        int subErrorCode = parseSubErrorCode(exception.getMessage());
+
+        if (subErrorCode > 0) {
+            logger.info("Active Directory authentication failed: " + subCodeToLogMessage(subErrorCode));
+
+            if (convertSubErrorCodesToExceptions) {
+                raiseExceptionForErrorCode(subErrorCode, exception);
+            }
+        } else {
+            logger.debug("Failed to locate AD-specific sub-error code in message");
+        }
+    }
+
+    int parseSubErrorCode(String message) {
+        Matcher m = SUB_ERROR_CODE.matcher(message);
+
+        if (m.matches()) {
+            return Integer.parseInt(m.group(1), 16);
+        }
+
+        return -1;
+    }
+
+    void raiseExceptionForErrorCode(int code, NamingException exception) {
+        String hexString = Integer.toHexString(code);
+        Throwable cause = new ActiveDirectoryAuthenticationExceptionCustom(hexString, exception.getMessage(), exception);
+        switch (code) {
+            case PASSWORD_EXPIRED:
+                throw new CredentialsExpiredException(messages.getMessage("LdapAuthenticationProvider.credentialsExpired",
+                        "User credentials have expired"), cause);
+            case ACCOUNT_DISABLED:
+                throw new DisabledException(messages.getMessage("LdapAuthenticationProvider.disabled",
+                        "User is disabled"), cause);
+            case ACCOUNT_EXPIRED:
+                throw new AccountExpiredException(messages.getMessage("LdapAuthenticationProvider.expired",
+                        "User account has expired"), cause);
+            case ACCOUNT_LOCKED:
+                throw new LockedException(messages.getMessage("LdapAuthenticationProvider.locked",
+                        "User account is locked"), cause);
+            default:
+                throw badCredentials(cause);
+        }
+    }
+
+    String subCodeToLogMessage(int code) {
+        switch (code) {
+            case USERNAME_NOT_FOUND:
+                return "User was not found in directory";
+            case INVALID_PASSWORD:
+                return "Supplied password was invalid";
+            case NOT_PERMITTED:
+                return "User not permitted to logon at this time";
+            case PASSWORD_EXPIRED:
+                return "Password has expired";
+            case ACCOUNT_DISABLED:
+                return "Account is disabled";
+            case ACCOUNT_EXPIRED:
+                return "Account expired";
+            case PASSWORD_NEEDS_RESET:
+                return "User must reset password";
+            case ACCOUNT_LOCKED:
+                return "Account locked";
+        }
+
+        return "Unknown (error code " + Integer.toHexString(code) + ")";
+    }
+
+    private BadCredentialsException badCredentials() {
+        return new BadCredentialsException(messages.getMessage(
+                "LdapAuthenticationProvider.badCredentials", "Bad credentials"));
+    }
+
+    private BadCredentialsException badCredentials(Throwable cause) {
+        return (BadCredentialsException) badCredentials().initCause(cause);
+    }
+
+    @SuppressWarnings("deprecation")
+    private DirContextOperations searchForUser(DirContext ctx, String username) throws NamingException {
+        SearchControls searchCtls = new SearchControls();
+        searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        String searchFilter = "(&(objectClass=user)(userPrincipalName={0}))";
+
+        final String bindPrincipal = createBindPrincipal(username);
+
+        String searchRoot = rootDn != null ? rootDn : searchRootFromPrincipal(bindPrincipal);
+
+        try {
+            return SpringSecurityLdapTemplate.searchForSingleEntryInternal(ctx, searchCtls, searchRoot, searchFilter,
+                    new Object[]{bindPrincipal});
+        } catch (IncorrectResultSizeDataAccessException incorrectResults) {
+            if (incorrectResults.getActualSize() == 0) {
+                UsernameNotFoundException userNameNotFoundException = new UsernameNotFoundException("User " + username + " not found in directory.");
+                userNameNotFoundException.initCause(incorrectResults);
+                throw badCredentials(userNameNotFoundException);
+            }
+            // Search should never return multiple results if properly configured, so just rethrow
+            throw incorrectResults;
+        }
+    }
+
+    private String searchRootFromPrincipal(String bindPrincipal) {
+        int atChar = bindPrincipal.lastIndexOf('@');
+
+        if (atChar < 0) {
+            logger.debug("User principal '" + bindPrincipal + "' does not contain the domain, and no domain has been configured");
+            throw badCredentials();
+        }
+
+        return rootDnFromDomain(bindPrincipal.substring(atChar + 1, bindPrincipal.length()));
+    }
+
+    private String rootDnFromDomain(String domain) {
+        String[] tokens = StringUtils.tokenizeToStringArray(domain, ".");
+        StringBuilder root = new StringBuilder();
+
+        for (String token : tokens) {
+            if (root.length() > 0) {
+                root.append(',');
+            }
+            root.append("dc=").append(token);
+        }
+
+        return root.toString();
+    }
+
+    String createBindPrincipal(String username) {
+        if (domain == null || username.toLowerCase().endsWith(domain)) {
+            return username;
+        }
+
+        return username + "@" + domain;
+    }
+
+    /**
+     * By default, a failed authentication (LDAP error 49) will result in a
+     * {@code BadCredentialsException}.
+     * <p>
+     * If this property is set to {@code true}, the exception message from a
+     * failed bind attempt will be parsed for the AD-specific error code and a {@link CredentialsExpiredException}, {@link DisabledException},
+     * {@link AccountExpiredException} or {@link LockedException} will be thrown
+     * for the corresponding codes. All other codes will result in the default
+     * {@code BadCredentialsException}.
+     *
+     * @param convertSubErrorCodesToExceptions {@code true} to raise an
+     * exception based on the AD error code.
+     */
+    public void setConvertSubErrorCodesToExceptions(boolean convertSubErrorCodesToExceptions) {
+        this.convertSubErrorCodesToExceptions = convertSubErrorCodesToExceptions;
+    }
+
+    static class ContextFactory {
+
+        DirContext createContext(Hashtable<?, ?> env) throws NamingException {
+            return new InitialLdapContext(env, null);
+        }
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryLdapAuthenticationProviderCustom.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/ActiveDirectoryLdapAuthenticationProviderCustom.java
@@ -111,12 +111,11 @@ public class ActiveDirectoryLdapAuthenticationProviderCustom extends AbstractLda
     /**
      * @param domain the domain name (may be null or empty)
      * @param url an LDAP url (or multiple URLs)
-     * @param authoritiesPopulator 
+     * @param authoritiesPopulator
      */
     public ActiveDirectoryLdapAuthenticationProviderCustom(String domain, String url, LdapAuthoritiesPopulator authoritiesPopulator) {
         Assert.isTrue(StringUtils.hasText(url), "Url cannot be empty");
         this.domain = StringUtils.hasText(domain) ? domain.toLowerCase() : null;
-        //this.url = StringUtils.hasText(url) ? url : null;
         this.url = url;
         rootDn = this.domain == null ? null : rootDnFromDomain(this.domain);
         this.authoritiesPopulator = authoritiesPopulator;

--- a/src/main/resources/META-INF/spring-security.xml
+++ b/src/main/resources/META-INF/spring-security.xml
@@ -42,13 +42,21 @@
             <bean class="org.synyx.urlaubsverwaltung.security.AuthoritiesPopulatorImpl"/>
         </constructor-arg>
     </bean>
+    
+    <bean id="activeDirectoryAuthProvider" class="org.synyx.urlaubsverwaltung.security.ActiveDirectoryLdapAuthenticationProviderCustom">
+        <constructor-arg value="${activeDirectory.domain}" />
+        <constructor-arg value="${activeDirectory.domainControllerUrl}" />
+        <constructor-arg>
+            <bean class="org.synyx.urlaubsverwaltung.security.AuthoritiesPopulatorImpl"/>
+        </constructor-arg>
+    </bean>
 
     <bean id="devUserDetailsService" class="org.synyx.urlaubsverwaltung.security.TestUserDetailsService">
         <constructor-arg ref="personDAO"></constructor-arg>
     </bean>
 
     <security:authentication-manager alias="authenticationManager">
-        <security:authentication-provider ref="ldapAuthProvider"/>
+        <security:authentication-provider ref="${authentication.providerId}"/>
         <security:authentication-provider user-service-ref="devUserDetailsService"/>
     </security:authentication-manager>
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,10 +2,18 @@
 application.version=${project.groupId}:${project.artifactId}:${project.version} - build at ${buildTime} by ${user.name}
 application.version.short=${project.version}
 
+# The ID of the authenticateion provider. Change this to
+# activeDirectoryAuthProvider for active directory authentication.
+authentication.providerId=${AUTHENTICATION_PROVIDER:ldapAuthProvider}
+
 # LDAP CONFIG
 ldap.url=${LDAP_URL:ldap://ldap:389}
 ldap.base=${LDAP_BASE:dc=theia,dc=localdomain}
 ldap.userDnPatterns=${LDAP_USER_DN_PATTERNS:uid={0},ou=People}
+
+# Active directory configuration
+activeDirectory.domain=${AD_DOMAIN:mydomain.tld}
+activeDirectory.domainControllerUrl=${AD_DOMAINCONTROLLER_URL:ldap://domaincontroller.mydomain.tld/}
 
 # URL OF APP - needed for links in emails
 application.url=${APPLICATION_URL:http://localhost:8080/urlaubsverwaltung/}


### PR DESCRIPTION
A custom implementation of the Spring authentication provider for
active directory servers is added.

The security configuration is enhanced so that environment variables
can be used to switch to Active Directory authentication.

A custom implementation of the Active Directory authentication
provider is used because the ActiveDirectoryLdapAuthenticationProvider
that comes with the spring framework is marked final and can not be
extended, see: http://goo.gl/qNBSNo.