### PR TITLE
Automatische Erinnerung für wartende Anträge

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailService.java
@@ -215,4 +215,6 @@ public interface MailService {
      * @param  overtimeComment  may contain further information
      */
     void sendOvertimeNotification(Overtime overtime, OvertimeComment overtimeComment);
+
+    void sendRemindForWaitingApplicationsReminderNotification(List<Application> application);
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
@@ -617,7 +617,7 @@ class MailServiceImpl implements MailService {
          * See: http://stackoverflow.com/questions/33086686/java-8-stream-collect-and-group-by-objects-that-map-to-multiple-keys
          */
         Map<Person, List<Application>> applicationsPerRecipient = waitingApplications.stream()
-                .flatMap(application -> getBossesAndDepartmentHeads(application).stream()
+                .flatMap(application -> getRecipientsForAllowAndRemind(application).stream()
                         .map(person -> new AbstractMap.SimpleEntry<>(person, application)))
                 .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
@@ -1,5 +1,6 @@
 package org.synyx.urlaubsverwaltung.core.settings;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 
@@ -31,7 +32,16 @@ public class AbsenceSettings {
      * of days before the end of sick pay)
      */
     private Integer daysBeforeEndOfSickPayNotification = 7; // NOSONAR
-    private boolean remindForWaitingApplications;
+
+    /**
+     * Activates a notification after {daysBeforeWaitingApplicationsReminderNotification} days for waiting applications
+     */
+    private boolean remindForWaitingApplications = false;
+
+    /**
+     * After this number of days a reminder notification for waiting applications will be sent
+     */
+    private Integer daysBeforeWaitingApplicationsReminderNotification = 2;
 
     public Integer getMaximumAnnualVacationDays() {
 
@@ -81,14 +91,20 @@ public class AbsenceSettings {
     }
 
     public boolean getRemindForWaitingApplications() {
-        return remindForWaitingApplications;
-    }
 
-    public boolean isRemindForWaitingApplications() {
         return remindForWaitingApplications;
     }
 
     public void setRemindForWaitingApplications(boolean remindForWaitingApplications) {
         this.remindForWaitingApplications = remindForWaitingApplications;
     }
+
+    public Integer getDaysBeforeWaitingApplicationsReminderNotification() {
+        return daysBeforeWaitingApplicationsReminderNotification;
+    }
+
+    public void setDaysBeforeWaitingApplicationsReminderNotification(Integer daysBeforeWaitingApplicationsReminderNotification) {
+        this.daysBeforeWaitingApplicationsReminderNotification = daysBeforeWaitingApplicationsReminderNotification;
+    }
+
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
@@ -31,6 +31,7 @@ public class AbsenceSettings {
      * of days before the end of sick pay)
      */
     private Integer daysBeforeEndOfSickPayNotification = 7; // NOSONAR
+    private boolean remindForWaitingApplications;
 
     public Integer getMaximumAnnualVacationDays() {
 
@@ -77,5 +78,17 @@ public class AbsenceSettings {
     public void setDaysBeforeEndOfSickPayNotification(Integer daysBeforeEndOfSickPayNotification) {
 
         this.daysBeforeEndOfSickPayNotification = daysBeforeEndOfSickPayNotification;
+    }
+
+    public boolean getRemindForWaitingApplications() {
+        return remindForWaitingApplications;
+    }
+
+    public boolean isRemindForWaitingApplications() {
+        return remindForWaitingApplications;
+    }
+
+    public void setRemindForWaitingApplications(boolean remindForWaitingApplications) {
+        this.remindForWaitingApplications = remindForWaitingApplications;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/settings/AbsenceSettings.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.core.settings;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 
@@ -37,11 +36,6 @@ public class AbsenceSettings {
      * Activates a notification after {daysBeforeWaitingApplicationsReminderNotification} days for waiting applications
      */
     private boolean remindForWaitingApplications = false;
-
-    /**
-     * After this number of days a reminder notification for waiting applications will be sent
-     */
-    private Integer daysBeforeWaitingApplicationsReminderNotification = 2;
 
     public Integer getMaximumAnnualVacationDays() {
 
@@ -97,14 +91,6 @@ public class AbsenceSettings {
 
     public void setRemindForWaitingApplications(boolean remindForWaitingApplications) {
         this.remindForWaitingApplications = remindForWaitingApplications;
-    }
-
-    public Integer getDaysBeforeWaitingApplicationsReminderNotification() {
-        return daysBeforeWaitingApplicationsReminderNotification;
-    }
-
-    public void setDaysBeforeWaitingApplicationsReminderNotification(Integer daysBeforeWaitingApplicationsReminderNotification) {
-        this.daysBeforeWaitingApplicationsReminderNotification = daysBeforeWaitingApplicationsReminderNotification;
     }
 
 }

--- a/src/main/resources/META-INF/resources/jsp/settings/settings_form.jsp
+++ b/src/main/resources/META-INF/resources/jsp/settings/settings_form.jsp
@@ -122,6 +122,21 @@
                                 <span class="help-inline"><form:errors path="absenceSettings.maximumMonthsToApplyForLeaveInAdvance" cssClass="error"/></span>
                             </div>
                         </div>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <div class="col-xs-12">
+                        <legend><spring:message code="settings.vacation.remindForWaitingApplications.title" /></legend>
+                    </div>
+                    <div class="col-md-4 col-md-push-8">
+                        <span class="help-block">
+                            <i class="fa fa-fw fa-info-circle"></i>
+                            <spring:message code="settings.vacation.daysBeforeWaitingApplicationsReminderNotification.descripton"/>
+                        </span>
+                    </div>
+                    <div class="col-md-8 col-md-pull-4">
+
                         <div class="form-group is-required">
                             <label class="control-label col-md-4" for="absenceSettings.remindForWaitingApplications">
                                 <spring:message code='settings.vacation.remindForWaitingApplications'/>:
@@ -137,15 +152,17 @@
                                 </label>
                             </div>
                         </div>
+
                         <div class="form-group is-required">
                             <label class="control-label col-md-4" for="absenceSettings.daysBeforeWaitingApplicationsReminderNotification">
                                 <spring:message code='settings.vacation.daysBeforeWaitingApplicationsReminderNotification'/>:
                             </label>
                             <div class="col-md-8">
-                                <form:input id="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" path="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" class="form-control" cssErrorClass="form-control error" />
-                                <span class="help-inline"><form:errors path="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" cssClass="error"/></span>
+                                <spring:eval var="daysBeforeWaitingApplicationsReminderNotification" expression="@environment.getProperty('uv.cron.daysBeforeWaitingApplicationsReminderNotification')" />
+                                <input value="${daysBeforeWaitingApplicationsReminderNotification}" class="form-control" disabled="true" />
                             </div>
                         </div>
+
                     </div>
                 </div>
 

--- a/src/main/resources/META-INF/resources/jsp/settings/settings_form.jsp
+++ b/src/main/resources/META-INF/resources/jsp/settings/settings_form.jsp
@@ -122,6 +122,30 @@
                                 <span class="help-inline"><form:errors path="absenceSettings.maximumMonthsToApplyForLeaveInAdvance" cssClass="error"/></span>
                             </div>
                         </div>
+                        <div class="form-group is-required">
+                            <label class="control-label col-md-4" for="absenceSettings.remindForWaitingApplications">
+                                <spring:message code='settings.vacation.remindForWaitingApplications'/>:
+                            </label>
+                            <div class="col-md-8 radio">
+                                <label class="halves">
+                                    <form:radiobutton id="absenceSettings.remindForWaitingApplications" path="absenceSettings.remindForWaitingApplications" value="true"/>
+                                    <spring:message code="settings.vacation.remindForWaitingApplications.true"/>
+                                </label>
+                                <label class="halves">
+                                    <form:radiobutton id="absenceSettings.remindForWaitingApplications" path="absenceSettings.remindForWaitingApplications" value="false"/>
+                                    <spring:message code="settings.vacation.remindForWaitingApplications.false"/>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group is-required">
+                            <label class="control-label col-md-4" for="absenceSettings.daysBeforeWaitingApplicationsReminderNotification">
+                                <spring:message code='settings.vacation.daysBeforeWaitingApplicationsReminderNotification'/>:
+                            </label>
+                            <div class="col-md-8">
+                                <form:input id="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" path="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" class="form-control" cssErrorClass="form-control error" />
+                                <span class="help-inline"><form:errors path="absenceSettings.daysBeforeWaitingApplicationsReminderNotification" cssClass="error"/></span>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,8 +76,8 @@ uv.security.activeDirectory.sync.password=password
 uv.cron.updateHolidaysAccounts=0 0 5 1 1 *
 # Send notification about end of sick pay every day at 06:00 am
 uv.cron.endOfSickPayNotification=0 0 6 * * ?
-# Send notification about waiting applications every two days at 07:00 am
-uv.cron.remindForNotification=0 7 */2 * * ?
+# Send notification about waiting applications every x days at 07:00 am
+uv.cron.daysBeforeWaitingApplicationsReminderNotification=2
 
 # ACTUATOR -------------------------------------------------------------------------------------------------------------
 info.app.name=@project.name@

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,6 +76,8 @@ uv.security.activeDirectory.sync.password=password
 uv.cron.updateHolidaysAccounts=0 0 5 1 1 *
 # Send notification about end of sick pay every day at 06:00 am
 uv.cron.endOfSickPayNotification=0 0 6 * * ?
+# Send notification about waiting applications every two days at 07:00 am
+uv.cron.remindForNotification=0 7 */2 * * ?
 
 # ACTUATOR -------------------------------------------------------------------------------------------------------------
 info.app.name=@project.name@

--- a/src/main/resources/dbchangelogs/changelog-2.21.0-add_remind_waiting_application_settings.xml
+++ b/src/main/resources/dbchangelogs/changelog-2.21.0-add_remind_waiting_application_settings.xml
@@ -1,0 +1,21 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet author="honnel" id="add_remind_waiting_application_settings" >
+
+        <preConditions>
+            <tableExists tableName="Settings"/>
+        </preConditions>
+
+        <addColumn tableName="Settings">
+            <column name="remindForWaitingApplications" type="BIT(1)" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="daysBeforeWaitingApplicationsReminderNotification" type="INT(10)" valueNumeric="2"/>
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelog-2.21.0-add_remind_waiting_application_settings.xml
+++ b/src/main/resources/dbchangelogs/changelog-2.21.0-add_remind_waiting_application_settings.xml
@@ -13,7 +13,6 @@
             <column name="remindForWaitingApplications" type="BIT(1)" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
-            <column name="daysBeforeWaitingApplicationsReminderNotification" type="INT(10)" valueNumeric="2"/>
         </addColumn>
 
     </changeSet>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -45,5 +45,6 @@
     <include file="dbchangelogs/changelog-2.15.0-add_settings_minimum_overtime.xml"/>
     <include file="dbchangelogs/changelog-2.16.0-add_base_link_url_to_mail_settings.xml"/>
     <include file="dbchangelogs/changelog-2.18.0-add_federal_state_override.xml"/>
+    <include file="dbchangelogs/changelog-2.21.0-add_remind_waiting_application_settings.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -431,6 +431,10 @@ settings.vacation.title=Einstellungen zu Urlaub
 settings.vacation.description=Die Einstellungen f\u00FCr die Maximalwerte werden zur Validierung von Formularen herangezogen.
 settings.vacation.maximumAnnualVacationDays=Maximale Anzahl der Urlaubstage pro Jahr
 settings.vacation.maximumMonthsToApplyForLeaveInAdvance=Wieviele Monate im Voraus d\u00FCrfen Mitarbeiter Urlaub beantragen
+settings.vacation.remindForWaitingApplications=Erinnerungsfunktion f\u00FCr wartende Antr\u00E4ge
+settings.vacation.remindForWaitingApplications.true=aktivieren
+settings.vacation.remindForWaitingApplications.false=deaktivieren
+settings.vacation.daysBeforeWaitingApplicationsReminderNotification=Tage bis die Erinnerung versendet wird
 # Sick Days
 settings.sickDays.title=Einstellungen zu Krankmeldungen
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office Mitarbeiter per E-Mail \u00FCber das Ende der Lohnfortzahlung informiert werden.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -431,10 +431,13 @@ settings.vacation.title=Einstellungen zu Urlaub
 settings.vacation.description=Die Einstellungen f\u00FCr die Maximalwerte werden zur Validierung von Formularen herangezogen.
 settings.vacation.maximumAnnualVacationDays=Maximale Anzahl der Urlaubstage pro Jahr
 settings.vacation.maximumMonthsToApplyForLeaveInAdvance=Wieviele Monate im Voraus d\u00FCrfen Mitarbeiter Urlaub beantragen
-settings.vacation.remindForWaitingApplications=Erinnerungsfunktion f\u00FCr wartende Antr\u00E4ge
+# Reminder Notification
+settings.vacation.remindForWaitingApplications.title=Automatische Erinnerung f\u00FCr wartende Urlaubsantr\u00E4ge
+settings.vacation.remindForWaitingApplications=Automatische Erinnerungsfunktion
 settings.vacation.remindForWaitingApplications.true=aktivieren
 settings.vacation.remindForWaitingApplications.false=deaktivieren
-settings.vacation.daysBeforeWaitingApplicationsReminderNotification=Tage bis die Erinnerung versendet wird
+settings.vacation.daysBeforeWaitingApplicationsReminderNotification=Erinnerungsmail alle x Tage
+settings.vacation.daysBeforeWaitingApplicationsReminderNotification.descripton=Diese Einstellung erm\u00F6glicht es die Chefs bzw. Abteilungsleiter auf wartende Urlaubsantr\u00E4ge per Mail aufmerksam zu machen. Die Anzahl der Tage nach denen, auf ein wartenen Antrag hingewiesen wird, muss durch einen Administrator in der `application.properties` konfiguriert werden.
 # Sick Days
 settings.sickDays.title=Einstellungen zu Krankmeldungen
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office Mitarbeiter per E-Mail \u00FCber das Ende der Lohnfortzahlung informiert werden.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -401,6 +401,7 @@ subject.application.rejected=Dein Urlaubsantrag wurde abgelehnt
 subject.application.cancelled.user=Dein Antrag wurde storniert
 subject.application.refer=Hilfe bei der Entscheidung \u00FCber einen Urlaubsantrag
 subject.application.remind=Erinnerung wartender Urlaubsantrag
+subject.application.cronRemind=Erinnerung f\u00FCr wartende Urlaubsantr\u00E4ge
 subject.application.holidayReplacement=Urlaubsvertretung
 subject.application.cancellationRequest=Ein Benutzer beantragt die Stornierung eines genehmigten Antrags
 # sick notes

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cron_remind.vm
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cron_remind.vm
@@ -1,0 +1,9 @@
+Hallo ${recipient.niceName},
+
+Die folgenden gestellten Urlaubsanträge warten auf ihre Bearbeitung:
+
+#foreach ( $application in $applicationList )
+Antrag von ${application.person.niceName} vom ${application.applicationDate.toString("dd.MM.yyyy")}: ${baseUrl}${application.id}
+#end
+
+Ohne eine Bearbeitung kann es passieren, dass ihr weitere Erinnerungen erhaltet ;-)

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/cron/CronMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/cron/CronMailServiceTest.java
@@ -1,0 +1,117 @@
+package org.synyx.urlaubsverwaltung.core.cron;
+
+import org.joda.time.DateMidnight;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.synyx.urlaubsverwaltung.core.application.domain.Application;
+import org.synyx.urlaubsverwaltung.core.application.domain.ApplicationStatus;
+import org.synyx.urlaubsverwaltung.core.application.domain.VacationCategory;
+import org.synyx.urlaubsverwaltung.core.application.service.ApplicationService;
+import org.synyx.urlaubsverwaltung.core.mail.MailService;
+import org.synyx.urlaubsverwaltung.core.settings.AbsenceSettings;
+import org.synyx.urlaubsverwaltung.core.settings.Settings;
+import org.synyx.urlaubsverwaltung.core.settings.SettingsService;
+import org.synyx.urlaubsverwaltung.core.sicknote.SickNote;
+import org.synyx.urlaubsverwaltung.core.sicknote.SickNoteService;
+import org.synyx.urlaubsverwaltung.test.TestDataCreator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CronMailServiceTest {
+
+    private CronMailService sut;
+    private ApplicationService applicationService;
+    private SettingsService settingsService;
+    private SickNoteService sickNoteService;
+    private MailService mailService;
+
+    @Before
+    public void setUp() throws Exception {
+
+        applicationService = mock(ApplicationService.class);
+        settingsService = mock(SettingsService.class);
+        sickNoteService = mock(SickNoteService.class);
+        mailService = mock(MailService.class);
+
+        sut = new CronMailService(applicationService, settingsService, sickNoteService, mailService);
+    }
+
+    @Test
+    public void ensureSendEndOfSickPayNotification() throws Exception {
+
+        SickNote sickNoteA = new SickNote();
+        SickNote sickNoteB = new SickNote();
+        when(sickNoteService.getSickNotesReachingEndOfSickPay()).thenReturn(Arrays.asList(sickNoteA, sickNoteB));
+
+        sut.sendEndOfSickPayNotification();
+
+        verify(mailService).sendEndOfSickPayNotification(sickNoteA);
+        verify(mailService).sendEndOfSickPayNotification(sickNoteB);
+    }
+
+    @Test
+    public void ensureSendWaitingApplicationsReminderNotification() throws Exception {
+
+        prepareSettingsWithActiveRemindForWaitingApplications();
+
+        Application shortWaitingApplication = TestDataCreator.createApplication(TestDataCreator.createPerson("leo"), TestDataCreator.createVacationType(VacationCategory.HOLIDAY));
+        shortWaitingApplication.setApplicationDate(DateMidnight.now());
+
+        Application longWaitingApplicationA = TestDataCreator.createApplication(TestDataCreator.createPerson("lea"), TestDataCreator.createVacationType(VacationCategory.HOLIDAY));
+        longWaitingApplicationA.setApplicationDate(DateMidnight.now().minusDays(3));
+
+        Application longWaitingApplicationB = TestDataCreator.createApplication(TestDataCreator.createPerson("heinz"), TestDataCreator.createVacationType(VacationCategory.HOLIDAY));
+        longWaitingApplicationB.setApplicationDate(DateMidnight.now().minusDays(3));
+
+        Application longWaitingApplicationAlreadyRemindedToday = TestDataCreator.createApplication(TestDataCreator.createPerson("heinz"), TestDataCreator.createVacationType(VacationCategory.HOLIDAY));
+        longWaitingApplicationAlreadyRemindedToday.setApplicationDate(DateMidnight.now().minusDays(3));
+        DateMidnight today = DateMidnight.now();
+        longWaitingApplicationAlreadyRemindedToday.setRemindDate(today);
+
+        Application longWaitingApplicationAlreadyRemindedEalier = TestDataCreator.createApplication(TestDataCreator.createPerson("heinz"), TestDataCreator.createVacationType(VacationCategory.HOLIDAY));
+        longWaitingApplicationAlreadyRemindedEalier.setApplicationDate(DateMidnight.now().minusDays(5));
+        DateMidnight oldRemindDateEarlier = DateMidnight.now().minusDays(3);
+        longWaitingApplicationAlreadyRemindedEalier.setRemindDate(oldRemindDateEarlier);
+
+        List<Application> waitingApplications = Arrays.asList(shortWaitingApplication,
+                                                              longWaitingApplicationA,
+                                                              longWaitingApplicationB,
+                                                              longWaitingApplicationAlreadyRemindedToday,
+                                                              longWaitingApplicationAlreadyRemindedEalier);
+
+        when(applicationService.getApplicationsForACertainState(ApplicationStatus.WAITING)).thenReturn(waitingApplications);
+
+        sut.daysBeforeWaitingApplicationsReminderNotification = 2;
+        sut.sendWaitingApplicationsReminderNotification();
+
+        verify(mailService).sendRemindForWaitingApplicationsReminderNotification(Arrays.asList(longWaitingApplicationA, longWaitingApplicationB, longWaitingApplicationAlreadyRemindedEalier));
+
+        assertTrue(longWaitingApplicationA.getRemindDate().isAfter(longWaitingApplicationA.getApplicationDate()));
+        assertTrue(longWaitingApplicationB.getRemindDate().isAfter(longWaitingApplicationB.getApplicationDate()));
+        assertTrue(longWaitingApplicationAlreadyRemindedEalier.getRemindDate().isAfter(oldRemindDateEarlier));
+        assertTrue(longWaitingApplicationAlreadyRemindedToday.getRemindDate().isEqual(today));
+    }
+
+    private void prepareSettingsWithActiveRemindForWaitingApplications() {
+        Settings settings = new Settings();
+        AbsenceSettings absenceSettings = new AbsenceSettings();
+        absenceSettings.setRemindForWaitingApplications(true);
+        settings.setAbsenceSettings(absenceSettings);
+        when(settingsService.getSettings()).thenReturn(settings);
+    }
+
+}


### PR DESCRIPTION
Über die globalen Einstellungen wird ermöglicht die Erinnerungsfunktion aus #227 zu aktivieren:
![erinnernung-settings](https://cloud.githubusercontent.com/assets/142107/17297220/1026f606-5805-11e6-9358-c9805fb787ea.png)

In der `application.properties` kann über die folgende Einstellung die Anzahl der Tage gesteuert werden, nach denen Chefs/Abteilungsleiter benachrichtigt werden:
```
uv.cron.daysBeforeWaitingApplicationsReminderNotification=2
```

Im Standard-Fall bekommen die Chefs alle zwei Tage eine Email mit allen offenen Urlaubsanträgen zugesendet.
