### PR TITLE
fix h2 configuration

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/config/H2ServerConfig.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/config/H2ServerConfig.java
@@ -18,7 +18,7 @@ import java.sql.SQLException;
  * @author  Aljona Murygina - murygina@synyx.de
  */
 @Configuration
-@ConditionalOnProperty("h2.db.console")
+@ConditionalOnProperty("spring.h2.console.enabled")
 public class H2ServerConfig {
 
     @Value("${h2.db.tcpPort}")

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,7 +11,7 @@ spring.datasource.password=
 
 # H2 DATABASE ----------------------------------------------------------------------------------------------------------
 # Should H2 web console should be enabled or not?
-h2.db.console=true
+spring.h2.console.enabled=true
 h2.db.tcpPort=9995
 h2.db.webPort=11115
 


### PR DESCRIPTION
* h2 config was moved to "spring.h2.console.enabled" in Spring Boot
1.4.x
* but custom h2 config uses old "h2.db.console"