### PR TITLE
Adjust `beforeApril` view attribute according to the relevant year, fixes #260

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
@@ -61,7 +61,21 @@ public class VacationDaysService {
         VacationDaysLeft vacationDaysLeft = getVacationDaysLeft(account);
 
         // it's before April - the left remaining vacation days must be used
-        if (DateUtil.isBeforeApril(nowService.now(), account.getYear())) {
+        if (DateUtil.isBeforeApril(nowService.now(), account.getYear()) &&
+
+                // TODO: if you apply for leave at the beginning of NEXT year, you
+                // should be able to use the remaining vacation days for THIS year.
+                // However, if we allow this here now, you would then later be able
+                // to take additional holiday this year, and we do not prevent this
+                // currently. So before that is fixed, we do not allow it here.
+                // For now, you can only use the remaining vacation days from LAST year
+                // if you apply for them THIS year.
+                //
+                // See issues #372 for a complaint about this being rejected here
+                // and #378 for an example of remaining vacation days not being
+                // counted properly when application and vacation are in different years
+                nowService.currentYear() == account.getYear()
+                ) {
             return vacationDaysLeft.getVacationDays().add(vacationDaysLeft.getRemainingVacationDays());
         } else {
             // it's after April - only the left not expiring remaining vacation days must be used

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
@@ -61,7 +61,7 @@ public class VacationDaysService {
         VacationDaysLeft vacationDaysLeft = getVacationDaysLeft(account);
 
         // it's before April - the left remaining vacation days must be used
-        if (DateUtil.isBeforeApril(nowService.now()) && account.getYear() == nowService.currentYear()) {
+        if (DateUtil.isBeforeApril(nowService.now(), account.getYear())) {
             return vacationDaysLeft.getVacationDays().add(vacationDaysLeft.getRemainingVacationDays());
         } else {
             // it's after April - only the left not expiring remaining vacation days must be used

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/util/DateUtil.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/util/DateUtil.java
@@ -30,16 +30,18 @@ public final class DateUtil {
     }
 
     /**
-     * Check if given date is before April.
+     * Check if given date is before April of the given year
      *
      * @param date
      *            to check
+     * @param year
+     *            the year whose April the date will be compared to
      *
-     * @return {@code true} if the given date is before April, {@code false} if it is after April
+     * @return {@code true} if the given date is before April of the given year, {@code false} if it is in or after that April
      */
-    public static boolean isBeforeApril(DateMidnight date) {
+    public static boolean isBeforeApril(DateMidnight date, int year) {
 
-        return date.getMonthOfYear() < DateTimeConstants.APRIL;
+        return date.getMonthOfYear() < DateTimeConstants.APRIL || date.getYear() < year;
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
@@ -161,9 +161,10 @@ public class ApplicationForLeaveDetailsController {
         Optional<Account> account = accountService.getHolidaysAccount(year, application.getPerson());
 
         if (account.isPresent()) {
-            model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get()));
-            model.addAttribute("account", account.get());
-            model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now()));
+            Account acc = account.get();
+            model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(acc));
+            model.addAttribute("account", acc);
+            model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now(), acc.getYear()));
         }
 
         // UNSPECIFIC ATTRIBUTES

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/overview/OverviewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/overview/OverviewController.java
@@ -170,9 +170,10 @@ public class OverviewController {
 		Optional<Account> account = accountService.getHolidaysAccount(year, person);
 
 		if (account.isPresent()) {
-			model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get()));
-			model.addAttribute("account", account.get());
-			model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now()));
+			Account acc = account.get();
+			model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(acc));
+			model.addAttribute("account", acc);
+			model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now(), acc.getYear()));
 		}
 	}
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
@@ -251,7 +251,7 @@ public class PersonController {
         model.addAttribute(PersonConstants.PERSONS_ATTRIBUTE, persons);
         model.addAttribute("accounts", accounts);
         model.addAttribute("vacationDaysLeftMap", vacationDaysLeftMap);
-        model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now()));
+        model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now(), year));
         model.addAttribute(ControllerConstants.YEAR_ATTRIBUTE, year);
         model.addAttribute("now", DateMidnight.now());
 


### PR DESCRIPTION
Wie von @fraulyoner in #260 beschreiben, wird der Resturlaub im nächsten Jahr nicht korrekt angezeigt, weil die Weiche `beforeApril` falsch gestellt wird (denn auch im Oktober 2018 sind wir noch vor dem April 2019).

Dieser PR korrigiert dies. 

Sowohl #260 als auch dieser PR betrifft nur die Anzeige des Resturlaubs, Probleme bei der Berechnung desgleichen (siehe #372 #378) bleiben weiterhin bestehen.