### PR TITLE
Consider vacation already booked for next year when calculating number of available days, fixes #447

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/domain/VacationDaysLeft.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/domain/VacationDaysLeft.java
@@ -12,16 +12,25 @@ import java.math.BigDecimal;
  */
 public final class VacationDaysLeft {
 
+    /** Vacation days for this year that have not been used yet */
     private final BigDecimal vacationDays;
+
+    /** Additional vacation days left over from last year */
     private final BigDecimal remainingVacationDays;
+
+    /** Non-expiring vacation days left over from last year (included in `remainingVacationDays`) */
     private final BigDecimal remainingVacationDaysNotExpiring;
 
+    /** Vacaction days for this year that have already been used NEXT year */
+    private final BigDecimal vacationDaysUsedNextYear;
+
     private VacationDaysLeft(BigDecimal vacationDays, BigDecimal remainingVacationDays,
-        BigDecimal remainingVacationDaysNotExpiring) {
+        BigDecimal remainingVacationDaysNotExpiring, BigDecimal vacationDaysUsedNextYear) {
 
         this.vacationDays = vacationDays;
         this.remainingVacationDays = remainingVacationDays;
         this.remainingVacationDaysNotExpiring = remainingVacationDaysNotExpiring;
+        this.vacationDaysUsedNextYear = vacationDaysUsedNextYear;
     }
 
     public static Builder builder() {
@@ -47,6 +56,10 @@ public final class VacationDaysLeft {
         return remainingVacationDaysNotExpiring;
     }
 
+    public BigDecimal getVacationDaysUsedNextYear() {
+        return vacationDaysUsedNextYear;
+    }
+
     /**
      * Builds information object about left vacation days.
      */
@@ -57,6 +70,7 @@ public final class VacationDaysLeft {
         private BigDecimal remainingVacationDaysNotExpiring;
         private BigDecimal usedDaysBeforeApril;
         private BigDecimal usedDaysAfterApril;
+        private BigDecimal vacationDaysUsedNextYear = BigDecimal.ZERO;
 
         public Builder withAnnualVacation(BigDecimal annualVacation) {
 
@@ -97,10 +111,17 @@ public final class VacationDaysLeft {
             return this;
         }
 
+        public Builder withVacationDaysUsedNextYear(BigDecimal vacationDaysUsedNextYear) {
+
+            this.vacationDaysUsedNextYear = vacationDaysUsedNextYear;
+
+            return this;
+        }
+
 
         public VacationDaysLeft get() {
 
-            BigDecimal leftVacationDays = annualVacationDays;
+            BigDecimal leftVacationDays = annualVacationDays.subtract(vacationDaysUsedNextYear);
             BigDecimal leftRemainingVacationDays = remainingVacationDays;
             BigDecimal leftRemainingVacationDaysNotExpiring = remainingVacationDaysNotExpiring;
 
@@ -157,7 +178,7 @@ public final class VacationDaysLeft {
             }
 
             return new VacationDaysLeft(leftVacationDays, leftRemainingVacationDays,
-                    leftRemainingVacationDaysNotExpiring);
+                    leftRemainingVacationDaysNotExpiring, vacationDaysUsedNextYear);
         }
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysService.java
@@ -71,7 +71,14 @@ public class VacationDaysService {
     }
 
 
-    // TODO: remove this method, use the one with the `nextYear` parameter
+    /**
+     * @deprecated use instead {@link #getVacationDaysLeft(Account, Optional)}
+     * because the account for the following year may also be relevant for the calculation
+     *
+     * @param account the account for the year to calculate the vacation days for
+     *
+     * @return information about the vacation days left for that year
+     */
     public VacationDaysLeft getVacationDaysLeft(Account account) {
 
        return getVacationDaysLeft(account, Optional.empty());
@@ -81,6 +88,12 @@ public class VacationDaysService {
      * This version of the method also considers the account for next year,
      * so that it can adjust for vacation days carried over from this year to the next and then used there
      * (reducing the amount available in this year accordingly)
+     *
+     * @param account the account for the year to calculate the vacation days for
+     *
+     * @param nextYear the account for following year, if available
+     *
+     * @return information about the vacation days left for that year
      */
     public VacationDaysLeft getVacationDaysLeft(Account account, Optional<Account> nextYear) {
 
@@ -90,6 +103,7 @@ public class VacationDaysService {
 
         BigDecimal daysBeforeApril = getUsedDaysBeforeApril(account);
         BigDecimal daysAfterApril = getUsedDaysAfterApril(account);
+        BigDecimal daysUsedNextYear = getRemainingVacationDaysAlreadyUsed(nextYear);
 
         return VacationDaysLeft.builder()
                 .withAnnualVacation(vacationDays)
@@ -97,7 +111,7 @@ public class VacationDaysService {
                 .notExpiring(remainingVacationDaysNotExpiring)
                 .forUsedDaysBeforeApril(daysBeforeApril)
                 .forUsedDaysAfterApril(daysAfterApril)
-                .withVacationDaysUsedNextYear(getRemainingVacationDaysAlreadyUsed(nextYear))
+                .withVacationDaysUsedNextYear(daysUsedNextYear)
                 .get();
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
@@ -1,5 +1,6 @@
 package org.synyx.urlaubsverwaltung.core.application.service;
 
+import org.apache.log4j.Logger;
 import org.joda.time.DateMidnight;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
+import org.synyx.urlaubsverwaltung.core.account.domain.VacationDaysLeft;
 import org.synyx.urlaubsverwaltung.core.account.service.AccountInteractionService;
 import org.synyx.urlaubsverwaltung.core.account.service.AccountService;
 import org.synyx.urlaubsverwaltung.core.account.service.VacationDaysService;
@@ -29,6 +31,9 @@ import java.util.Optional;
  */
 @Service
 public class CalculationService {
+
+    private static final Logger LOG = Logger.getLogger(CalculationService.class);
+
 
     private final VacationDaysService vacationDaysService;
     private final AccountInteractionService accountInteractionService;
@@ -68,10 +73,7 @@ public class CalculationService {
         if (yearOfStartDate == yearOfEndDate) {
             BigDecimal workDays = calendarService.getWorkDays(dayLength, startDate, endDate, person);
 
-            Optional<Account> holidaysAccount = getHolidaysAccount(yearOfStartDate, person);
-
-            return holidaysAccount.isPresent()
-                && vacationDaysService.calculateTotalLeftVacationDays(holidaysAccount.get()).compareTo(workDays) >= 0;
+            return accountHasEnoughVacationDaysLeft(person, yearOfStartDate, workDays);
         } else {
             // ensure that applying for leave for the period in the old year is possible
             BigDecimal workDaysInOldYear = calendarService.getWorkDays(dayLength, startDate,
@@ -81,19 +83,50 @@ public class CalculationService {
             BigDecimal workDaysInNewYear = calendarService.getWorkDays(dayLength,
                     DateUtil.getFirstDayOfYear(yearOfEndDate), endDate, person);
 
-            Optional<Account> holidaysAccountForOldYear = getHolidaysAccount(yearOfStartDate, person);
-            Optional<Account> holidaysAccountForNewYear = getHolidaysAccount(yearOfEndDate, person);
-
-            return accountHasEnoughVacationDaysLeft(holidaysAccountForOldYear, workDaysInOldYear)
-                && accountHasEnoughVacationDaysLeft(holidaysAccountForNewYear, workDaysInNewYear);
+            return accountHasEnoughVacationDaysLeft(person, yearOfStartDate, workDaysInOldYear)
+                && accountHasEnoughVacationDaysLeft(person, yearOfEndDate, workDaysInNewYear);
         }
     }
 
 
-    private boolean accountHasEnoughVacationDaysLeft(Optional<Account> account, BigDecimal workDays) {
+    private boolean accountHasEnoughVacationDaysLeft(Person person, int year, BigDecimal workDays) {
+        Optional<Account> account = getHolidaysAccount(year, person);
+        if (!account.isPresent()){
+            return false;
+        }
 
-        return account.isPresent()
-            && vacationDaysService.calculateTotalLeftVacationDays(account.get()).compareTo(workDays) >= 0;
+
+
+        // we also need to look at the next year, because "remaining days" from this year
+        // may already have been booked then
+
+        BigDecimal alreadyUsedNextYear = BigDecimal.ZERO;
+        // call accountService directly to avoid auto-creating a new account for next year
+        Optional<Account> nextYear = accountService.getHolidaysAccount(year+1, person);
+        if (nextYear.isPresent()){
+            Account nextAccount = nextYear.get();
+            if (nextAccount.getRemainingVacationDays().signum() > 0){
+                VacationDaysLeft nextYearLeft = vacationDaysService.getVacationDaysLeft(nextAccount);
+                BigDecimal totalUsedNextYear = nextAccount.getVacationDays()
+                        .add(nextAccount.getRemainingVacationDays())
+                        .subtract(nextYearLeft.getVacationDays())
+                        .subtract(nextYearLeft.getRemainingVacationDays());
+                BigDecimal remainingUsedNextYear = totalUsedNextYear.subtract(nextAccount.getVacationDays());
+                if (remainingUsedNextYear.signum() > 0){
+                    alreadyUsedNextYear = remainingUsedNextYear;
+                }
+            }
+        }
+
+
+        if(vacationDaysService.calculateTotalLeftVacationDays(account.get()).subtract(workDays).compareTo(alreadyUsedNextYear) >= 0) {
+            return true;
+        } else {
+            if (alreadyUsedNextYear.signum() > 0) {
+                LOG.info("Rejecting application by "+person+" for "+workDays+" days in "+year+" because "+alreadyUsedNextYear+" remaining days have already been used in "+(year+1));
+            }
+            return false;
+        }
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationService.java
@@ -106,7 +106,7 @@ public class CalculationService {
         if (nextYear.isPresent()){
             Account nextAccount = nextYear.get();
             if (nextAccount.getRemainingVacationDays().signum() > 0){
-                VacationDaysLeft nextYearLeft = vacationDaysService.getVacationDaysLeft(nextAccount);
+                VacationDaysLeft nextYearLeft = vacationDaysService.getVacationDaysLeft(nextAccount, Optional.empty());
                 BigDecimal totalUsedNextYear = nextAccount.getVacationDays()
                         .add(nextAccount.getRemainingVacationDays())
                         .subtract(nextYearLeft.getVacationDays())

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/application/ApplicationForLeaveDetailsController.java
@@ -161,7 +161,7 @@ public class ApplicationForLeaveDetailsController {
         Optional<Account> account = accountService.getHolidaysAccount(year, application.getPerson());
 
         if (account.isPresent()) {
-            model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get()));
+            model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get(), accountService.getHolidaysAccount(year+1, application.getPerson())));
             model.addAttribute("account", account.get());
             model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now()));
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/overview/OverviewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/overview/OverviewController.java
@@ -170,7 +170,7 @@ public class OverviewController {
 		Optional<Account> account = accountService.getHolidaysAccount(year, person);
 
 		if (account.isPresent()) {
-			model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get()));
+			model.addAttribute("vacationDaysLeft", vacationDaysService.getVacationDaysLeft(account.get(), accountService.getHolidaysAccount(year+1, person)));
 			model.addAttribute("account", account.get());
 			model.addAttribute(PersonConstants.BEFORE_APRIL_ATTRIBUTE, DateUtil.isBeforeApril(DateMidnight.now()));
 		}

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/person/PersonController.java
@@ -244,7 +244,7 @@ public class PersonController {
             if (account.isPresent()) {
                 Account holidaysAccount = account.get();
                 accounts.put(person, holidaysAccount);
-                vacationDaysLeftMap.put(person, vacationDaysService.getVacationDaysLeft(holidaysAccount));
+                vacationDaysLeftMap.put(person, vacationDaysService.getVacationDaysLeft(holidaysAccount, accountService.getHolidaysAccount(year+1, person)));
             }
         }
 

--- a/src/main/resources/META-INF/resources/WEB-INF/tags/account-left.tag
+++ b/src/main/resources/META-INF/resources/WEB-INF/tags/account-left.tag
@@ -22,6 +22,12 @@
                                         arguments="${vacationDaysLeft.remainingVacationDaysNotExpiring}"/>
                     </c:otherwise>
                 </c:choose>
+                <c:choose>
+                    <c:when test="${vacationDaysLeft.vacationDaysUsedNextYear.unscaledValue() != 0}">
+                        <br/>
+                        <b><spring:message code="person.account.vacation.left.alreadyUsedNextYear" arguments="${vacationDaysLeft.vacationDaysUsedNextYear}" /></b>
+                    </c:when>
+                </c:choose>
             </c:when>
             <c:otherwise>
                 <spring:message code='person.account.vacation.noInformation'/>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -232,6 +232,7 @@ person.account.vacation.entitlement.remaining=(sowie {0} Tage Resturlaub)
 person.account.vacation.entitlement.remaining.notExpiring=Es wurde vereinbart, dass <h4>{0} Tage Resturlaub</h4> zum 1. April <b>nicht verfallen</b>
 person.account.vacation.left=Es <b>verbleiben</b> <h4>{0} Urlaubstage</h4>
 person.account.vacation.left.remaining=(sowie {0} Tage Resturlaub)
+person.account.vacation.left.alreadyUsedNextYear=Weitere {0} Tage sind bereits als Resturlaub im n\u00E4chsten Jahr verplant.
 
 # OVERVIEW PAGE
 overview.title=\u00DCbersicht f\u00FCr

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
@@ -255,7 +255,42 @@ public class VacationDaysServiceTest {
             vacationDaysLeft.getRemainingVacationDays());
         Assert.assertEquals("Wrong number of remaining vacation days that do not expire", BigDecimal.ZERO,
             vacationDaysLeft.getRemainingVacationDaysNotExpiring());
+        Assert.assertEquals("Number of vacation days already used for next year", BigDecimal.ZERO, vacationDaysLeft.getVacationDaysUsedNextYear());
+
     }
+
+
+    @Test
+    public void testGetVacationDaysLeft_WithRemainingAlreadyUsed() {
+
+        initCustomService("4", "20");
+
+        // 36 Total, using 24, so 12 left
+        Account account = new Account();
+        account.setAnnualVacationDays(new BigDecimal("30"));
+        account.setVacationDays(new BigDecimal("30"));
+        account.setRemainingVacationDays(new BigDecimal("6"));
+        account.setRemainingVacationDaysNotExpiring(new BigDecimal("2"));
+
+        // next year has only 12 new days, but using 24, i.e. all 12 from this year
+        Account nextYear = new Account();
+        nextYear.setAnnualVacationDays(new BigDecimal("12"));
+        nextYear.setVacationDays(new BigDecimal("12"));
+        nextYear.setRemainingVacationDays(new BigDecimal("20"));
+        nextYear.setRemainingVacationDaysNotExpiring(new BigDecimal("2"));
+
+
+        VacationDaysLeft vacationDaysLeft = vacationDaysService.getVacationDaysLeft(account, Optional.of(nextYear));
+
+        Assert.assertEquals("Number of vacation days already used for next year", new BigDecimal("12"), vacationDaysLeft.getVacationDaysUsedNextYear());
+
+        Assert.assertEquals("Wrong number of vacation days", BigDecimal.ZERO, vacationDaysLeft.getVacationDays());
+        Assert.assertEquals("Wrong number of remaining vacation days", BigDecimal.ZERO,
+                vacationDaysLeft.getRemainingVacationDays());
+        Assert.assertEquals("Wrong number of remaining vacation days that do not expire", BigDecimal.ZERO,
+                vacationDaysLeft.getRemainingVacationDaysNotExpiring());
+    }
+
 
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/VacationDaysServiceTest.java
@@ -255,13 +255,13 @@ public class VacationDaysServiceTest {
             vacationDaysLeft.getRemainingVacationDays());
         Assert.assertEquals("Wrong number of remaining vacation days that do not expire", BigDecimal.ZERO,
             vacationDaysLeft.getRemainingVacationDaysNotExpiring());
-        Assert.assertEquals("Number of vacation days already used for next year", BigDecimal.ZERO, vacationDaysLeft.getVacationDaysUsedNextYear());
+        Assert.assertEquals("Wrong number of vacation days already used for next year", BigDecimal.ZERO, vacationDaysLeft.getVacationDaysUsedNextYear());
 
     }
 
 
     @Test
-    public void testGetVacationDaysLeft_WithRemainingAlreadyUsed() {
+    public void testGetVacationDaysLeftWithRemainingAlreadyUsed() {
 
         initCustomService("4", "20");
 
@@ -282,7 +282,7 @@ public class VacationDaysServiceTest {
 
         VacationDaysLeft vacationDaysLeft = vacationDaysService.getVacationDaysLeft(account, Optional.of(nextYear));
 
-        Assert.assertEquals("Number of vacation days already used for next year", new BigDecimal("12"), vacationDaysLeft.getVacationDaysUsedNextYear());
+        Assert.assertEquals("Wrong number of vacation days already used for next year", new BigDecimal("12"), vacationDaysLeft.getVacationDaysUsedNextYear());
 
         Assert.assertEquals("Wrong number of vacation days", BigDecimal.ZERO, vacationDaysLeft.getVacationDays());
         Assert.assertEquals("Wrong number of remaining vacation days", BigDecimal.ZERO,

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
@@ -142,7 +142,7 @@ public class CalculationServiceTest {
         Mockito.when(accountService.getHolidaysAccount(2013, person)).thenReturn(Optional.of(nextYear));
 
         // set up 13 days already used next year, i.e. 10 + 3 remaining
-        Mockito.when(vacationDaysService.getVacationDaysLeft(nextYear)).thenReturn(
+        Mockito.when(vacationDaysService.getVacationDaysLeft(nextYear, Optional.empty())).thenReturn(
                 VacationDaysLeft.builder()
                         .withAnnualVacation(BigDecimal.TEN)
                         .withRemainingVacation(BigDecimal.TEN)

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/application/service/CalculationServiceTest.java
@@ -78,7 +78,7 @@ public class CalculationServiceTest {
 
 
     @Test
-    public void testCheckApplication_Simple() {
+    public void testCheckApplicationSimple() {
 
         Person person = TestDataCreator.createPerson("horscht");
 
@@ -116,7 +116,7 @@ public class CalculationServiceTest {
      * https://github.com/synyx/urlaubsverwaltung/issues/447
      */
     @Test
-    public void testCheckApplication_NextYearUsingRemainingAlready() {
+    public void testCheckApplicationNextYearUsingRemainingAlready() {
 
         Person person = TestDataCreator.createPerson("horscht");
 


### PR DESCRIPTION
When calculating the number of days available for vacation applications, we may also need to consider that some of the days for this year have already been used in applications next year (via the "remaining days" mechanism).

This PR adjusts both the check if the application can be submitted as well as the display of the number of available days (it adds a warning message to explain why the number has been decreased there if that happened).