### PR TITLE
Sicherheitsupdate für Tomcat, siehe #428

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <google-api-client.version>1.23.0</google-api-client.version>
         <google-api-services-calendar.version>v3-rev281-1.23.0</google-api-services-calendar.version>
+        <!-- Override Tomcat version from Spring Boot to address security issues,
+           review this from time to time and when updating Spring Boot -->
+        <tomcat.version>8.5.32</tomcat.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
https://www.heise.de/security/meldung/Apache-Tomcat-Wichtige-Updates-schliessen-Sicherheitsluecken-4119967.html

Wir sind zur Zeit auf Tomcat 8.5.6 (kommt mit Spring Boot 1.4.2).

Der verlinkte Artikel empfiehlt das Update auf 8.5.32 (mittlerweile gibt es auch schon 8.5.33).

Da Spring-Boot 1.4.x scheinbar nicht weiter gepflegt wird, können wir die Tomcat-Version auch direkt in `pom.xml` selbst festlegen.