### PR TITLE
Fix Spring Framework deprecations to unblock upgrade path

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailBuilder.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailBuilder.java
@@ -2,14 +2,16 @@ package org.synyx.urlaubsverwaltung.core.mail;
 
 import org.apache.commons.lang.CharEncoding;
 
+import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 
+import org.apache.velocity.exception.VelocityException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.stereotype.Service;
 
-import org.springframework.ui.velocity.VelocityEngineUtils;
-
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Map;
 
 
@@ -42,7 +44,7 @@ class MailBuilder {
      */
     String buildMailBody(String templateName, Map<String, Object> model) {
 
-        return VelocityEngineUtils.mergeTemplateIntoString(velocityEngine, getFullyQualifiedTemplateName(templateName),
+        return mergeTemplateIntoString(velocityEngine, getFullyQualifiedTemplateName(templateName),
                 CharEncoding.UTF_8, model);
     }
 
@@ -58,5 +60,50 @@ class MailBuilder {
     private String getFullyQualifiedTemplateName(String templateName) {
 
         return TEMPLATE_PATH + templateName + TEMPLATE_TYPE;
+    }
+
+
+    //
+    // Code below copied from Spring's VelocityEngineUtils (because they are deprecated in Spring 4.3
+    // and will be removed in future versions)
+    //
+
+
+    /**
+     * Merge the specified Velocity template with the given model into a String.
+     * <p>When using this method to prepare a text for a mail to be sent with Spring's
+     * mail support, consider wrapping VelocityException in MailPreparationException.
+     * @param velocityEngine VelocityEngine to work with
+     * @param templateLocation the location of template, relative to Velocity's resource loader path
+     * @param encoding the encoding of the template file
+     * @param model the Map that contains model names as keys and model objects as values
+     * @return the result as String
+     * @throws VelocityException if the template wasn't found or rendering failed
+     * @see org.springframework.mail.MailPreparationException
+     */
+    private static String mergeTemplateIntoString(VelocityEngine velocityEngine, String templateLocation,
+                                                 String encoding, Map<String, Object> model) throws VelocityException {
+
+        StringWriter result = new StringWriter();
+        mergeTemplate(velocityEngine, templateLocation, encoding, model, result);
+        return result.toString();
+    }
+
+    /**
+     * Merge the specified Velocity template with the given model and write the result
+     * to the given Writer.
+     * @param velocityEngine VelocityEngine to work with
+     * @param templateLocation the location of template, relative to Velocity's resource loader path
+     * @param encoding the encoding of the template file
+     * @param model the Map that contains model names as keys and model objects as values
+     * @param writer the Writer to write the result to
+     * @throws VelocityException if the template wasn't found or rendering failed
+     */
+    private static void mergeTemplate(
+            VelocityEngine velocityEngine, String templateLocation, String encoding,
+            Map<String, Object> model, Writer writer) throws VelocityException {
+
+        VelocityContext velocityContext = new VelocityContext(model);
+        velocityEngine.mergeTemplate(templateLocation, encoding, velocityContext, writer);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/ExceptionHandlerControllerAdviceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/ExceptionHandlerControllerAdviceIT.java
@@ -8,8 +8,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.springframework.boot.test.SpringApplicationConfiguration;
-
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author  Aljona Murygina - murygina@synyx.de
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = UrlaubsverwaltungApplication.class)
+@SpringBootTest(classes = UrlaubsverwaltungApplication.class)
 @WebAppConfiguration
 public class ExceptionHandlerControllerAdviceIT {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/overtime/OvertimeControllerIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/overtime/OvertimeControllerIT.java
@@ -8,8 +8,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.springframework.boot.test.SpringApplicationConfiguration;
-
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author  Aljona Murygina - murygina@synyx.de
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = UrlaubsverwaltungApplication.class)
+@SpringBootTest(classes = UrlaubsverwaltungApplication.class)
 @WebAppConfiguration
 public class OvertimeControllerIT {
 


### PR DESCRIPTION
If we want to upgrade to Spring Boot 1.5 and above, we need to stop using the API already deprecated in 1.4.

This PR fixes all Spring Framework related deprecation warnings, except for this one in `UrlaubsverwaltungApplication.java`:

    @SpringBootApplication(exclude = { VelocityAutoConfiguration.class })

But that can just be removed when we upgrade (Spring Boot 1.5 no longer has Velocity support built-in, so we also don't need to disable that anymore).