### PR TITLE
[FEATURE] Auto create persons on login

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/security/PersonContextMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/PersonContextMapper.java
@@ -33,10 +33,13 @@ public class PersonContextMapper implements UserDetailsContextMapper {
     private final PersonService personService;
     private final MailService mailService;
 
-    public PersonContextMapper(PersonService personService, MailService mailService) {
+    private boolean createOnLogin;
+
+    public PersonContextMapper(PersonService personService, MailService mailService, boolean createOnLogin) {
 
         this.personService = personService;
         this.mailService = mailService;
+        this.createOnLogin = createOnLogin;
     }
 
     @Override
@@ -49,10 +52,10 @@ public class PersonContextMapper implements UserDetailsContextMapper {
          * NOTE: If the system has no user yet, the first person that successfully signs in
          * is created as user with {@link Role#OFFICE}
          */
-        boolean noActivePersonExistsYet = person == null && personService.getActivePersons().size() == 0;
+        boolean noActivePersonExistsYet = personService.getActivePersons().size() == 0;
 
-        if (noActivePersonExistsYet) {
-            person = createFirstPerson(username);
+        if (person == null && (noActivePersonExistsYet || this.createOnLogin)) {
+            person = createPerson(username, noActivePersonExistsYet);
         }
 
         org.springframework.security.ldap.userdetails.Person.Essence p =
@@ -72,7 +75,7 @@ public class PersonContextMapper implements UserDetailsContextMapper {
      *
      * @return  the created person
      */
-    Person createFirstPerson(String login) {
+    Person createPerson(String login, boolean isFirst) {
 
         Person person = new Person();
         person.setLoginName(login);
@@ -80,7 +83,10 @@ public class PersonContextMapper implements UserDetailsContextMapper {
 
         List<Role> permissions = new ArrayList<>();
         permissions.add(Role.USER);
-        permissions.add(Role.OFFICE);
+
+        if (isFirst) {
+            permissions.add(Role.OFFICE);
+        }
 
         /**
          * NOTE: Do not change this to

--- a/src/main/resources/META-INF/spring-security-activeDirectory.xml
+++ b/src/main/resources/META-INF/spring-security-activeDirectory.xml
@@ -11,6 +11,7 @@
     <bean id="personContextMapper" class="org.synyx.urlaubsverwaltung.security.PersonContextMapper">
         <constructor-arg ref="personService"/>
         <constructor-arg ref="mailService"/>
+        <constructor-arg value="${person.createOnLogin}"/>
     </bean>
 
     <bean id="activeDirectoryAuthenticationProvider"

--- a/src/main/resources/META-INF/spring-security-ldap.xml
+++ b/src/main/resources/META-INF/spring-security-ldap.xml
@@ -11,6 +11,7 @@
     <bean id="personContextMapper" class="org.synyx.urlaubsverwaltung.security.PersonContextMapper">
         <constructor-arg ref="personService"/>
         <constructor-arg ref="mailService"/>
+        <constructor-arg value="${person.createOnLogin}"/>
     </bean>
 
     <security:ldap-server id="ldapAuthServer" url="${ldap.url}/${ldap.base}"/>

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -13,3 +13,5 @@ ldap.activeDirectory.ldapUrl=${UV_LDAP_AD_URL:ldap://adserver.mydomain.com/}
 
 # URL OF APP - needed for links in emails
 application.url=${UV_APPLICATION_URL:http://localhost:8080/urlaubsverwaltung/}
+
+person.createOnLogin=${UV_PERSON_CREATE_ON_LOGIN:false}

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/PersonContextMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/PersonContextMapperTest.java
@@ -34,7 +34,7 @@ public class PersonContextMapperTest {
         personService = Mockito.mock(PersonService.class);
         mailService = Mockito.mock(MailService.class);
 
-        personContextMapper = new PersonContextMapper(personService, mailService);
+        personContextMapper = new PersonContextMapper(personService, mailService, false);
     }
 
 
@@ -65,9 +65,9 @@ public class PersonContextMapperTest {
 
 
     @Test
-    public void ensureCreatedPersonHasTheCorrectRoles() {
+    public void ensureFirstCreatedPersonHasTheCorrectRoles() {
 
-        Person person = personContextMapper.createFirstPerson("murygina");
+        Person person = personContextMapper.createPerson("murygina", true);
 
         Collection<Role> roles = person.getPermissions();
 
@@ -78,11 +78,24 @@ public class PersonContextMapperTest {
         Assert.assertTrue("Should be active", person.isActive());
     }
 
+    @Test
+    public void ensureFurtherCreatedPersonHasTheCorrectRoles() {
+
+        Person person = personContextMapper.createPerson("murygina2", false);
+
+        Collection<Role> roles = person.getPermissions();
+
+        Assert.assertEquals("Wrong number of roles", 1, roles.size());
+        Assert.assertTrue("Does not contain user role", roles.contains(Role.USER));
+
+        Assert.assertTrue("Should be active", person.isActive());
+    }
+
 
     @Test
     public void ensureCreatedPersonIsSaved() {
 
-        personContextMapper.createFirstPerson("murygina");
+        personContextMapper.createPerson("murygina", true);
 
         Mockito.verify(personService).save(Mockito.any(Person.class));
     }


### PR DESCRIPTION
To prevent the generic error message when a user logs in who does
not exist in the database a new option is introduced that allows
the creation of the person record on the fly:

person.createOnLogin

Only the first user will get the office role (as before) and new
users will only get the user role.