### PR TITLE
Fix bug with overlapping applications for leave

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/workingtime/OverlapService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/workingtime/OverlapService.java
@@ -181,9 +181,11 @@ public class OverlapService {
                             boolean isWaitingOrAllowed = input.hasStatus(ApplicationStatus.WAITING)
                                 || input.hasStatus(ApplicationStatus.ALLOWED);
 
-                            // if only half day, then only the same time of day is relevant
+                            // if only half day, then only the same time of day and full day is relevant
                             if (!DayLength.FULL.equals(dayLength)) {
-                                return isWaitingOrAllowed && input.getDayLength().equals(dayLength);
+                                boolean isOverlappingDayLength = input.getDayLength().equals(dayLength)
+                                        || input.getDayLength().equals(DayLength.FULL);
+                                return isWaitingOrAllowed && isOverlappingDayLength;
                             }
 
                             return isWaitingOrAllowed;

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/workingtime/OverlapServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/workingtime/OverlapServiceTest.java
@@ -403,6 +403,32 @@ public class OverlapServiceTest {
         Assert.assertEquals("Wrong overlap case", OverlapCase.FULLY_OVERLAPPING, overlapCase);
     }
 
+    @Test
+    public void ensureFullyOverlappingIfApplyingForHalfDayAlthoughThereIsAlreadyAFullDayVacation() {
+
+        DateMidnight vacationDate = new DateMidnight(2012, DateTimeConstants.JANUARY, 16);
+
+        Application fullDayVacation = new Application();
+        fullDayVacation.setDayLength(DayLength.FULL);
+        fullDayVacation.setStartDate(vacationDate);
+        fullDayVacation.setEndDate(vacationDate);
+        fullDayVacation.setStatus(ApplicationStatus.WAITING);
+
+        Mockito.when(applicationDAO.getApplicationsForACertainTimeAndPerson(Mockito.any(Date.class),
+                Mockito.any(Date.class), Mockito.any(Person.class)))
+                .thenReturn(Arrays.asList(fullDayVacation));
+
+        Application morningVacation = new Application();
+        morningVacation.setDayLength(DayLength.MORNING);
+        morningVacation.setStartDate(vacationDate);
+        morningVacation.setEndDate(vacationDate);
+
+        OverlapCase overlapCase = service.checkOverlap(morningVacation);
+
+        Assert.assertNotNull("Should not be null", overlapCase);
+        Assert.assertEquals("Wrong overlap case", OverlapCase.FULLY_OVERLAPPING, overlapCase);
+    }
+
 
     @Test
     public void ensureFullyOverlappingIfCreatingSickNoteOnADayWithHalfDayVacation() {


### PR DESCRIPTION
* Avoid that applying for leave is possible if there is already
  a full day vacation.

* refs #257