### PR TITLE
Ersetzen von Guava mit Java 8 Features

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.joda.time.DateMidnight;
@@ -20,6 +18,8 @@ import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountService.java
@@ -1,9 +1,9 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.synyx.urlaubsverwaltung.core.account.dao.AccountDAO;
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**
@@ -30,7 +30,7 @@ public class AccountServiceImpl implements AccountService {
     @Override
     public Optional<Account> getHolidaysAccount(int year, Person person) {
 
-        return Optional.fromNullable(accountDAO.getHolidaysAccountByYearAndPerson(year, person));
+        return Optional.ofNullable(accountDAO.getHolidaysAccountByYearAndPerson(year, person));
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-
 import org.joda.time.DateMidnight;
 import org.joda.time.DateTimeConstants;
 
@@ -24,6 +21,7 @@ import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 import java.math.BigDecimal;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -112,17 +110,11 @@ public class VacationDaysService {
                 firstMilestone, lastMilestone, person);
 
         // filter them since only waiting and allowed applications for leave of type holiday are relevant
-        List<Application> applicationsForLeave = FluentIterable.from(allApplicationsForLeave).filter(
-                new Predicate<Application>() {
-
-                    @Override
-                    public boolean apply(Application input) {
-
-                        return input.getVacationType() == VacationType.HOLIDAY
-                            && (input.hasStatus(ApplicationStatus.WAITING)
-                                || input.hasStatus(ApplicationStatus.ALLOWED));
-                    }
-                }).toList();
+        List<Application> applicationsForLeave = allApplicationsForLeave.stream().
+                filter(input -> input.getVacationType() == VacationType.HOLIDAY
+                        && (input.hasStatus(ApplicationStatus.WAITING)
+                        || input.hasStatus(ApplicationStatus.ALLOWED))).
+                collect(Collectors.toList());
 
         BigDecimal usedDays = BigDecimal.ZERO;
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionService.java
@@ -1,9 +1,9 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.synyx.urlaubsverwaltung.core.application.domain.Application;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.joda.time.DateMidnight;
@@ -18,6 +16,8 @@ import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.application.domain.Comment;
 import org.synyx.urlaubsverwaltung.core.mail.MailService;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.synyx.urlaubsverwaltung.core.application.domain.Application;
@@ -9,6 +7,7 @@ import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationServiceImpl.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +13,7 @@ import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -36,7 +35,7 @@ class ApplicationServiceImpl implements ApplicationService {
     @Override
     public Optional<Application> getApplicationById(Integer id) {
 
-        return Optional.fromNullable(applicationDAO.findOne(id));
+        return Optional.ofNullable(applicationDAO.findOne(id));
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +17,8 @@ import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 
 import java.math.BigDecimal;
+
+import java.util.Optional;
 
 
 /**
@@ -104,7 +104,7 @@ public class CalculationService {
         Optional<Account> lastYearsHolidaysAccount = accountService.getHolidaysAccount(year - 1, person);
 
         if (!lastYearsHolidaysAccount.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         return Optional.of(accountInteractionService.autoCreateHolidaysAccount(lastYearsHolidaysAccount.get()));

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CommentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CommentService.java
@@ -1,13 +1,12 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.synyx.urlaubsverwaltung.core.application.domain.Application;
 import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.application.domain.Comment;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CommentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CommentServiceImpl.java
@@ -4,8 +4,6 @@
  */
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +19,7 @@ import org.synyx.urlaubsverwaltung.core.application.domain.Comment;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/JollydayCalendar.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/JollydayCalendar.java
@@ -4,9 +4,6 @@
  */
 package org.synyx.urlaubsverwaltung.core.calendar;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 
 import de.jollyday.Holiday;
 import de.jollyday.HolidayManager;
@@ -27,6 +24,8 @@ import java.math.BigDecimal;
 import java.net.URL;
 
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 
 /**
@@ -111,15 +110,13 @@ public class JollydayCalendar {
 
         Set<Holiday> holidays = getHolidays(year);
 
-        Iterable<Holiday> holidaysForMonth = Iterables.filter(holidays, new Predicate<Holiday>() {
+        return holidays.stream().
+                filter(byMonth(month)).
+                collect(Collectors.toSet());
 
-                    @Override
-                    public boolean apply(Holiday holiday) {
+    }
 
-                        return holiday.getDate().getMonthOfYear() == month;
-                    }
-                });
-
-        return Sets.newHashSet(holidaysForMonth);
+    private Predicate<Holiday> byMonth(int month) {
+        return holiday -> holiday.getDate().getMonthOfYear() == month;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/OwnCalendarService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/OwnCalendarService.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.core.calendar;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +16,8 @@ import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 
 import java.math.BigDecimal;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTimeService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.calendar.workingtime;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +12,7 @@ import org.synyx.urlaubsverwaltung.core.application.domain.DayLength;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -63,13 +62,12 @@ public class WorkingTimeService {
 
     public Optional<WorkingTime> getByPersonAndValidityDateEqualsOrMinorDate(Person person, DateMidnight date) {
 
-        return Optional.fromNullable(workingTimeDAO.findByPersonAndValidityDateEqualsOrMinorDate(person,
-                    date.toDate()));
+        return Optional.ofNullable(workingTimeDAO.findByPersonAndValidityDateEqualsOrMinorDate(person, date.toDate()));
     }
 
 
     public Optional<WorkingTime> getCurrentOne(Person person) {
 
-        return Optional.fromNullable(workingTimeDAO.findLastOneByPerson(person));
+        return Optional.ofNullable(workingTimeDAO.findLastOneByPerson(person));
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/cron/TurnOfTheYearAccountUpdaterService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/cron/TurnOfTheYearAccountUpdaterService.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.core.cron;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.joda.time.DateMidnight;
@@ -22,6 +20,7 @@ import org.synyx.urlaubsverwaltung.core.person.PersonService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
@@ -1,9 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.mail;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import org.apache.commons.lang.CharEncoding;
 
 import org.apache.log4j.Logger;
@@ -36,7 +32,13 @@ import org.synyx.urlaubsverwaltung.core.util.PropertiesUtil;
 
 import java.io.IOException;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
 
 /**
@@ -154,15 +156,9 @@ class MailServiceImpl implements MailService {
 
         final String internationalizedSubject = properties.getProperty(subject);
 
-        final List<Person> recipientsWithMailAddress = Lists.newArrayList(Iterables.filter(recipients,
-                    new Predicate<Person>() {
-
-                        @Override
-                        public boolean apply(Person person) {
-
-                            return StringUtils.hasText(person.getEmail());
-                        }
-                    }));
+        final List<Person> recipientsWithMailAddress= recipients.stream().
+                filter(person -> StringUtils.hasText(person.getEmail())).
+                collect(Collectors.toList());
 
         if (recipientsWithMailAddress.size() > 0) {
             SimpleMailMessage mailMessage = new SimpleMailMessage();

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.mail;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -37,11 +36,7 @@ import org.synyx.urlaubsverwaltung.core.util.PropertiesUtil;
 
 import java.io.IOException;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 
 /**
@@ -94,7 +89,7 @@ class MailServiceImpl implements MailService {
     @Override
     public void sendNewApplicationNotification(Application application) {
 
-        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>absent());
+        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>empty());
         String text = buildMailBody("new_applications", model);
         sendEmail(getBosses(), "subject.new", text);
     }
@@ -201,7 +196,7 @@ class MailServiceImpl implements MailService {
     @Override
     public void sendRemindBossNotification(Application application) {
 
-        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>absent());
+        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>empty());
         String text = buildMailBody("remind", model);
         sendEmail(getBosses(), "subject.remind", text);
     }
@@ -215,13 +210,13 @@ class MailServiceImpl implements MailService {
 
         // email to office
         Map<String, Object> modelForOffice = createModelForApplicationStatusChangeMail(application,
-                Optional.fromNullable(comment));
+                Optional.ofNullable(comment));
         String textOffice = buildMailBody("allowed_office", modelForOffice);
         sendEmail(getOfficeMembers(), "subject.allowed.office", textOffice);
 
         // email to applicant
         Map<String, Object> modelForUser = createModelForApplicationStatusChangeMail(application,
-                Optional.fromNullable(comment));
+                Optional.ofNullable(comment));
         String textUser = buildMailBody("allowed_user", modelForUser);
         sendEmail(Arrays.asList(application.getPerson()), "subject.allowed.user", textUser);
     }
@@ -237,7 +232,7 @@ class MailServiceImpl implements MailService {
     public void sendRejectedNotification(Application application, Comment comment) {
 
         Map<String, Object> model = createModelForApplicationStatusChangeMail(application,
-                Optional.fromNullable(comment));
+                Optional.ofNullable(comment));
         String text = buildMailBody("rejected", model);
         sendEmail(Arrays.asList(application.getPerson()), "subject.rejected", text);
     }
@@ -260,7 +255,7 @@ class MailServiceImpl implements MailService {
     @Override
     public void sendConfirmation(Application application) {
 
-        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>absent());
+        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>empty());
         String text = buildMailBody("confirm", model);
         sendEmail(Arrays.asList(application.getPerson()), "subject.confirm", text);
     }
@@ -269,7 +264,7 @@ class MailServiceImpl implements MailService {
     @Override
     public void sendAppliedForLeaveByOfficeNotification(Application application) {
 
-        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>absent());
+        Map<String, Object> model = createModelForApplicationStatusChangeMail(application, Optional.<Comment>empty());
         String text = buildMailBody("new_application_by_office", model);
         sendEmail(Arrays.asList(application.getPerson()), "subject.new.app.by.office", text);
     }
@@ -280,7 +275,7 @@ class MailServiceImpl implements MailService {
 
         String text;
         Map<String, Object> model = createModelForApplicationStatusChangeMail(application,
-                Optional.fromNullable(comment));
+                Optional.ofNullable(comment));
 
         if (cancelledByOffice) {
             // mail to applicant anyway

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/Person.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/Person.java
@@ -1,8 +1,6 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/Person.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/Person.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -18,6 +17,7 @@ import org.synyx.urlaubsverwaltung.security.Role;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.persistence.*;
 
@@ -179,16 +179,11 @@ public class Person extends AbstractPersistable<Integer> {
 
     public boolean hasRole(final Role role) {
 
-        Optional<Role> hasRole = Iterables.tryFind(getPermissions(), new Predicate<Role>() {
+        return getPermissions().stream().
+                filter(permission -> permission.equals(role)).
+                findFirst().
+                isPresent();
 
-                    @Override
-                    public boolean apply(Role input) {
-
-                        return input.equals(role);
-                    }
-                });
-
-        return hasRole.isPresent();
     }
 
 
@@ -210,19 +205,12 @@ public class Person extends AbstractPersistable<Integer> {
 
     public boolean hasNotificationType(final MailNotification notification) {
 
-        Optional<MailNotification> hasNotificationType = Iterables.tryFind(getNotifications(),
-                new Predicate<MailNotification>() {
 
-                    @Override
-                    public boolean apply(MailNotification input) {
-
-                        return input.equals(notification);
-                    }
-                });
-
-        return hasNotificationType.isPresent();
+        return getNotifications().stream().
+                filter(element -> element.equals(notification)).
+                findFirst().
+                isPresent();
     }
-
 
     public String getNiceName() {
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.joda.time.DateMidnight;
@@ -24,6 +22,8 @@ import java.math.BigDecimal;
 
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteInteractionServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.sicknote;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +17,8 @@ import org.synyx.urlaubsverwaltung.core.mail.MailService;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.sicknote.comment.SickNoteCommentService;
 import org.synyx.urlaubsverwaltung.core.sicknote.comment.SickNoteStatus;
+
+import java.util.Optional;
 
 
 /**
@@ -60,7 +60,7 @@ public class SickNoteInteractionServiceImpl implements SickNoteInteractionServic
         sickNote.setLastEdited(DateMidnight.now());
 
         sickNoteService.save(sickNote);
-        sickNoteCommentService.create(sickNote, SickNoteStatus.CREATED, Optional.<String>absent(), creator);
+        sickNoteCommentService.create(sickNote, SickNoteStatus.CREATED, Optional.<String>empty(), creator);
 
         return sickNote;
     }
@@ -73,7 +73,7 @@ public class SickNoteInteractionServiceImpl implements SickNoteInteractionServic
         sickNote.setLastEdited(DateMidnight.now());
 
         sickNoteService.save(sickNote);
-        sickNoteCommentService.create(sickNote, SickNoteStatus.EDITED, Optional.<String>absent(), editor);
+        sickNoteCommentService.create(sickNote, SickNoteStatus.EDITED, Optional.<String>empty(), editor);
 
         return sickNote;
     }
@@ -88,7 +88,7 @@ public class SickNoteInteractionServiceImpl implements SickNoteInteractionServic
 
         signService.signApplicationByBoss(application, converter);
         applicationService.save(application);
-        applicationCommentService.create(application, ApplicationStatus.ALLOWED, Optional.<String>absent(), converter);
+        applicationCommentService.create(application, ApplicationStatus.ALLOWED, Optional.<String>empty(), converter);
         mailService.sendSickNoteConvertedToVacationNotification(application);
 
         // make sick note inactive
@@ -96,7 +96,7 @@ public class SickNoteInteractionServiceImpl implements SickNoteInteractionServic
         sickNote.setLastEdited(DateMidnight.now());
 
         sickNoteService.save(sickNote);
-        sickNoteCommentService.create(sickNote, SickNoteStatus.CONVERTED_TO_VACATION, Optional.<String>absent(),
+        sickNoteCommentService.create(sickNote, SickNoteStatus.CONVERTED_TO_VACATION, Optional.<String>empty(),
             converter);
 
         return sickNote;
@@ -110,7 +110,7 @@ public class SickNoteInteractionServiceImpl implements SickNoteInteractionServic
         sickNote.setLastEdited(DateMidnight.now());
 
         sickNoteService.save(sickNote);
-        sickNoteCommentService.create(sickNote, SickNoteStatus.CANCELLED, Optional.<String>absent(), canceller);
+        sickNoteCommentService.create(sickNote, SickNoteStatus.CANCELLED, Optional.<String>empty(), canceller);
 
         return sickNote;
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteService.java
@@ -1,12 +1,11 @@
 package org.synyx.urlaubsverwaltung.core.sicknote;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.synyx.urlaubsverwaltung.core.person.Person;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.sicknote;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +11,7 @@ import org.synyx.urlaubsverwaltung.core.settings.Settings;
 import org.synyx.urlaubsverwaltung.core.settings.SettingsService;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -43,7 +42,7 @@ public class SickNoteServiceImpl implements SickNoteService {
     @Override
     public Optional<SickNote> getById(Integer id) {
 
-        return Optional.fromNullable(sickNoteDAO.findOne(id));
+        return Optional.ofNullable(sickNoteDAO.findOne(id));
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentService.java
@@ -1,11 +1,10 @@
 package org.synyx.urlaubsverwaltung.core.sicknote.comment;
 
-import com.google.common.base.Optional;
-
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.sicknote.SickNote;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentServiceImpl.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.sicknote.comment;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +10,7 @@ import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.sicknote.SickNote;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/startup/TestDataCreationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/startup/TestDataCreationService.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.startup;
 
-import com.google.common.base.Optional;
-
 import org.apache.log4j.Logger;
 
 import org.joda.time.DateMidnight;
@@ -32,6 +30,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/PersonController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/PersonController.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -22,6 +19,7 @@ import org.synyx.urlaubsverwaltung.core.person.PersonService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 /**
@@ -46,7 +44,7 @@ public class PersonController {
         @RequestParam(value = "ldap", required = false)
         String ldapName) {
 
-        List<Person> persons = new ArrayList<Person>();
+        List<Person> persons = new ArrayList<>();
 
         if (ldapName == null) {
             persons = personService.getActivePersons();
@@ -57,15 +55,9 @@ public class PersonController {
                 persons.add(person.get());
             }
         }
-
-        List<PersonResponse> personResponses = Lists.transform(persons, new Function<Person, PersonResponse>() {
-
-                    @Override
-                    public PersonResponse apply(Person person) {
-
-                        return new PersonResponse(person);
-                    }
-                });
+        List<PersonResponse> personResponses = persons.stream().
+                map(PersonResponse::new).
+                collect(Collectors.toList());
 
         return new PersonListResponse(personResponses);
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/PublicHolidayController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/PublicHolidayController.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -27,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -77,18 +75,9 @@ public class PublicHolidayController {
             }
         }
 
-        List<PublicHolidayResponse> publicHolidayResponses = FluentIterable.from(holidays).transform(
-                new Function<Holiday, PublicHolidayResponse>() {
-
-                    @Override
-                    public PublicHolidayResponse apply(Holiday holiday) {
-
-                        BigDecimal duration = jollydayCalendar.getWorkingDurationOfDate(
-                                holiday.getDate().toDateMidnight());
-
-                        return new PublicHolidayResponse(holiday, duration);
-                    }
-                }).toList();
+        List<PublicHolidayResponse> publicHolidayResponses = holidays.stream().
+                map(holiday -> new PublicHolidayResponse(holiday, jollydayCalendar.getWorkingDurationOfDate(holiday.getDate().toDateMidnight()))).
+                collect(Collectors.toList());
 
         return new PublicHolidayListResponse(publicHolidayResponses);
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/restapi/SickNoteController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/restapi/SickNoteController.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.restapi;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -24,6 +21,7 @@ import org.synyx.urlaubsverwaltung.core.sicknote.SickNote;
 import org.synyx.urlaubsverwaltung.core.sicknote.SickNoteService;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -58,15 +56,10 @@ public class SickNoteController {
 
         List<SickNote> sickNotes = sickNoteService.getByPeriod(startDate, endDate);
 
-        List<AbsenceResponse> sickNoteResponses = Lists.transform(sickNotes,
-                new Function<SickNote, AbsenceResponse>() {
 
-                    @Override
-                    public AbsenceResponse apply(SickNote sickNote) {
-
-                        return new AbsenceResponse(sickNote);
-                    }
-                });
+        List<AbsenceResponse> sickNoteResponses = sickNotes.stream().
+                map(AbsenceResponse::new).
+                collect(Collectors.toList());
 
         return new SickNoteListResponse(sickNoteResponses);
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveController.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.application;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.stereotype.Controller;
@@ -25,6 +22,7 @@ import org.synyx.urlaubsverwaltung.web.util.GravatarUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -73,14 +71,10 @@ public class ApplicationForLeaveController {
 
         List<Application> applications = applicationService.getApplicationsForACertainState(ApplicationStatus.WAITING);
 
-        return FluentIterable.from(applications).transform(new Function<Application, ApplicationForLeave>() {
+        return applications.stream().
+                map(application -> new ApplicationForLeave(application, calendarService)).
+                collect(Collectors.toList());
 
-                    @Override
-                    public ApplicationForLeave apply(Application input) {
-
-                        return new ApplicationForLeave(input, calendarService);
-                    }
-                }).toList();
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.application;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +41,7 @@ import org.synyx.urlaubsverwaltung.web.validator.CommentValidator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 /**
@@ -173,7 +172,7 @@ public class ApplicationForLeaveDetailsController {
                 redirectAttributes.addFlashAttribute("errors", errors);
                 redirectAttributes.addFlashAttribute("action", "allow");
             } else {
-                applicationInteractionService.allow(application.get(), boss, Optional.fromNullable(comment.getText()));
+                applicationInteractionService.allow(application.get(), boss, Optional.ofNullable(comment.getText()));
                 redirectAttributes.addFlashAttribute("allowSuccess", true);
             }
 
@@ -227,7 +226,7 @@ public class ApplicationForLeaveDetailsController {
                 redirectAttributes.addFlashAttribute("errors", errors);
                 redirectAttributes.addFlashAttribute("action", "reject");
             } else {
-                applicationInteractionService.reject(application.get(), boss, Optional.fromNullable(comment.getText()));
+                applicationInteractionService.reject(application.get(), boss, Optional.ofNullable(comment.getText()));
                 redirectAttributes.addFlashAttribute("rejectSuccess", true);
             }
 
@@ -277,7 +276,7 @@ public class ApplicationForLeaveDetailsController {
             redirectAttributes.addFlashAttribute("errors", errors);
             redirectAttributes.addFlashAttribute("action", "cancel");
         } else {
-            applicationInteractionService.cancel(application, loggedUser, Optional.fromNullable(comment.getText()));
+            applicationInteractionService.cancel(application, loggedUser, Optional.ofNullable(comment.getText()));
         }
 
         return "redirect:/web/application/" + applicationId;

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.application;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 
 import org.joda.time.DateMidnight;
@@ -40,6 +39,7 @@ import org.synyx.urlaubsverwaltung.web.validator.ApplicationValidator;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -205,7 +205,7 @@ public class ApplyForLeaveController {
         Application application = appForm.generateApplicationForLeave();
 
         Application savedApplicationForLeave = applicationInteractionService.apply(application, applier,
-                Optional.fromNullable(appForm.getComment()));
+                Optional.ofNullable(appForm.getComment()));
 
         redirectAttributes.addFlashAttribute("applySuccess", true);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplyForLeaveController.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.application;
 
-import com.google.common.collect.FluentIterable;
-
 import org.joda.time.DateMidnight;
 import org.joda.time.chrono.GregorianChronology;
 
@@ -40,6 +38,7 @@ import org.synyx.urlaubsverwaltung.web.validator.ApplicationValidator;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 /**
@@ -138,21 +137,12 @@ public class ApplyForLeaveController {
 
     private void prepareApplicationForLeaveForm(Person person, ApplicationForLeaveForm appForm, Model model) {
 
-        List<Person> persons = FluentIterable.from(personService.getActivePersons()).toSortedList(
-                new Comparator<Person>() {
-
-                    @Override
-                    public int compare(Person p1, Person p2) {
-
-                        String niceName1 = p1.getNiceName();
-                        String niceName2 = p2.getNiceName();
-
-                        return niceName1.toLowerCase().compareTo(niceName2.toLowerCase());
-                    }
-                });
+        List<Person> persons = personService.getActivePersons().stream().
+                sorted(personComperator()).
+                collect(Collectors.toList());
 
         Optional<Account> account = accountService.getHolidaysAccount(DateMidnight.now(
-                    GregorianChronology.getInstance()).getYear(), person);
+                GregorianChronology.getInstance()).getYear(), person);
 
         if (account.isPresent()) {
             model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get()));
@@ -167,6 +157,10 @@ public class ApplyForLeaveController {
         model.addAttribute("account", account);
         model.addAttribute("vacTypes", VacationType.values());
         model.addAttribute(PersonConstants.LOGGED_USER, sessionService.getLoggedUser());
+    }
+
+    private Comparator<Person> personComperator() {
+        return (p1, p2) -> p1.getNiceName().toLowerCase().compareTo(p2.getNiceName().toLowerCase());
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.person;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +26,7 @@ import org.synyx.urlaubsverwaltung.web.util.GravatarUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
@@ -1,7 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.web.person;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -23,6 +22,9 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+
+import static org.synyx.urlaubsverwaltung.security.Role.INACTIVE;
 
 
 /**
@@ -322,7 +324,7 @@ public class PersonForm {
 
         if (personShouldBeSetToInactive(permissions)) {
             List<Role> onlyInactive = new ArrayList<>();
-            onlyInactive.add(Role.INACTIVE);
+            onlyInactive.add(INACTIVE);
             person.setPermissions(onlyInactive);
         } else {
             person.setPermissions(permissions);
@@ -332,15 +334,9 @@ public class PersonForm {
 
     private boolean personShouldBeSetToInactive(Collection<Role> permissions) {
 
-        Optional<Role> shouldBeInactiveOptional = Iterables.tryFind(permissions, new Predicate<Role>() {
-
-                    @Override
-                    public boolean apply(Role role) {
-
-                        return role.equals(Role.INACTIVE);
-                    }
-                });
-
-        return shouldBeInactiveOptional.isPresent();
+        return permissions.stream().
+                filter(permission -> permission.equals(INACTIVE)).
+                findFirst().
+                isPresent();
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.web.person;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import org.joda.time.DateMidnight;
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.web.person;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +36,7 @@ import org.synyx.urlaubsverwaltung.web.validator.PersonValidator;
 import java.math.BigDecimal;
 
 import java.util.Locale;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonOverviewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonOverviewController.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.web.person;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -49,6 +48,7 @@ import java.math.BigDecimal;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/sicknote/SickNoteController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/sicknote/SickNoteController.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.sicknote;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 
 import org.joda.time.DateMidnight;
@@ -46,6 +45,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.security.RolesAllowed;
 
@@ -233,7 +233,7 @@ public class SickNoteController {
                 redirectAttributes.addFlashAttribute("errors", errors);
             } else {
                 sickNoteCommentService.create(sickNote.get(), SickNoteStatus.COMMENTED,
-                    Optional.fromNullable(comment.getText()), sessionService.getLoggedUser());
+                    Optional.ofNullable(comment.getText()), sessionService.getLoggedUser());
             }
 
             return "redirect:/web/sicknote/" + id;

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/statistics/ApplicationForLeaveStatisticsBuilder.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/statistics/ApplicationForLeaveStatisticsBuilder.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.statistics;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +22,7 @@ import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 import java.math.BigDecimal;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/HolidaysAccountInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/HolidaysAccountInteractionServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.joda.time.DateMidnight;
@@ -23,6 +21,8 @@ import org.synyx.urlaubsverwaltung.core.settings.SettingsService;
 import java.io.IOException;
 
 import java.math.BigDecimal;
+
+import java.util.Optional;
 
 
 /**
@@ -212,7 +212,7 @@ public class HolidaysAccountInteractionServiceImplTest {
         Mockito.when(accountService.getHolidaysAccount(2012, person)).thenReturn(Optional.of(account2012));
         Mockito.when(accountService.getHolidaysAccount(2013, person)).thenReturn(Optional.of(account2013));
         Mockito.when(accountService.getHolidaysAccount(2014, person)).thenReturn(Optional.of(account2014));
-        Mockito.when(accountService.getHolidaysAccount(2015, person)).thenReturn(Optional.<Account>absent());
+        Mockito.when(accountService.getHolidaysAccount(2015, person)).thenReturn(Optional.<Account>empty());
 
         Mockito.when(vacationDaysService.calculateTotalLeftVacationDays(account2012)).thenReturn(BigDecimal.valueOf(6));
         Mockito.when(vacationDaysService.calculateTotalLeftVacationDays(account2013)).thenReturn(BigDecimal.valueOf(2));

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/HolidaysAccountServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/HolidaysAccountServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -12,6 +10,8 @@ import org.mockito.Mockito;
 import org.synyx.urlaubsverwaltung.core.account.dao.AccountDAO;
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.account.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.joda.time.DateMidnight;
@@ -34,6 +32,7 @@ import java.math.BigDecimal;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationInteractionServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.junit.Assert;
@@ -16,6 +14,8 @@ import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.application.domain.Comment;
 import org.synyx.urlaubsverwaltung.core.mail.MailService;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/ApplicationServiceImplTest.java
@@ -4,8 +4,6 @@
  */
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -15,6 +13,8 @@ import org.mockito.Mockito;
 
 import org.synyx.urlaubsverwaltung.core.application.dao.ApplicationDAO;
 import org.synyx.urlaubsverwaltung.core.application.domain.Application;
+
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.joda.time.DateMidnight;
@@ -32,6 +30,7 @@ import java.math.BigDecimal;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CommentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CommentServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -14,6 +12,8 @@ import org.synyx.urlaubsverwaltung.core.application.domain.Application;
 import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.core.application.domain.Comment;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+
+import java.util.Optional;
 
 
 /**
@@ -41,7 +41,7 @@ public class CommentServiceImplTest {
         Person author = new Person();
         Application application = new Application();
 
-        Comment comment = commentService.create(application, ApplicationStatus.ALLOWED, Optional.<String>absent(),
+        Comment comment = commentService.create(application, ApplicationStatus.ALLOWED, Optional.<String>empty(),
                 author);
 
         Assert.assertNotNull("Should not be null", comment);

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/calendar/OwnCalendarServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/calendar/OwnCalendarServiceTest.java
@@ -1,8 +1,6 @@
 
 package org.synyx.urlaubsverwaltung.core.calendar;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 import org.joda.time.DateTimeConstants;
 
@@ -25,6 +23,7 @@ import java.math.BigDecimal;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/person/PersonInteractionServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.person;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.junit.Assert;
@@ -63,8 +61,8 @@ public class PersonInteractionServiceImplTest {
         examplePersonForm.setWorkingDays(Arrays.asList(Day.MONDAY.getDayOfWeek(), Day.TUESDAY.getDayOfWeek()));
         examplePersonForm.setPermissions(Arrays.asList(Role.USER));
 
-        Mockito.when(accountService.getHolidaysAccount(Mockito.anyInt(), Mockito.any(Person.class))).thenReturn(Optional
-            .<Account>absent());
+        Mockito.when(accountService.getHolidaysAccount(Mockito.anyInt(), Mockito.any(Person.class))).thenReturn(
+            java.util.Optional.<Account>empty());
     }
 
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/sicknote/SickNoteInteractionServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.sicknote;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -18,6 +16,8 @@ import org.synyx.urlaubsverwaltung.core.mail.MailService;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.sicknote.comment.SickNoteCommentService;
 import org.synyx.urlaubsverwaltung.core.sicknote.comment.SickNoteStatus;
+
+import java.util.Optional;
 
 
 /**
@@ -60,7 +60,7 @@ public class SickNoteInteractionServiceImplTest {
         SickNote createdSickNote = sickNoteInteractionService.create(sickNote, person);
 
         Mockito.verify(sickNoteService).save(sickNote);
-        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.CREATED, Optional.<String>absent(),
+        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.CREATED, Optional.<String>empty(),
             person);
 
         Assert.assertNotNull("Should not be null", createdSickNote);
@@ -79,7 +79,7 @@ public class SickNoteInteractionServiceImplTest {
         SickNote updatedSickNote = sickNoteInteractionService.update(sickNote, person);
 
         Mockito.verify(sickNoteService).save(sickNote);
-        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.EDITED, Optional.<String>absent(),
+        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.EDITED, Optional.<String>empty(),
             person);
 
         Assert.assertNotNull("Should not be null", updatedSickNote);
@@ -98,7 +98,7 @@ public class SickNoteInteractionServiceImplTest {
         SickNote cancelledSickNote = sickNoteInteractionService.cancel(sickNote, person);
 
         Mockito.verify(sickNoteService).save(sickNote);
-        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.CANCELLED, Optional.<String>absent(),
+        Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.CANCELLED, Optional.<String>empty(),
             person);
 
         Assert.assertNotNull("Should not be null", cancelledSickNote);
@@ -121,7 +121,7 @@ public class SickNoteInteractionServiceImplTest {
 
         Mockito.verify(sickNoteService).save(sickNote);
         Mockito.verify(sickNoteCommentService).create(sickNote, SickNoteStatus.CONVERTED_TO_VACATION,
-            Optional.<String>absent(), person);
+            Optional.<String>empty(), person);
 
         Assert.assertNotNull("Should not be null", convertedSickNote);
 
@@ -132,7 +132,7 @@ public class SickNoteInteractionServiceImplTest {
 
         Mockito.verify(applicationService).save(applicationForLeave);
         Mockito.verify(applicationCommentService).create(Mockito.eq(applicationForLeave),
-            Mockito.eq(ApplicationStatus.ALLOWED), Mockito.eq(Optional.<String>absent()), Mockito.eq(person));
+            Mockito.eq(ApplicationStatus.ALLOWED), Mockito.eq(Optional.<String>empty()), Mockito.eq(person));
         Mockito.verify(signService).signApplicationByBoss(Mockito.eq(applicationForLeave), Mockito.eq(person));
         Mockito.verify(mailService).sendSickNoteConvertedToVacationNotification(Mockito.eq(applicationForLeave));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/sicknote/comment/SickNoteCommentServiceImplTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.sicknote.comment;
 
-import com.google.common.base.Optional;
-
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -11,6 +9,8 @@ import org.mockito.Mockito;
 
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.sicknote.SickNote;
+
+import java.util.Optional;
 
 
 /**
@@ -40,7 +40,7 @@ public class SickNoteCommentServiceImplTest {
         SickNote sickNote = new SickNote();
 
         SickNoteComment comment = sickNoteCommentService.create(sickNote, SickNoteStatus.EDITED,
-                Optional.<String>absent(), author);
+                Optional.<String>empty(), author);
 
         Assert.assertNotNull("Should not be null", comment);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/SecurityTestUtil.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/SecurityTestUtil.java
@@ -1,8 +1,5 @@
 package org.synyx.urlaubsverwaltung.security;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import org.springframework.security.core.GrantedAuthority;
 
@@ -18,20 +15,9 @@ public class SecurityTestUtil {
 
     public static boolean authorityForRoleExists(Collection<? extends GrantedAuthority> authorities, final Role role) {
 
-        Optional<? extends GrantedAuthority> authorityForRoleExistsOptional = Iterables.tryFind(authorities,
-                new Predicate<GrantedAuthority>() {
-
-                    @Override
-                    public boolean apply(GrantedAuthority input) {
-
-                        if (input.getAuthority().equals(role.name())) {
-                            return true;
-                        }
-
-                        return false;
-                    }
-                });
-
-        return authorityForRoleExistsOptional.isPresent();
+        return authorities.stream().
+                filter(authority -> authority.getAuthority().equals(role.name())).
+                findFirst().
+                isPresent();
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/person/PersonFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/person/PersonFormTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.person;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.junit.Assert;
@@ -9,10 +7,9 @@ import org.junit.Test;
 
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.calendar.workingtime.WorkingTime;
-import org.synyx.urlaubsverwaltung.core.mail.MailNotification;
-import org.synyx.urlaubsverwaltung.security.Role;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 
 /**
@@ -25,8 +22,8 @@ public class PersonFormTest {
     @Test(expected = IllegalArgumentException.class)
     public void ensureThrowsIfPersonIsNull() {
 
-        new PersonForm(null, 2014, Optional.<Account>absent(), Optional.<WorkingTime>absent(), new ArrayList<Role>(),
-            new ArrayList<MailNotification>());
+        new PersonForm(null, 2014, Optional.<Account>empty(), Optional.<WorkingTime>empty(), new ArrayList<>(),
+            new ArrayList<>());
     }
 
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web.statistics;
 
-import com.google.common.base.Optional;
-
 import org.joda.time.DateMidnight;
 
 import org.junit.Assert;
@@ -25,6 +23,7 @@ import java.math.BigDecimal;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 
 /**


### PR DESCRIPTION
Alle guava-Funktionen bis auf Operationen mit der Klasse com.google.common.base.MoreObjects wurden mit Java8 Features ersetzt.

Dadurch wird vor Allem die Lesbarkeit und auch die Performance verbessert.