### PR TITLE
Austausch der guava-Helfer mit neuen Java 8 Features für den PersonServiceImpl

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImpl.java
@@ -109,7 +109,7 @@ public class PersonInteractionServiceImpl implements PersonInteractionService {
     @Override
     public Person update(PersonForm personForm) {
 
-        Optional<Person> optionalPersonToUpdate = personService.getPersonByID(personForm.getId());
+        java.util.Optional<Person> optionalPersonToUpdate = personService.getPersonByID(personForm.getId());
 
         if (!optionalPersonToUpdate.isPresent()) {
             throw new IllegalArgumentException("Can not find a person for ID = " + personForm.getId());

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonService.java
@@ -1,11 +1,10 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
-import com.google.common.base.Optional;
-
 import org.synyx.urlaubsverwaltung.core.mail.MailNotification;
 import org.synyx.urlaubsverwaltung.security.Role;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImpl.java
@@ -1,11 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.stereotype.Service;
@@ -14,6 +8,7 @@ import org.synyx.urlaubsverwaltung.core.mail.MailNotification;
 import org.synyx.urlaubsverwaltung.security.Role;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.synyx.urlaubsverwaltung.security.Role.*;
@@ -46,14 +41,14 @@ class PersonServiceImpl implements PersonService {
     @Override
     public Optional<Person> getPersonByID(Integer id) {
 
-        return Optional.fromNullable(personDAO.findOne(id));
+        return java.util.Optional.ofNullable(personDAO.findOne(id));
     }
 
 
     @Override
     public Optional<Person> getPersonByLogin(String loginName) {
 
-        return Optional.fromNullable(personDAO.findByLoginName(loginName));
+        return java.util.Optional.ofNullable(personDAO.findByLoginName(loginName));
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImpl.java
@@ -14,6 +14,9 @@ import org.synyx.urlaubsverwaltung.core.mail.MailNotification;
 import org.synyx.urlaubsverwaltung.security.Role;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.synyx.urlaubsverwaltung.security.Role.*;
 
 
 /**
@@ -57,55 +60,36 @@ class PersonServiceImpl implements PersonService {
     @Override
     public List<Person> getActivePersons() {
 
-        return FluentIterable.from(personDAO.findAll()).filter(new Predicate<Person>() {
+        return personDAO.findAll().stream().
+                filter(person -> !person.hasRole(INACTIVE)).
+                collect(Collectors.toList());
 
-                    @Override
-                    public boolean apply(Person person) {
-
-                        return !person.hasRole(Role.INACTIVE);
-                    }
-                }).toList();
     }
 
 
     @Override
     public List<Person> getInactivePersons() {
 
-        return FluentIterable.from(personDAO.findAll()).filter(new Predicate<Person>() {
-
-                    @Override
-                    public boolean apply(Person person) {
-
-                        return person.hasRole(Role.INACTIVE);
-                    }
-                }).toList();
+        return personDAO.findAll().stream().
+                filter(person -> person.hasRole(INACTIVE)).
+                collect(Collectors.toList());
     }
 
 
     @Override
     public List<Person> getPersonsByRole(final Role role) {
 
-        return Lists.newArrayList(Iterables.filter(getActivePersons(), new Predicate<Person>() {
-
-                        @Override
-                        public boolean apply(Person person) {
-
-                            return person.hasRole(role);
-                        }
-                    }));
+        return getActivePersons().stream().
+                filter(person -> person.hasRole(role)).
+                collect(Collectors.toList());
     }
 
 
     @Override
     public List<Person> getPersonsWithNotificationType(final MailNotification notification) {
 
-        return Lists.newArrayList(Iterables.filter(getActivePersons(), new Predicate<Person>() {
-
-                        @Override
-                        public boolean apply(Person person) {
-
-                            return person.hasNotificationType(notification);
-                        }
-                    }));
+        return getActivePersons().stream().
+                filter(person -> person.hasNotificationType(notification)).
+                collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/PersonController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/PersonController.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 import com.wordnik.swagger.annotations.Api;
@@ -22,6 +21,7 @@ import org.synyx.urlaubsverwaltung.core.person.PersonService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/VacationController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/VacationController.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 import com.google.gson.Gson;
@@ -37,6 +36,7 @@ import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/WorkDayController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/WorkDayController.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
-import com.google.common.base.Optional;
 
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
@@ -27,6 +26,7 @@ import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.PersonService;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/DevUserDetailsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/DevUserDetailsService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.security;
 
-import com.google.common.base.Optional;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,6 +12,7 @@ import org.synyx.urlaubsverwaltung.core.startup.TestDataCreationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/PersonContextMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/PersonContextMapper.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.security;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.springframework.ldap.core.DirContextAdapter;
@@ -21,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/Role.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/Role.java
@@ -11,5 +11,5 @@ public enum Role {
     USER,
     BOSS,
     OFFICE,
-    INACTIVE;
+    INACTIVE
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/SessionService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/SessionService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.security;
 
-import com.google.common.base.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -10,6 +8,8 @@ import org.springframework.stereotype.Service;
 
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.PersonService;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/PersonPropertyEditor.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/PersonPropertyEditor.java
@@ -1,11 +1,11 @@
 package org.synyx.urlaubsverwaltung.web;
 
-import com.google.common.base.Optional;
 
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.PersonService;
 
 import java.beans.PropertyEditorSupport;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
@@ -193,7 +193,7 @@ public class ApplicationForLeaveDetailsController {
         @ModelAttribute("modelPerson") Person p, RedirectAttributes redirectAttributes) {
 
         Optional<Application> application = applicationService.getApplicationById(applicationId);
-        Optional<Person> recipient = personService.getPersonByLogin(p.getLoginName());
+        java.util.Optional<Person> recipient = personService.getPersonByLogin(p.getLoginName());
 
         if (sessionService.isBoss() && application.isPresent() && recipient.isPresent()) {
             Person sender = sessionService.getLoggedUser();

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
@@ -101,7 +101,7 @@ public class ApplyForLeaveController {
             person = sessionService.getLoggedUser();
             applier = person;
         } else {
-            Optional<Person> personByID = personService.getPersonByID(personId);
+            java.util.Optional<Person> personByID = personService.getPersonByID(personId);
 
             if (!personByID.isPresent()) {
                 return ControllerConstants.ERROR_JSP;
@@ -181,7 +181,7 @@ public class ApplyForLeaveController {
         if (personId == null) {
             personToApplyForLeave = applier;
         } else {
-            Optional<Person> optionalPerson = personService.getPersonByID(personId);
+            java.util.Optional<Person> optionalPerson = personService.getPersonByID(personId);
 
             if (!optionalPerson.isPresent()) {
                 return ControllerConstants.ERROR_JSP;

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
@@ -132,7 +132,7 @@ public class PersonManagementController {
             yearOfHolidaysAccount = DateMidnight.now().getYear();
         }
 
-        Optional<Person> optionalPerson = personService.getPersonByID(personId);
+        java.util.Optional<Person> optionalPerson = personService.getPersonByID(personId);
 
         if (!optionalPerson.isPresent()) {
             return ControllerConstants.ERROR_JSP;
@@ -158,7 +158,7 @@ public class PersonManagementController {
     public String editPerson(@PathVariable("personId") Integer personId,
         @ModelAttribute("personForm") PersonForm personForm, Errors errors, Model model) {
 
-        Optional<Person> personToUpdate = personService.getPersonByID(personId);
+        java.util.Optional<Person> personToUpdate = personService.getPersonByID(personId);
 
         if (!sessionService.isOffice() || !personToUpdate.isPresent()) {
             return ControllerConstants.ERROR_JSP;

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonOverviewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonOverviewController.java
@@ -103,7 +103,7 @@ public class PersonOverviewController {
     public String showOverview(@PathVariable("personId") Integer personId,
         @RequestParam(value = ControllerConstants.YEAR, required = false) String year, Model model) {
 
-        Optional<Person> optionalPerson = personService.getPersonByID(personId);
+        java.util.Optional<Person> optionalPerson = personService.getPersonByID(personId);
 
         if (sessionService.isInactive() || !optionalPerson.isPresent()) {
             return ControllerConstants.ERROR_JSP;

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/person/PersonServiceImplTest.java
@@ -1,0 +1,95 @@
+package org.synyx.urlaubsverwaltung.core.person;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.synyx.urlaubsverwaltung.security.Role;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.synyx.urlaubsverwaltung.core.mail.MailNotification.*;
+import static org.synyx.urlaubsverwaltung.security.Role.BOSS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PersonServiceImplTest {
+
+    private PersonServiceImpl sut;
+
+    @Mock
+    private PersonDAO personDAOMock;
+    private ArrayList<Person> persons;
+    private Person activeBoss;
+
+    @Before
+    public void setUp() {
+
+        sut = new PersonServiceImpl(personDAOMock);
+
+        activeBoss = new Person();
+        activeBoss.setFirstName("pete");
+        activeBoss.setPermissions(asList(BOSS));
+        activeBoss.setNotifications(asList(NOTIFICATION_BOSS));
+
+        Person activeUser = new Person();
+        activeUser.setPermissions(asList(Role.USER));
+        activeUser.setFirstName("bete");
+        activeUser.setNotifications(asList(NOTIFICATION_OFFICE));
+
+        Person notActivePerson = new Person();
+        notActivePerson.setFirstName("maria");
+        notActivePerson.setPermissions(asList(Role.INACTIVE));
+
+        persons = new ArrayList<>();
+        persons.add(activeBoss);
+        persons.add(activeUser);
+        persons.add(notActivePerson);
+    }
+
+    @Test
+    public void getActivePersons() {
+
+        when(personDAOMock.findAll()).thenReturn(persons);
+        List<Person> activePersons = sut.getActivePersons();
+
+        assertThat(activePersons.size(), is(2));
+        assertThat(activePersons.get(0).getFirstName(), is("pete"));
+        assertThat(activePersons.get(1).getFirstName(), is("bete"));
+    }
+
+    @Test
+    public void getInactivePersons() {
+
+        when(personDAOMock.findAll()).thenReturn(persons);
+        List<Person> activePersons = sut.getInactivePersons();
+
+        assertThat(activePersons.size(), is(1));
+        assertThat(activePersons.get(0).getFirstName(), is("maria"));
+    }
+
+    @Test
+    public void getPersonsByRole() {
+
+        when(personDAOMock.findAll()).thenReturn(persons);
+        List<Person> bosses = sut.getPersonsByRole(BOSS);
+
+        assertThat(bosses.size(), is(1));
+        assertThat(bosses.get(0).getFirstName(), is("pete"));
+    }
+
+    @Test
+    public void getPersonsWithNotificationType() {
+
+        when(personDAOMock.findAll()).thenReturn(persons);
+        List<Person> bosses = sut.getPersonsWithNotificationType(NOTIFICATION_OFFICE);
+
+        assertThat(bosses.size(), is(1));
+        assertThat(bosses.get(0).getFirstName(), is("bete"));
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/DevUserDetailsServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/DevUserDetailsServiceTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.security;
 
-import com.google.common.base.Optional;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +16,7 @@ import org.synyx.urlaubsverwaltung.core.startup.TestDataCreationService;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 
 /**
@@ -51,7 +50,7 @@ public class DevUserDetailsServiceTest {
 
         String login = TestDataCreationService.USER;
 
-        Mockito.when(personService.getPersonByLogin(login)).thenReturn(Optional.<Person>absent());
+        Mockito.when(personService.getPersonByLogin(login)).thenReturn(Optional.<Person>empty());
 
         UserDetails userDetails = devUserDetailsService.loadUserByUsername(login);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/validator/PersonValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/validator/PersonValidatorTest.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.web.validator;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.junit.Before;
@@ -25,6 +23,7 @@ import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -269,7 +268,7 @@ public class PersonValidatorTest {
     @Test
     public void ensureUniqueUsernameHasNoValidationError() {
 
-        Mockito.when(personService.getPersonByLogin("foo")).thenReturn(Optional.<Person>absent());
+        Mockito.when(personService.getPersonByLogin("foo")).thenReturn(Optional.<Person>empty());
         validator.validateLogin("foo", errors);
         Mockito.verify(errors, Mockito.never()).rejectValue(Mockito.anyString(), Mockito.anyString());
     }


### PR DESCRIPTION
In 2 Commits werden alle Guava-Helfer aus dem PersonServiceImpl entfernt und mit neuen Java 8 Features ersetzt.

Der erste Commit ersetzt Guava-Filter-Funktionen mit der Java-Stream-Api.
Der Zweite ersetzt Guava-Optionals mit Java8-Optionals.