### PR TITLE
Remove nexus.synyx.de repository from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,14 +61,6 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>nexus.synyx.de</id>
-            <name>Synyx OpenSource Repository</name>
-            <url>http://nexus.synyx.de/content/groups/synyx/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
 
         <!-- UTIL DEPENDENCIES -->


### PR DESCRIPTION
Since the referenced repository is not available for anyone outside
of our company (protected via password), it leads to non-successful
builds, dependending on the Maven version in question.

Since there are no actual artifacts, that need to be fetched from
there, we can simply remove it. We keep the distribution management
repositories though, since we use those for automatic deployment and
they don't affect people outside of synyx, who are building from
source.