### PR TITLE
Remove duplications and improve comprehension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,37 @@
 [![Build Status](https://travis-ci.org/synyx/urlaubsverwaltung.png)](https://travis-ci.org/synyx/urlaubsverwaltung)
 
-# Urlaubsverwaltung
+
+## Urlaubsverwaltung
 
 * [Übersicht](https://github.com/synyx/urlaubsverwaltung#übersicht)
 * [Installation](https://github.com/synyx/urlaubsverwaltung#installation)
-* [Konfiguration < Version 2.7.0](https://github.com/synyx/urlaubsverwaltung#konfiguration--version-270)
-* [Konfiguration ab Version 2.7.0](https://github.com/synyx/urlaubsverwaltung#konfiguration-ab-version-270)
+* [Konfiguration](https://github.com/synyx/urlaubsverwaltung#konfiguration)
+    * [Umgebungen](https://github.com/synyx/urlaubsverwaltung#umgebungen)
+    * [Authentifizierung](https://github.com/synyx/urlaubsverwaltung#authentifizierung)
+    * [Konfiguration ab Version 2.7.0](https://github.com/synyx/urlaubsverwaltung#konfiguration-ab-version-270)
+    * [Konfiguration bis Version 2.6.4](https://github.com/synyx/urlaubsverwaltung#konfiguration--version-270)
 * [Entwicklung](https://github.com/synyx/urlaubsverwaltung#entwicklung)
 * [Hinweise zu Versionen](https://github.com/synyx/urlaubsverwaltung#hinweise-zu-versionen)
 * [Technologien](https://github.com/synyx/urlaubsverwaltung#technologien)
 * [Lizenz](https://github.com/synyx/urlaubsverwaltung#lizenz)
 
-# Übersicht
+---
 
-Die Urlaubsverwaltung ist eine Web-Anwendung, die es ermöglicht, Urlaubsanträge von Mitarbeitern elektronisch zu
-verwalten. Mitarbeiter stellen Urlaubsanträge, die von den jeweils Berechtigten genehmigt oder abgelehnt werden.
-Die Anwendung bietet eine Übersicht über die bestehenden Urlaubsanträge und ermöglicht außerdem Überblick und Pflege von
-Urlaubsanspruch und Anzahl verbleibender Urlaubstage der Mitarbeiter. Zusätzlich können Krankmeldungen erfasst und
-überblickt werden.
+## Übersicht
+
+Die Urlaubsverwaltung ist eine Web-Anwendung, die es ermöglicht, Urlaubsanträge von Mitarbeitern elektronisch zu verwalten. Mitarbeiter stellen Urlaubsanträge, die von den jeweils Berechtigten genehmigt oder abgelehnt werden.
+Die Anwendung bietet eine Übersicht über die bestehenden Urlaubsanträge und ermöglicht außerdem Überblick und Pflege von Urlaubsanspruch und Anzahl verbleibender Urlaubstage der Mitarbeiter. Zusätzlich können Krankmeldungen erfasst und überblickt werden.
 
 ![Screenshot Urlaubsverwaltung](http://synyx.de/images/opensource/screen_01.jpg)
 
-## Demo System
+#### Demo System
 
 Zum Ausprobieren der Anwendung gibt es ein [Demo System](http://urlaubsverwaltung-demo.synyx.de) mit einem Testbenutzer.
 
 * Benutzername: test
 * Passwort: secret
 
-## Blogposts
+#### Blogposts
 
 Weitere Informationen zur Geschichte und Entwicklung der Urlaubsverwaltung findet man im [synyx Blog](http://blog.synyx.de):
 
@@ -36,50 +39,157 @@ Weitere Informationen zur Geschichte und Entwicklung der Urlaubsverwaltung finde
 * [Stand November 2012](http://blog.synyx.de/2012/11/urlaubsverwaltung-was-hat-sich-getan/)
 * [Stand Oktober 2014](http://blog.synyx.de/2014/10/urlaubsverwaltung-goes-mobile/)
 
-## Berechtigungen
+#### Berechtigungen
 
 In der Urlaubsverwaltung gibt es aktuell folgende Arten von Berechtigungen:
 
-* **inaktiv**: hat keinen Zugang mehr zur Urlaubsverwaltung (bestehende Daten des Benutzers bleiben zur
-Archivierung bestehen)
+* **inaktiv**: hat keinen Zugang mehr zur Urlaubsverwaltung (bestehende Daten des Benutzers bleiben zur Archivierung bestehen)
 * **User**: darf Urlaub für sich selbst beantragen
-* **Boss**:	darf Urlaubsanträge von Mitarbeitern einsehen, genehmigen und ablehnen
+* **Boss**: darf Urlaubsanträge von Mitarbeitern einsehen, genehmigen und ablehnen
 * **Office**: darf Mitarbeiterdaten verwalten, Urlaub für Mitarbeiter beantragen und Urlaubsanträge stornieren
 
 Eine aktive Person kann eine oder mehrere Rollen innehaben.
 
-# Installation
+---
+
+## Installation
 
 Die folgende Anleitung beschreibt die Installation der Urlaubsverwaltung auf einem [Tomcat Server](http://tomcat.apache.org/).
 
-## Systemvoraussetzungen
+#### Systemvoraussetzungen
 
 * Apache Tomcat Version 7
 * JDK 8
 * Maven 3.3
 * MySQL Datenbank
 
-## Download
+#### Download
 
-Die Anwendung steht auf Github als ZIP oder Tarball zum Download zur Verfügung. Am Besten
-[hier](https://github.com/synyx/urlaubsverwaltung/releases) die aktuellste Version auswählen und downloaden.
+Die Anwendung steht auf Github als ZIP oder Tarball zum Download zur Verfügung. Am Besten [hier](https://github.com/synyx/urlaubsverwaltung/releases) die aktuellste Version auswählen und downloaden.
 
-## Erstellen der WAR-Datei
+#### Erstellen der WAR-Datei
 
-Nach dem Entpacken der Datei kann die WAR-Datei mithilfe von [Maven](http://maven.apache.org/) erstellt werden.
-Dies erfolgt durch Ausführen folgenden Befehls im Root-Verzeichnis der Anwendung:
+Nach dem Entpacken der Zip oder Tarball Datei kann die [WAR-Datei](http://de.wikipedia.org/wiki/Web_Application_Archive) mithilfe von [Maven](http://maven.apache.org/) erstellt werden.
+Dies erfolgt durch Ausführen folgenden Befehls im entpackten Root-Verzeichnis der Anwendung:
 
 <pre>mvn clean install</pre>
 
-## Deployment unter Tomcat
+Die erstellte WAR-Datei `urlaubsverwaltung-X.X.X-SNAPSHOT.war` findet man im neu erstellten `target/` Verzeichnis des Projekts.
+
+#### Deployment unter Tomcat
 
 Die erstellte WAR-Datei kann nun im installierten Tomcat Server deployed werden.
-Dazu kopiert man die WAR-Datei in das Tomcat-Webapps-Verzeichnis.
-([weiterführende Informationen zum Tomcat Deployment](http://tomcat.apache.org/tomcat-6.0-doc/deployer-howto.html))
+Dazu kopiert man die WAR-Datei in das Tomcat Verzeichnis `/webapps` und benennt sie in `urlaubsverwaltung.war` um ([weiterführende Informationen zum Tomcat Deployment](http://tomcat.apache.org/tomcat-6.0-doc/deployer-howto.html)).
 
-## Konfiguration < Version 2.7.0
+#### Starten der Anwendung
 
-### Überschreiben der Properties
+Damit man die Anwendung möglichst schnell ausprobieren kann, bietet es sich an die Anwendung in der Umgebung Entwicklung (`env=dev`) zu starten.
+
+Zusätzlich wird die standardmäßige Authentifizierung (`auth=default`) angegeben.
+
+Hierzu wird `CATALINA_OPTS` folgendermaßen gesetzt:
+
+<pre>export CATALINA_OPTS="-Denv=dev -Dauth=default"</pre>
+
+#### Aufrufen der Anwendung
+
+Wenn die Anwendung im Tomcat Verzeichnis `webapps/` mit dem Dateinamen `urlaubsverwaltung.war` deployed wurde, ist sie nach dem Starten des Tomcat unter
+
+`<servername>:8080/urlaubsverwaltung`
+
+erreichbar.
+
+Der erste Benutzer, der sich erfolgreich im System einloggt, wird in der Urlaubsverwaltung mit der Rolle Office angelegt.
+Dies ermöglicht Benutzer- und Rechteverwaltung innerhalb der Anwendung und das Pflegen der Einstellungen für die Anwendung.
+
+---
+
+## Konfiguration
+
+#### Umgebungen
+
+Die Anwendung verfügt über **drei** verschiedene Umgebungsmöglichkeiten:
+
+* `dev`
+    * zum lokalen Entwickeln
+    * nutzt eine H2-Datenbank
+    * legt Testdaten an
+    * nutzt als Mail-Sender einen Dummy (verschickt keine E-Mails)
+* `test`
+    * zum Testen der Anwendung
+    * nutzt eine MySQL-Datenbank
+    * legt keine Testdaten an
+    * nutzt als Mail-Sender einen Dummy (verschickt keine E-Mails)
+* `prod`
+    * zum Ausführen der produktiven Anwendung
+    * nutzt eine MySQL-Datenbank
+    * legt keine Testdaten an
+    * nutzt den Java-Mail-Sender von [Spring](http://www.springsource.org/) (verschickt E-Mails)
+
+##### Umgebung aktivieren
+
+Damit die Anwendung in einer Umgebung gestartet wird, muss man in den `CATALINA_OPTS` die System-Property `env` auf `dev`, `test` oder `prod` setzen:
+
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Denv=UMGEBUNG"</pre>
+
+#### Authentifizierung
+
+Die Anwendung verfügt über **drei** verschiedene Authentifizierungsmöglichkeiten:
+
+* `default`
+    * für lokale Entwicklungsumgebung
+* `ldap`
+    * Authentifizierung via LDAP
+    * Es müssen die LDAP URL, die LDAP Base und LDAP User DN Patterns konfiguriert sein, damit eine Authentifizierung via LDAP möglich ist. Die Properties sind unter `src/main/resources/config.properties` zu finden.
+* `activeDirectory`
+    * Authentifizierung via Active Directory
+    * Es müssen die Active Directory Domain und LDAP URL konfiguriert sein, damit eine Authentifizierung via Active Directory möglich ist. Die Properties sind unter `src/main/resources/config.properties` zu finden.
+
+#### Konfiguration ab Version 2.7.0
+
+##### Überschreiben der Properties
+
+Die Anwendung besitzt im Verzeichnis `src/main/resources` jeweils eine `.properties` Datei zur Konfiguration der jeweiligen [Umgebung](https://github.com/synyx/urlaubsverwaltung#umgebungen).
+
+* `application-dev.properties`
+* `application-test.properties`
+* `application-prod.properties`
+
+Diese beinhalten gewisse Grundeinstellungen und Standardwerte. Diese allein reichen für die Produktivnahme der Anwendung allerdings noch nicht aus.
+Spezifische Konfigurationen wie z.B. die Datenbank Einstellungen müssen durch eine eigene Properties-Datei hinterlegt werden.
+Dazu kann die Beispieldatei im Root-Verzeichnis der Anwendung `urlaubsverwaltung.properties` als Vorlage verwendet werden, um die gewünschten Einstellungen zu überschreiben.
+
+Damit die eigene Konfigurationsdatei benutzt wird, gibt es zwei Möglichkeiten:
+
+* Eine eigene Properties-Datei erstellen und diese unter dem Namen `urlaubsverwaltung.properties` in das `/conf` Verzeichnis unterhalb von `CATALINA_BASE` ablegen, z.B. `tomcat/conf/urlaubsverwaltung.properties`. Danach den Tomcat neu starten.
+
+* Die erstellte Properties-Datei an einem beliebigen Ort ablegen und mithilfe der System Property `config` innerhalb der `CATALINA_OPTS` den absoluten Pfad der Konfigurationsdatei angeben:
+
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Dconfig=/home/urlaub/config/my.properties"</pre>
+
+##### Produktivumgebung aktivieren
+
+Die Anwendung mit dem Parameter `-Denv=prod` starten:
+
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Denv=prod"</pre>
+
+##### Authentifizierung
+
+###### LDAP
+
+Die Anwendung mit dem Parameter `-Dauth=ldap` starten:
+
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Dauth=ldap"</pre>
+
+###### Active Directory
+
+Die Anwendung mit dem Parameter `-Dauth=activeDirectory` starten:
+
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Dauth=activeDirectory"</pre>
+
+#### Konfiguration bis Version 2.6.4
+
+##### Überschreiben der Properties
 
 Die Anwendung besitzt im Verzeichnis `src/main/resources` mehrere Properties Dateien, die zur Konfiguration genutzt werden.
 
@@ -88,134 +198,46 @@ Die Anwendung besitzt im Verzeichnis `src/main/resources` mehrere Properties Dat
 * `mail.properties` Konfiguration zum Mailversand (im `prod` Environment wird die Datei `mail.prod.properties` herangezogen)
 * `business.properties` Individuelle Regelungen wie bspw. maximal möglicher Jahresurlaub
 
-Die vorhandenen Properties können  entweder vor dem Erstellen der WAR-Datei direkt innerhalb der oben genannten Dateien
-angepasst werden oder aber über durch Setzen der dort definierten globalen Variablen.
+Die vorhandenen Properties können entweder vor dem Erstellen der WAR-Datei direkt innerhalb der oben genannten Dateien angepasst werden oder aber über durch Setzen der dort definierten globalen Variablen.
 
-**Beispiel:**
+###### Beispiel:
 
 <pre>export UV_DB_URL=jdbc:mysql://127.0.0.1:3306/urlaub</pre>
 
-### Produktivumgebung aktivieren
+##### Produktivumgebung aktivieren
 
-Damit die Anwendung in der Produktivumgebung gestartet wird, muss man in den `CATALINA_OPTS` die System-Property `env`
-auf `prod` setzen:
+Die Anwendung mit dem Parameter `-Denv=prod` starten:
 
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod</pre>
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Denv=prod"</pre>
 
-**Hinweis:**
+##### Authentifizierung
 
-Die Anwendung verfügt über drei verschiedene Environment-Möglichkeiten. Standardmäßig (ohne Angabe) wird die
-Anwendung in der `dev` Umgebung gestartet.
-
-* `dev` nutzt eine H2-Datenbank, legt Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `test` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `prod` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt den Java-Mail-Sender von
-[Spring](http://www.springsource.org/) (kann also E-Mails verschicken)
-
-### Authentifizierung
-
-Es kann gewählt werden zwischen Authentifizierung mittels LDAP und Authentifizierung mittels Active Directory. 
-
-**Authentifizierung via LDAP:**
-
-Voraussetzung: Es müssen die LDAP URL, die LDAP Base und LDAP User DN Patterns konfiguriert sein, damit eine Authentifizierung
-via LDAP möglich ist. Die Properties sind unter `src/main/resources/config.properties` zu finden.
+###### LDAP
 
 Die Anwendung mit dem Parameter `-Dspring.profiles.active=ldap` starten:
 
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod -Dspring.profiles.active=ldap</pre>
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Dspring.profiles.active=ldap"</pre>
 
-**Authentifizierung via Active Directory:**
-
-Voraussetzung: Es müssen die Active Directory Domain und LDAP URL konfiguriert sein, damit eine Authentifizierung via
-Active Directory möglich ist. Die Properties sind unter `src/main/resources/config.properties` zu finden.
+###### Active Directory
 
 Die Anwendung mit dem Parameter `-Dspring.profiles.active=activeDirectory` starten:
 
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod -Dspring.profiles.active=activeDirectory</pre>
+<pre>export CATALINA_OPTS="$CATALINA_OPTS -Dspring.profiles.active=activeDirectory"</pre>
 
-## Konfiguration ab Version 2.7.0
+---
 
-### Überschreiben der Properties
-
-Die Anwendung besitzt im Verzeichnis `src/main/resources` jeweils eine `application.properties` Datei pro Umgebung.
-
-* `application-dev.properties` zur lokalen Entwicklung mit einer H2 Datenbank
-* `application-test.properties` zum Testen der Anwendung mit einer MySQL Datenbank
-* `application-prod.properties` zum Ausführen der produktiven Anwendung
-
-Diese beinhalten gewisse Grundeinstellungen und Standardwerte. Diese allein reichen für die Produktivnahme der Anwendung allerdings noch nicht aus.
-Spezifische Konfigurationen wie z.B. die Datenbank Einstellungen müssen durch eine eigene Properties-Datei hinterlegt werden.
-Dazu kann die in der Anwendung befindliche Beispieldatei `urlaubsverwaltung.properties` als Vorlage verwendet werden,
-um die gewünschten Einstellungen zu überschreiben.
-
-Damit die eigene Konfigurationsdatei benutzt wird, gibt es zwei Möglichkeiten:
-
-* Eine eigene Properties-Datei erstellen und diese unter dem Namen `urlaubsverwaltung.properties` in das `/conf` Verzeichnis unterhalb von `CATALINA_BASE`
-ablegen, z.B. `tomcat/conf/urlaubsverwaltung.properties`, und den Tomcat neu starten
-* Die erstellte Properties-Datei an einem beliebigen Ort ablegen und mithilfe der System Property `config` innerhalb der `CATALINA_OPTS`
-den absoluten Pfad der Konfigurationsdatei angeben:
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod -Dauth=activeDirectory -Dconfig=/home/urlaub/config/my.properties</pre>
-
-### Produktivumgebung aktivieren
-
-Damit die Anwendung in der Produktivumgebung gestartet wird, muss man in den `CATALINA_OPTS` die System-Property `env`
-auf `prod` setzen:
-
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod</pre>
-
-**Hinweis:**
-
-Die Anwendung verfügt über drei verschiedene Environment-Möglichkeiten:
-
-* `dev` nutzt eine H2-Datenbank, legt Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `test` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `prod` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt den Java-Mail-Sender von
-[Spring](http://www.springsource.org/) (kann also E-Mails verschicken)
-
-### Authentifizierung
-
-Es kann gewählt werden zwischen Authentifizierung mittels LDAP und Authentifizierung mittels Active Directory.
-
-**Authentifizierung via LDAP:**
-
-Voraussetzung: Es müssen die LDAP URL, die LDAP Base und LDAP User DN Patterns konfiguriert sein, damit eine Authentifizierung
-via LDAP möglich ist.
-
-Die Anwendung mit dem Parameter `-Dauth=ldap` starten:
-
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod -Dauth=ldap</pre>
-
-**Authentifizierung via Active Directory:**
-
-Voraussetzung: Es müssen die Active Directory Domain und LDAP URL konfiguriert sein, damit eine Authentifizierung via
-Active Directory möglich ist.
-
-Die Anwendung mit dem Parameter `-Dauth=activeDirectory` starten:
-
-<pre>export CATALINA_OPTS=$CATALINA_OPTS -Denv=prod -Dauth=activeDirectory</pre>
-
-## Getting started
-
-Wenn die Anwendung im Tomcat beispielsweise im Verzeichnis `/home/user/tomcat/webapps/urlaubsverwaltung.war` deployed
-wurde, ist sie erreichbar unter `<servername>:8080/urlaubsverwaltung`.
-
-Der erste Benutzer, der sich erfolgreich im System einloggt, wird in der Urlaubsverwaltung mit der Rolle Office angelegt.
-Dies ermöglicht Benutzer- und Rechteverwaltung innerhalb der Anwendung und das Pflegen der Einstellungen für die Anwendung.
-
-# Entwicklung
+## Entwicklung
 
 Im Folgenden werden die durchzuführenden Schritte beschrieben, wenn man an der Urlaubsverwaltung entwickeln möchte.
 
-### Repository clonen
+#### Repository clonen
 
 <pre>git clone git@github.com:synyx/urlaubsverwaltung.git</pre>
 
-### Anwendung starten
+#### Anwendung starten
 
 Man kann die Anwendung lokal mit dem Maven Jetty Plugin starten.
-Ohne weitere Angabe wird das Development-Environment genutzt, d.h. es wird eine H2-Datenbank verwendet und es werden
-keine E-Mails versendet.
+Ohne weitere Angabe wird das Development-Environment genutzt, d.h. es wird eine H2-Datenbank verwendet und es werden keine E-Mails versendet.
 
 <pre>mvn jetty:run</pre>
 
@@ -224,36 +246,25 @@ Man kann sich in dieser Umgebung ebenfalls mit dem Testbenutzer `test/secret` an
 
 Im Browser lässt sich die Anwendung dann über `http://localhost:8080/` ansteuern.
 
-### API
+#### API
 
 Die Urlaubsverwaltung verfügt über eine API, die unter `http://localhost:8080/api` erreichbar ist.
 
-### Environments
+#### Environments
 
-Die Anwendung verfügt über drei verschiedene Environment-Möglichkeiten:
+Siehe [Umgebungen](https://github.com/synyx/urlaubsverwaltung#umgebungen)
 
-* `dev` nutzt eine H2-Datenbank, legt Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `test` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt als Mail-Sender einen Dummy (verschickt also keine E-Mails)
-* `prod` nutzt eine MySQL-Datenbank, legt keine Testdaten an, nutzt den Java-Mail-Sender von
-[Spring](http://www.springsource.org/) (kann also E-Mails verschicken)
-
-Standardmäßig ohne jegliche Angabe wird als Environment `dev` genutzt.
-Möchte man ein anderes Environment nutzen, muss man beim Starten des Maven Jetty Plugins die `env` Property mitgeben, z.B.:
+Standardmäßig ohne jegliche Angabe wird als Environment `dev` genutzt. Möchte man ein anderes Environment nutzen, muss man beim Starten des Maven Jetty Plugins die `env` Property mitgeben, z.B.:
 
 <pre>mvn jetty:run -Denv=test</pre>
 
-### Authentifizierung
+#### Authentifizierung
 
-Es gibt drei mögliche Authentifizierungsmethoden:
+Siehe [Authentifizierung](https://github.com/synyx/urlaubsverwaltung#authentifizierung)
 
-* Authentifizierung für lokale Entwicklungsumgebung
-* Authentifizierung via LDAP
-* Authentifizierung via Active Directory
+##### Authentifizierung für lokale Entwicklungsumgebung
 
-**Authentifizierung für lokale Entwicklungsumgebung:**
-
-Möchte man die Anwendung lokal mit generierten Testdaten bei sich laufen lassen, reicht es folgenden
-Befehl auszuführen:
+Möchte man die Anwendung lokal mit generierten Testdaten bei sich laufen lassen, reicht es folgenden Befehl auszuführen:
 
 <pre>mvn jetty:run</pre>
 
@@ -263,46 +274,39 @@ Man kann man sich nun mit verschiedenen Testbenutzern anmelden:
 * `testBoss/secret`: Benutzer mit der Boss Rolle
 * `test/secret`: Benutzer mit der Office Rolle
 
-**Authentifizierung via LDAP:**
-
-Es müssen die LDAP URL, die LDAP Base und LDAP User DN Patterns konfiguriert sein, damit eine Authentifizierung via
-LDAP möglich ist.
+##### LDAP
 
 Die Anwendung mit dem Parameter `-Dauth=ldap` starten:
 
 <pre>mvn jetty:run -Dauth=ldap</pre>
 
-**Authentifizierung via Active Directory:**
-
-Es müssen die Active Directory Domain und LDAP URL konfiguriert sein, damit eine Authentifizierung via Active Directory
-möglich ist.
+##### Active Directory
 
 Die Anwendung mit dem Parameter `-Dauth=activeDirectory` starten:
 
 <pre>mvn jetty:run -Dauth=activeDirectory</pre>
 
-**Kombination:**
+##### Kombination
 
 Selbstverständlich können beide Properties gleichzeitig gesetzt werden, zum Beispiel:
 
 <pre>mvn jetty:run -Denv=test -Dauth=ldap</pre>
 
-# Hinweise zu Versionen
+---
 
-## Version 2.2.1
+## Hinweise zu Versionen
 
-Wenn man die Urlaubsverwaltung schon länger nutzt und auf Version 2.2.1 oder höher updaten möchte, muss sichergestellt
-sein, dass in der Datenbank keine Person mit gleichem Vor- und Nachnamen existiert. Dies führt ansonsten zu einem
-Problem beim Update des Datenbankschemas und die Anwendung kann nicht starten.
+#### Version 2.2.1
 
-## Version 2.7.0
+Wenn man die Urlaubsverwaltung schon länger nutzt und auf Version 2.2.1 oder höher updaten möchte, muss sichergestellt sein, dass in der Datenbank keine Person mit gleichem Vor- und Nachnamen existiert. Dies führt ansonsten zu einem Problem beim Update des Datenbankschemas und die Anwendung kann nicht starten.
+
+#### Version 2.7.0
 
 Die Anwendung hat nicht mehr mehrere unterschiedliche Properties-Dateien, sondern je eine `application.properties` pro Umgebung.
 Außerdem heißt die System Property für die Authentifizierungsmethode nicht mehr `spring.profiles.active`, sondern `auth`.
-Die fachlichen Einstellungen werden nicht mehr in einer Properties-Datei gepflegt, sondern innerhalb der Anwendung selbst unter dem
-Menüpunkt "Einstellungen".
+Die fachlichen Einstellungen werden nicht mehr in einer Properties-Datei gepflegt, sondern innerhalb der Anwendung selbst unter dem Menüpunkt "Einstellungen".
 
-# Technologien
+## Technologien
 
 Die Anwendung basiert auf dem [Spring](http://www.springsource.org/) MVC Framework.
 Zur Ermittlung von Feiertagen wird das Framework [Jollyday](http://jollyday.sourceforge.net/) benutzt.
@@ -310,10 +314,8 @@ Das Frontend beinhaltet Elemente von [Bootstrap](http://getbootstrap.com/) gewü
 [jQuery](http://jquery.com/) und [Font Awesome](http://fontawesome.io/).
 Für die Darstellung der Benutzer Avatare wird [Gravatar](http://de.gravatar.com/) benutzt.
 
-# Lizenz
+## Lizenz
 
-[synyx/urlaubsverwaltung](http://github.com/synyx/urlaubsverwaltung) is licensed under the
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[synyx/urlaubsverwaltung](http://github.com/synyx/urlaubsverwaltung) is licensed under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-Alle Logos, Marken- und Warenzeichen unterliegen **nicht** der Apache License 2.0 und dürfen nur mit schriftlicher
-Genehmigung von [synyx](http://www.synyx.de/) weiterverwendet werden.
+Alle Logos, Marken- und WARenzeichen unterliegen **nicht** der Apache License 2.0 und dürfen nur mit schriftlicher Genehmigung von [synyx](http://www.synyx.de/) weiterverwendet werden.


### PR DESCRIPTION
Different changes are made (some of them are probably personal preferences and should be discussed or removed):

- remove duplications (Authentifizierung, Umgebungen aka Environments) and centralize description
- add file name of WAR-File (urlaubsverwaltung-X.X.X-SNAPSHOT.war)
- make copy-paste-commands executable (add double quotes)
- change english headers to german ones if possible for language homogeneity
- add explicitly
    export CATALINA_OPTS="-Denv=dev -Dauth=default"
  for faster deployment success (without "-Dauth=default" it does not work)

Probably personal preferences:
- remove linebreaks in the middle of sentences
- shorten headers ("Authentifizierung" is main-header, "LDAP" is sub-header)
- change order of different configuration descriptions (newer version first) for better flow of reading
- describe explicitly the older version ("bis 2.6.4" instead of "< Version 2.7.0")
- change header sizes
- insert horizontal lines between great parts
- remove CATALINA_OPTS arguments that are not related to explanation
    export CATALINA_OPTS="$CATALINA_OPTS -Denv=prod"
  instead of
    export CATALINA_OPTS="$CATALINA_OPTS -Denv=prod -Dauth=ldap"


Further questions:

I could not find application-dev.properties. Is it called application.properties?
