### PR TITLE
Bundeslandauswahl pro User

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.synyx</groupId>
     <artifactId>urlaubsverwaltung</artifactId>
-    <version>2.17.4-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Urlaubsverwaltung</name>

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTime.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTime.java
@@ -259,4 +259,9 @@ public class WorkingTime extends AbstractPersistable<Integer> {
 
         return Optional.ofNullable(federalStateOverride);
     }
+
+    public void setFederalStateOverride(Optional<FederalState> state){
+
+        this.federalStateOverride = state.orElse(null);
+    }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTime.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTime.java
@@ -11,9 +11,11 @@ import org.springframework.data.jpa.domain.AbstractPersistable;
 import org.synyx.urlaubsverwaltung.core.period.DayLength;
 import org.synyx.urlaubsverwaltung.core.period.WeekDay;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+import org.synyx.urlaubsverwaltung.core.settings.FederalState;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -56,6 +58,14 @@ public class WorkingTime extends AbstractPersistable<Integer> {
 
     @Temporal(javax.persistence.TemporalType.DATE)
     private Date validFrom;
+
+    /**
+     * If set, override the system-wide FederalState setting for this person.
+     * TODO: Maybe we should embed the whole WorkingTimeSettings to allow overriding all of them?
+     */
+    @Enumerated(EnumType.STRING)
+    private FederalState federalStateOverride;
+
 
     public void setWorkingDays(List<Integer> workingDays, DayLength dayLength) {
 
@@ -243,5 +253,10 @@ public class WorkingTime extends AbstractPersistable<Integer> {
     public DayLength getSunday() {
 
         return sunday;
+    }
+
+    public Optional<FederalState> getFederalStateOverride(){
+
+        return Optional.ofNullable(federalStateOverride);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/calendar/workingtime/WorkingTimeService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import org.synyx.urlaubsverwaltung.core.period.DayLength;
 import org.synyx.urlaubsverwaltung.core.person.Person;
+import org.synyx.urlaubsverwaltung.core.settings.FederalState;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +33,7 @@ public class WorkingTimeService {
         this.workingTimeDAO = workingTimeDAO;
     }
 
-    public void touch(List<Integer> workingDays, DateMidnight validFrom, Person person) {
+    public void touch(List<Integer> workingDays, Optional<FederalState> federalState, DateMidnight validFrom, Person person) {
 
         WorkingTime workingTime = workingTimeDAO.findByPersonAndValidityDate(person, validFrom.toDate());
 
@@ -49,6 +50,8 @@ public class WorkingTimeService {
          * else just change the working days of the current working time object
          */
         workingTime.setWorkingDays(workingDays, DayLength.FULL);
+
+        workingTime.setFederalStateOverride(federalState);
 
         workingTimeDAO.save(workingTime);
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/dev/PersonDataProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/dev/PersonDataProvider.java
@@ -25,6 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -63,7 +64,7 @@ class PersonDataProvider {
 
         int currentYear = DateMidnight.now().getYear();
         workingTimeService.touch(Arrays.asList(WeekDay.MONDAY.getDayOfWeek(), WeekDay.TUESDAY.getDayOfWeek(),
-                WeekDay.WEDNESDAY.getDayOfWeek(), WeekDay.THURSDAY.getDayOfWeek(), WeekDay.FRIDAY.getDayOfWeek()),
+                WeekDay.WEDNESDAY.getDayOfWeek(), WeekDay.THURSDAY.getDayOfWeek(), WeekDay.FRIDAY.getDayOfWeek()), Optional.empty(),
             new DateMidnight(currentYear - 1, 1, 1), person);
 
         accountInteractionService.createHolidaysAccount(person, DateUtil.getFirstDayOfYear(currentYear),

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonForm.java
@@ -12,6 +12,7 @@ import org.synyx.urlaubsverwaltung.core.period.WeekDay;
 import org.synyx.urlaubsverwaltung.core.person.MailNotification;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.Role;
+import org.synyx.urlaubsverwaltung.core.settings.FederalState;
 import org.synyx.urlaubsverwaltung.core.util.DateUtil;
 
 import java.math.BigDecimal;
@@ -60,6 +61,8 @@ public class PersonForm {
     private List<Role> permissions = new ArrayList<>();
 
     private List<MailNotification> notifications = new ArrayList<>();
+
+    private FederalState federalState;
 
     public PersonForm() {
 
@@ -116,6 +119,7 @@ public class PersonForm {
             }
 
             this.validFrom = workingTime.getValidFrom();
+            this.federalState = workingTime.getFederalStateOverride().orElse(null);
         }
 
         this.permissions = new ArrayList<>(roles);
@@ -311,5 +315,13 @@ public class PersonForm {
     public void setNotifications(List<MailNotification> notifications) {
 
         this.notifications = notifications;
+    }
+
+    public FederalState getFederalState() {
+        return federalState;
+    }
+
+    public void setFederalState(FederalState federalState) {
+        this.federalState = federalState;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonFormProcessorImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonFormProcessorImpl.java
@@ -67,7 +67,7 @@ public class PersonFormProcessorImpl implements PersonFormProcessor {
 
     private void touchWorkingTime(Person person, PersonForm personForm) {
 
-        workingTimeService.touch(personForm.getWorkingDays(), personForm.getValidFrom(), person);
+        workingTimeService.touch(personForm.getWorkingDays(), Optional.ofNullable(personForm.getFederalState()), personForm.getValidFrom(), person);
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonManagementController.java
@@ -23,12 +23,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.account.service.AccountService;
+import org.synyx.urlaubsverwaltung.core.calendar.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.core.calendar.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.core.calendar.workingtime.WorkingTimeService;
 import org.synyx.urlaubsverwaltung.core.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.core.period.WeekDay;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.PersonService;
+import org.synyx.urlaubsverwaltung.core.settings.FederalState;
 import org.synyx.urlaubsverwaltung.security.SecurityRules;
 import org.synyx.urlaubsverwaltung.web.ControllerConstants;
 import org.synyx.urlaubsverwaltung.web.DateMidnightPropertyEditor;
@@ -64,6 +66,9 @@ public class PersonManagementController {
 
     @Autowired
     private DepartmentService departmentService;
+
+    @Autowired
+    private PublicHolidaysService publicHolidaysService;
 
     @InitBinder
     public void initBinder(DataBinder binder, Locale locale) {
@@ -130,6 +135,8 @@ public class PersonManagementController {
         model.addAttribute("headOfDepartments", departmentService.getManagedDepartmentsOfDepartmentHead(person));
         model.addAttribute("secondStageDepartments",
             departmentService.getManagedDepartmentsOfSecondStageAuthority(person));
+        model.addAttribute("federalStateTypes", FederalState.values());
+        model.addAttribute("defaultFederalState", publicHolidaysService.getSystemDefaultFederalState());
 
         return PersonConstants.PERSON_FORM_JSP;
     }

--- a/src/main/resources/META-INF/resources/jsp/person/person_form.jsp
+++ b/src/main/resources/META-INF/resources/jsp/person/person_form.jsp
@@ -265,11 +265,33 @@
     <div class="col-md-4 col-md-push-8">
     <span class="help-block">
         <i class="fa fa-fw fa-info-circle"></i>
+        <spring:message code="federalState.${defaultFederalState}" var="defaultFederalStateName" />
+        <spring:message code="person.form.workingTime.federalState.description" arguments="${defaultFederalStateName}" />
+    </span>
+    <span class="help-block">
+        <i class="fa fa-fw fa-info-circle"></i>
         <spring:message code="person.form.workingTime.description"/>
     </span>
     </div>
 
     <div class="col-md-8 col-md-pull-4">
+        <div class="form-group">
+            <label class="control-label col-md-3" for="federalStateType">
+                <spring:message code='settings.publicHolidays.federalState'/>:
+            </label>
+
+            <div class="col-md-9">
+                <form:select path="federalState" id="federalStateType" class="form-control" cssErrorClass="form-control error">
+                    <form:option value=""><spring:message code="person.form.workingTime.federalState.default" arguments="${defaultFederalStateName}" /></form:option>
+                    <option disabled='true' >---------------</option>
+                    <c:forEach items="${federalStateTypes}" var="federalStateType">
+                        <form:option value="${federalStateType}"><spring:message code="federalState.${federalStateType}" /></form:option>
+                    </c:forEach>
+                </form:select>
+            </div>
+        </div>
+
+
         <c:if test="${fn:length(workingTimes) > 1}">
 
             <div class="form-group">

--- a/src/main/resources/dbchangelogs/changelog-2.18.0-add_federal_state_override.xml
+++ b/src/main/resources/dbchangelogs/changelog-2.18.0-add_federal_state_override.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet author="thilo" id="add_federal_state_override" >
+
+        <preConditions>
+            <tableExists tableName="WorkingTime"/>
+        </preConditions>
+
+        <addColumn tableName="WorkingTime">
+            <column name="federalStateOverride" type="VARCHAR(255)" />
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -44,5 +44,6 @@
     <include file="dbchangelogs/changelog-2.15.0-add_application_startTime_and_endTime.xml"/>
     <include file="dbchangelogs/changelog-2.15.0-add_settings_minimum_overtime.xml"/>
     <include file="dbchangelogs/changelog-2.16.0-add_base_link_url_to_mail_settings.xml"/>
+    <include file="dbchangelogs/changelog-2.18.0-add_federal_state_override.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -361,6 +361,8 @@ person.form.workingTime.description=Die Wochentage haben Einfluss darauf, wie vi
 person.form.workingTime.validityPeriod=G\u00FCltig ab
 person.form.workingTime.weekDays=Wochentage
 person.form.workingTime.error.mandatory=Es muss mindestens ein Wochentag ausgew\u00E4hlt werden.
+person.form.workingTime.federalState.description=Wenn die systemweite Einstellung des Bundeslandes ({0}) f\u00FCr diesen Benutzer unzutreffend ist, kann zur Berechnung der Urlaubstage ein abweichendes Bundesland eingestellt werden.
+person.form.workingTime.federalState.default=Systemweite Einstellung ({0})
 
 # Departments
 person.form.departments.title=Zugeordnete Abteilungen

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -352,7 +352,7 @@ $(function() {
                 if (_CACHE['publicHoliday'][year]) {
                     return deferred.resolve( _CACHE[year] );
                 } else {
-                    return fetch('/holidays', {year: year}).success( cachePublicHoliday(year) );
+                    return fetch('/holidays', {year: year, person: personId}).success( cachePublicHoliday(year) );
                 }
             },
 

--- a/src/main/resources/static/js/datepicker.js
+++ b/src/main/resources/static/js/datepicker.js
@@ -85,11 +85,11 @@ function createDatepickerInstances(selectors, regional, urlPrefix, getPerson, on
       var year = date.getFullYear();
       var month = date.getMonth() + 1;
 
-      getHighlighted(urlPrefix + "/holidays?year=" + year + "&month=" + month, function (data) {
+      var personId = getPerson();
+
+      getHighlighted(urlPrefix + "/holidays?year=" + year + "&month=" + month+ "&person=" + personId, function (data) {
         highlighted = getPublicHolidays(data);
       });
-
-      var personId = getPerson();
 
       getHighlighted(urlPrefix + "/absences?year=" + year + "&month=" + month + "&person=" + personId, function (data) {
         highlightedAbsences = getAbsences(data);
@@ -98,11 +98,12 @@ function createDatepickerInstances(selectors, regional, urlPrefix, getPerson, on
     },
     onChangeMonthYear: function (year, month) {
 
-      getHighlighted(urlPrefix + "/holidays?year=" + year + "&month=" + month, function (data) {
+      var personId = getPerson();
+
+      getHighlighted(urlPrefix + "/holidays?year=" + year + "&month=" + month+ "&person=" + personId, function (data) {
         highlighted = getPublicHolidays(data);
       });
 
-      var personId = getPerson();
 
       getHighlighted(urlPrefix + "/absences?year=" + year + "&month=" + month + "&person=" + personId, function (data) {
         highlightedAbsences = getAbsences(data);

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/calendar/PublicHolidaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/calendar/PublicHolidaysServiceTest.java
@@ -30,6 +30,8 @@ public class PublicHolidaysServiceTest {
     private PublicHolidaysService publicHolidaysService;
     private SettingsService settingsService;
 
+    private final static FederalState state = FederalState.BADEN_WUERTTEMBERG;
+
     @Before
     public void setUp() throws IOException {
 
@@ -45,7 +47,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 25);
 
-        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate);
+        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate, state);
 
         Assert.assertTrue("Christmas should be recognized as public holiday", isPublicHoliday);
     }
@@ -56,7 +58,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 20);
 
-        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate);
+        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate, state);
 
         Assert.assertFalse("Work day should not be recognized as public holiday", isPublicHoliday);
     }
@@ -67,7 +69,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.MAY, 30);
 
-        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate);
+        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate, state);
 
         Assert.assertTrue("Corpus Christi should be recognized as public holiday", isPublicHoliday);
     }
@@ -78,7 +80,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 24);
 
-        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate);
+        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate, state);
 
         Assert.assertTrue("Christmas Eve should be recognized as public holiday", isPublicHoliday);
     }
@@ -89,7 +91,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 31);
 
-        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate);
+        boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(testDate, state);
 
         Assert.assertTrue("New Years Eve should be recognized as public holiday", isPublicHoliday);
     }
@@ -100,7 +102,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.NOVEMBER, 27);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ONE.setScale(1), workingDuration);
     }
@@ -111,7 +113,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 25);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ZERO, workingDuration);
     }
@@ -127,7 +129,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 24);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ONE.setScale(1), workingDuration);
     }
@@ -143,7 +145,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 31);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ONE.setScale(1), workingDuration);
     }
@@ -159,7 +161,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 24);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", new BigDecimal("0.5"), workingDuration);
     }
@@ -175,7 +177,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 31);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", new BigDecimal("0.5"), workingDuration);
     }
@@ -191,7 +193,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 24);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ZERO, workingDuration);
     }
@@ -207,7 +209,7 @@ public class PublicHolidaysServiceTest {
 
         DateMidnight testDate = new DateMidnight(2013, DateTimeConstants.DECEMBER, 31);
 
-        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate);
+        BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(testDate, state);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ZERO, workingDuration);
     }
@@ -216,13 +218,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureAssumptionDayIsAPublicHolidayForBayernMuenchen() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BAYERN_MUENCHEN);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(new DateMidnight(2015, DateTimeConstants.AUGUST,
-                    15));
+                    15), FederalState.BAYERN_MUENCHEN);
 
         Assert.assertTrue("Assumption Day should be recognized as public holiday", isPublicHoliday);
     }
@@ -231,13 +228,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureAssumptionDayIsNoPublicHolidayForBerlin() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BERLIN);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(new DateMidnight(2015, DateTimeConstants.AUGUST,
-                    15));
+                    15), FederalState.BERLIN);
 
         Assert.assertFalse("Assumption Day should not be recognized as public holiday", isPublicHoliday);
     }
@@ -246,13 +238,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureAssumptionDayIsNoPublicHolidayForBadenWuerttemberg() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BADEN_WUERTTEMBERG);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         boolean isPublicHoliday = publicHolidaysService.isPublicHoliday(new DateMidnight(2015, DateTimeConstants.AUGUST,
-                    15));
+                    15), FederalState.BADEN_WUERTTEMBERG);
 
         Assert.assertFalse("Assumption Day should not be recognized as public holiday", isPublicHoliday);
     }
@@ -261,13 +248,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureCorrectWorkingDurationForAssumptionDayForBerlin() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BERLIN);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(new DateMidnight(2015,
-                    DateTimeConstants.AUGUST, 15));
+                    DateTimeConstants.AUGUST, 15), FederalState.BERLIN);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ONE.setScale(1), workingDuration);
     }
@@ -276,13 +258,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureCorrectWorkingDurationForAssumptionDayForBadenWuerttemberg() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BADEN_WUERTTEMBERG);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(new DateMidnight(2015,
-                    DateTimeConstants.AUGUST, 15));
+                    DateTimeConstants.AUGUST, 15), FederalState.BADEN_WUERTTEMBERG);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ONE.setScale(1), workingDuration);
     }
@@ -291,13 +268,8 @@ public class PublicHolidaysServiceTest {
     @Test
     public void ensureCorrectWorkingDurationForAssumptionDayForBayernMuenchen() {
 
-        Settings settings = new Settings();
-        settings.getWorkingTimeSettings().setFederalState(FederalState.BAYERN_MUENCHEN);
-
-        Mockito.when(settingsService.getSettings()).thenReturn(settings);
-
         BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(new DateMidnight(2015,
-                    DateTimeConstants.AUGUST, 15));
+                    DateTimeConstants.AUGUST, 15), FederalState.BAYERN_MUENCHEN);
 
         Assert.assertEquals("Wrong working duration", BigDecimal.ZERO, workingDuration);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/person/PersonFormProcessorImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/person/PersonFormProcessorImplTest.java
@@ -19,6 +19,7 @@ import org.synyx.urlaubsverwaltung.core.person.MailNotification;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.person.PersonService;
 import org.synyx.urlaubsverwaltung.core.person.Role;
+import org.synyx.urlaubsverwaltung.core.settings.FederalState;
 import org.synyx.urlaubsverwaltung.test.TestDataCreator;
 
 import java.math.BigDecimal;
@@ -91,7 +92,7 @@ public class PersonFormProcessorImplTest {
         Person person = service.create(examplePersonForm);
 
         Mockito.verify(workingTimeService)
-            .touch(Mockito.anyListOf(Integer.class), Mockito.any(DateMidnight.class), Mockito.eq(person));
+            .touch(Mockito.anyListOf(Integer.class), Mockito.eq(Optional.empty()),Mockito.any(DateMidnight.class), Mockito.eq(person));
     }
 
 


### PR DESCRIPTION
* es kann in den Benutzereinstellungen ein "abweichendes Bundesland" eingestellt werden
* diese Einstellung ist optional, wenn nicht vorhanden wird das Bundesland aus den Systemeinstellungen verwendet
* infolgedessen können öffentliche Feiertage nur noch berechnet werden, wenn ein Benutzer (oder zumindest ein Bundesland) festgelegt wird, die entsprechenden API wurden angepasst