### PR TITLE
Fix for double account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Bugfix: (Rest)urlaub wird nicht korrekt berechnet [#372](https://github.com/synyx/urlaubsverwaltung/issues/#372) [#551](https://github.com/synyx/urlaubsverwaltung/pull/#551)
 * Verbesserung Urlaubsübersicht durch dynamische Sortierung [#395](https://github.com/synyx/urlaubsverwaltung/issues/395)
 * Kleine inhaltliche Verbesserungen in den E-Mail-Templates [#580](https://github.com/synyx/urlaubsverwaltung/issues/580)
+* Fix for double account creation [#457](https://github.com/synyx/urlaubsverwaltung/issues/457)
 
 ### [urlaubsverwaltung-2.38.3](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.38.3)
 * Bugfix: Fehlende englische Übersetzung für die Urlaubsübersicht [#559](https://github.com/synyx/urlaubsverwaltung/pull/559)

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionService.java
@@ -33,9 +33,9 @@ public interface AccountInteractionService {
      *
      * @return the created holidays account
      */
-    Account createHolidaysAccount(Person person, DateMidnight validFrom, DateMidnight validTo,
-        BigDecimal annualVacationDays, BigDecimal actualVacationDays, BigDecimal remainingDays,
-        BigDecimal remainingDaysNotExpiring, String comment);
+    Account updateOrCreateHolidaysAccount(Person person, DateMidnight validFrom, DateMidnight validTo,
+                                          BigDecimal annualVacationDays, BigDecimal actualVacationDays, BigDecimal remainingDays,
+                                          BigDecimal remainingDaysNotExpiring, String comment);
 
     /**
      * Edits the given {@link Account} with the given params.

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
@@ -33,9 +33,10 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
     }
 
     @Override
-    public Account createHolidaysAccount(Person person, DateMidnight validFrom, DateMidnight validTo,
-        BigDecimal annualVacationDays, BigDecimal actualVacationDays, BigDecimal remainingDays,
-        BigDecimal remainingDaysNotExpiring, String comment) {
+    public Account updateOrCreateHolidaysAccount(Person person, DateMidnight validFrom, DateMidnight validTo,
+                                                 BigDecimal annualVacationDays, BigDecimal actualVacationDays,
+                                                 BigDecimal remainingDays, BigDecimal remainingDaysNotExpiring,
+                                                 String comment) {
 
         Account account = new Account(person, validFrom.toDate(), validTo.toDate(), annualVacationDays, remainingDays,
             remainingDaysNotExpiring, comment);
@@ -51,8 +52,8 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
 
     @Override
     public Account editHolidaysAccount(Account account, DateMidnight validFrom, DateMidnight validTo,
-        BigDecimal annualVacationDays, BigDecimal actualVacationDays, BigDecimal remainingDays,
-        BigDecimal remainingDaysNotExpiring, String comment) {
+                                       BigDecimal annualVacationDays, BigDecimal actualVacationDays, BigDecimal remainingDays,
+                                       BigDecimal remainingDaysNotExpiring, String comment) {
 
         account.setValidFrom(validFrom);
         account.setValidTo(validTo);
@@ -98,10 +99,8 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
     /**
      * Updates the remaining vacation days of the given new account by using data of the given last account.
      *
-     * @param newAccount
-     *            to calculate and update remaining vacation days for
-     * @param lastAccount
-     *            as reference to be used for calculation of remaining vacation days
+     * @param newAccount  to calculate and update remaining vacation days for
+     * @param lastAccount as reference to be used for calculation of remaining vacation days
      */
     private void updateRemainingVacationDays(Account newAccount, Account lastAccount) {
 
@@ -136,7 +135,7 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
 
         BigDecimal leftVacationDays = vacationDaysService.calculateTotalLeftVacationDays(referenceAccount);
 
-        return createHolidaysAccount(referenceAccount.getPerson(), DateUtil.getFirstDayOfYear(nextYear),
+        return updateOrCreateHolidaysAccount(referenceAccount.getPerson(), DateUtil.getFirstDayOfYear(nextYear),
             DateUtil.getLastDayOfYear(nextYear), referenceAccount.getAnnualVacationDays(),
             referenceAccount.getAnnualVacationDays(), leftVacationDays, BigDecimal.ZERO, referenceAccount.getComment());
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImpl.java
@@ -38,8 +38,19 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
                                                  BigDecimal remainingDays, BigDecimal remainingDaysNotExpiring,
                                                  String comment) {
 
-        Account account = new Account(person, validFrom.toDate(), validTo.toDate(), annualVacationDays, remainingDays,
-            remainingDaysNotExpiring, comment);
+        Optional<Account> optionalAccount = accountService.getHolidaysAccount(validFrom.getYear(), person);
+        Account account;
+
+        if (optionalAccount.isPresent()) {
+            account = optionalAccount.get();
+            account.setAnnualVacationDays(annualVacationDays);
+            account.setRemainingVacationDays(remainingDays);
+            account.setRemainingVacationDaysNotExpiring(remainingDaysNotExpiring);
+            account.setComment(comment);
+        } else {
+            account = new Account(person, validFrom.toDate(), validTo.toDate(), annualVacationDays, remainingDays,
+                remainingDaysNotExpiring, comment);
+        }
 
         account.setVacationDays(actualVacationDays);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/dev/PersonDataProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/dev/PersonDataProvider.java
@@ -59,7 +59,7 @@ class PersonDataProvider {
                         WeekDay.WEDNESDAY.getDayOfWeek(), WeekDay.THURSDAY.getDayOfWeek(), WeekDay.FRIDAY.getDayOfWeek()),
                 Optional.empty(), new DateMidnight(currentYear - 1, 1, 1), person);
 
-        accountInteractionService.createHolidaysAccount(person, DateUtil.getFirstDayOfYear(currentYear),
+        accountInteractionService.updateOrCreateHolidaysAccount(person, DateUtil.getFirstDayOfYear(currentYear),
                 DateUtil.getLastDayOfYear(currentYear), new BigDecimal("30"), new BigDecimal("30"), new BigDecimal("5"),
                 BigDecimal.ZERO, null);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/account/AccountController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/account/AccountController.java
@@ -109,7 +109,7 @@ public class AccountController {
             accountInteractionService.editHolidaysAccount(account.get(), validFrom, validTo, annualVacationDays,
                 actualVacationDays, remainingVacationDays, remainingVacationDaysNotExpiring, comment);
         } else {
-            accountInteractionService.createHolidaysAccount(person, validFrom, validTo, annualVacationDays,
+            accountInteractionService.updateOrCreateHolidaysAccount(person, validFrom, validTo, annualVacationDays,
                 actualVacationDays, remainingVacationDays, remainingVacationDaysNotExpiring, comment);
         }
 

--- a/src/main/resources/dbchangelogs/changelog-2.39.0-add-unique-constraint-year-and-person-id-to-account.xml
+++ b/src/main/resources/dbchangelogs/changelog-2.39.0-add-unique-constraint-year-and-person-id-to-account.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <changeSet author="Tobias Schneider" id="add-unique-constraint-year-and-person-id-to-account">
+
+    <preConditions>
+      <tableExists tableName="Account"/>
+    </preConditions>
+
+    <addUniqueConstraint tableName="Account"
+                         columnNames="validFrom, person_id"
+                         constraintName="unique_account_by_valid-from_and_person"/>
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -57,4 +57,5 @@
     <include file="dbchangelogs/changelog-2.37.0-add_ews_url_settings.xml"/>
     <include file="dbchangelogs/changelog-2.37.0-add-messagekey-to-vacationtype-and-sicknotetype.xml"/>
     <include file="dbchangelogs/changelog-2.37.0-add-exchange-calendar-timezoneid.xml"/>
+    <include file="dbchangelogs/changelog-2.39.0-add-unique-constraint-year-and-person-id-to-account.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/dao/AccountDAOTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/dao/AccountDAOTest.java
@@ -1,0 +1,49 @@
+package org.synyx.urlaubsverwaltung.core.account.dao;
+
+
+import org.joda.time.DateMidnight;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.synyx.urlaubsverwaltung.core.account.domain.Account;
+import org.synyx.urlaubsverwaltung.core.person.Person;
+import org.synyx.urlaubsverwaltung.core.person.PersonDAO;
+import org.synyx.urlaubsverwaltung.test.TestDataCreator;
+
+import static java.math.BigDecimal.TEN;
+import static org.joda.time.DateTimeConstants.DECEMBER;
+import static org.joda.time.DateTimeConstants.JANUARY;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class AccountDAOTest {
+
+    @Autowired
+    private AccountDAO sut;
+
+    @Autowired
+    private PersonDAO personDAO;
+
+    @Test(expected = DataIntegrityViolationException.class)
+    public void ensureUniqueConstraintOfPersonAndValidFrom() {
+
+        final Person person = TestDataCreator.createPerson("test user");
+        person.setId(1);
+        personDAO.save(person);
+
+        final DateMidnight validFrom = new DateMidnight(2014, JANUARY, 1);
+        final DateMidnight validTo = new DateMidnight(2014, DECEMBER, 31);
+        Account account = new Account(person, validFrom.toDate(), validTo.toDate(), TEN, TEN, TEN, "comment");
+        sut.save(account);
+
+        final DateMidnight validFrom2 = new DateMidnight(2014, JANUARY, 1);
+        final DateMidnight validTo2 = new DateMidnight(2014, DECEMBER, 31);
+        Account account2 = new Account(person, validFrom2.toDate(), validTo2.toDate(), TEN, TEN, TEN, "comment 2");
+        sut.save(account2);
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImplTest.java
@@ -5,31 +5,39 @@ import org.joda.time.DateTimeConstants;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.synyx.urlaubsverwaltung.core.account.domain.Account;
 import org.synyx.urlaubsverwaltung.core.person.Person;
 import org.synyx.urlaubsverwaltung.core.settings.Settings;
 import org.synyx.urlaubsverwaltung.core.settings.SettingsService;
-import org.synyx.urlaubsverwaltung.core.workingtime.WorkingTimeService;
 import org.synyx.urlaubsverwaltung.test.TestDataCreator;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Optional;
 
-import static org.mockito.Mockito.mock;
+import static java.math.BigDecimal.ONE;
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.ZERO;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.joda.time.DateTimeConstants.DECEMBER;
+import static org.joda.time.DateTimeConstants.JANUARY;
+import static org.joda.time.DateTimeConstants.OCTOBER;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Unit test for {@link org.synyx.urlaubsverwaltung.core.account.service.AccountInteractionServiceImpl}.
- */
+
+@RunWith(MockitoJUnitRunner.class)
 public class AccountInteractionServiceImplTest {
 
-    private AccountInteractionServiceImpl service;
+    private AccountInteractionServiceImpl sut;
 
+    @Mock
     private AccountService accountService;
+    @Mock
     private VacationDaysService vacationDaysService;
 
     private Person person;
@@ -38,15 +46,7 @@ public class AccountInteractionServiceImplTest {
     @Before
     public void setup() {
 
-        accountService = mock(AccountService.class);
-
-        WorkingTimeService workingTimeService = mock(WorkingTimeService.class);
-        SettingsService settingsService = mock(SettingsService.class);
-        when(settingsService.getSettings()).thenReturn(new Settings());
-
-        vacationDaysService = mock(VacationDaysService.class);
-
-        service = new AccountInteractionServiceImpl(accountService, vacationDaysService);
+        sut = new AccountInteractionServiceImpl(accountService, vacationDaysService);
 
         person = TestDataCreator.createPerson("horscht");
     }
@@ -55,17 +55,17 @@ public class AccountInteractionServiceImplTest {
     @Test
     public void testUpdateRemainingVacationDays() {
 
-        DateMidnight startDate = new DateMidnight(2012, DateTimeConstants.JANUARY, 1);
+        DateMidnight startDate = new DateMidnight(2012, JANUARY, 1);
         DateMidnight endDate = new DateMidnight(2012, DateTimeConstants.DECEMBER, 31);
 
         Account account2012 = new Account(person, startDate.toDate(), endDate.toDate(), BigDecimal.valueOf(30),
-                BigDecimal.valueOf(5), BigDecimal.ZERO, null);
+                BigDecimal.valueOf(5), ZERO, null);
 
         Account account2013 = new Account(person, startDate.withYear(2013).toDate(), endDate.withYear(2013).toDate(),
-                BigDecimal.valueOf(30), BigDecimal.valueOf(3), BigDecimal.ZERO, "comment1");
+                BigDecimal.valueOf(30), BigDecimal.valueOf(3), ZERO, "comment1");
 
         Account account2014 = new Account(person, startDate.withYear(2014).toDate(), endDate.withYear(2014).toDate(),
-                BigDecimal.valueOf(30), BigDecimal.valueOf(8), BigDecimal.ZERO, "comment2");
+                BigDecimal.valueOf(30), BigDecimal.valueOf(8), ZERO, "comment2");
 
         when(accountService.getHolidaysAccount(2012, person)).thenReturn(Optional.of(account2012));
         when(accountService.getHolidaysAccount(2013, person)).thenReturn(Optional.of(account2013));
@@ -75,7 +75,7 @@ public class AccountInteractionServiceImplTest {
         when(vacationDaysService.calculateTotalLeftVacationDays(account2012)).thenReturn(BigDecimal.valueOf(6));
         when(vacationDaysService.calculateTotalLeftVacationDays(account2013)).thenReturn(BigDecimal.valueOf(2));
 
-        service.updateRemainingVacationDays(2012, person);
+        sut.updateRemainingVacationDays(2012, person);
 
         verify(vacationDaysService).calculateTotalLeftVacationDays(account2012);
         verify(vacationDaysService).calculateTotalLeftVacationDays(account2013);
@@ -103,8 +103,8 @@ public class AccountInteractionServiceImplTest {
         int year = 2014;
         int nextYear = 2015;
 
-        DateMidnight startDate = new DateMidnight(year, DateTimeConstants.JANUARY, 1);
-        DateMidnight endDate = new DateMidnight(year, DateTimeConstants.OCTOBER, 31);
+        DateMidnight startDate = new DateMidnight(year, JANUARY, 1);
+        DateMidnight endDate = new DateMidnight(year, OCTOBER, 31);
         BigDecimal leftDays = BigDecimal.ONE;
 
         Account referenceHolidaysAccount = new Account(person, startDate.toDate(), endDate.toDate(),
@@ -113,7 +113,7 @@ public class AccountInteractionServiceImplTest {
         when(accountService.getHolidaysAccount(nextYear, person)).thenReturn(Optional.empty());
         when(vacationDaysService.calculateTotalLeftVacationDays(referenceHolidaysAccount)).thenReturn(leftDays);
 
-        Account createdHolidaysAccount = service.autoCreateOrUpdateNextYearsHolidaysAccount(referenceHolidaysAccount);
+        Account createdHolidaysAccount = sut.autoCreateOrUpdateNextYearsHolidaysAccount(referenceHolidaysAccount);
 
         Assert.assertNotNull("Should not be null", createdHolidaysAccount);
 
@@ -122,7 +122,7 @@ public class AccountInteractionServiceImplTest {
                 createdHolidaysAccount.getAnnualVacationDays());
         Assert.assertEquals("Wrong number of remaining vacation days", leftDays,
                 createdHolidaysAccount.getRemainingVacationDays());
-        Assert.assertEquals("Wrong number of not expiring remaining vacation days", BigDecimal.ZERO,
+        Assert.assertEquals("Wrong number of not expiring remaining vacation days", ZERO,
                 createdHolidaysAccount.getRemainingVacationDaysNotExpiring());
         Assert.assertEquals("Wrong validity start date", new DateMidnight(nextYear, 1, 1),
                 createdHolidaysAccount.getValidFrom());
@@ -132,7 +132,7 @@ public class AccountInteractionServiceImplTest {
         verify(accountService).save(createdHolidaysAccount);
 
         verify(vacationDaysService).calculateTotalLeftVacationDays(referenceHolidaysAccount);
-        verify(accountService).getHolidaysAccount(nextYear, person);
+        verify(accountService, times(2)).getHolidaysAccount(nextYear, person);
     }
 
 
@@ -142,20 +142,20 @@ public class AccountInteractionServiceImplTest {
         int year = 2014;
         int nextYear = 2015;
 
-        DateMidnight startDate = new DateMidnight(year, DateTimeConstants.JANUARY, 1);
-        DateMidnight endDate = new DateMidnight(year, DateTimeConstants.OCTOBER, 31);
+        DateMidnight startDate = new DateMidnight(year, JANUARY, 1);
+        DateMidnight endDate = new DateMidnight(year, OCTOBER, 31);
         BigDecimal leftDays = BigDecimal.valueOf(7);
 
         Account referenceAccount = new Account(person, startDate.toDate(), endDate.toDate(), BigDecimal.valueOf(30),
                 BigDecimal.valueOf(8), BigDecimal.valueOf(4), "comment");
 
         Account nextYearAccount = new Account(person, new DateMidnight(nextYear, 1, 1).toDate(), new DateMidnight(
-                nextYear, 10, 31).toDate(), BigDecimal.valueOf(28), BigDecimal.ZERO, BigDecimal.ZERO, "comment");
+                nextYear, 10, 31).toDate(), BigDecimal.valueOf(28), ZERO, ZERO, "comment");
 
         when(accountService.getHolidaysAccount(nextYear, person)).thenReturn(Optional.of(nextYearAccount));
         when(vacationDaysService.calculateTotalLeftVacationDays(referenceAccount)).thenReturn(leftDays);
 
-        Account account = service.autoCreateOrUpdateNextYearsHolidaysAccount(referenceAccount);
+        Account account = sut.autoCreateOrUpdateNextYearsHolidaysAccount(referenceAccount);
 
         Assert.assertNotNull("Should not be null", account);
 
@@ -163,7 +163,7 @@ public class AccountInteractionServiceImplTest {
         Assert.assertEquals("Wrong number of annual vacation days", nextYearAccount.getAnnualVacationDays(),
                 account.getAnnualVacationDays());
         Assert.assertEquals("Wrong number of remaining vacation days", leftDays, account.getRemainingVacationDays());
-        Assert.assertEquals("Wrong number of not expiring remaining vacation days", BigDecimal.ZERO,
+        Assert.assertEquals("Wrong number of not expiring remaining vacation days", ZERO,
                 account.getRemainingVacationDaysNotExpiring());
         Assert.assertEquals("Wrong validity start date", nextYearAccount.getValidFrom(), account.getValidFrom());
         Assert.assertEquals("Wrong validity end date", nextYearAccount.getValidTo(), account.getValidTo());

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/account/service/AccountInteractionServiceImplTest.java
@@ -173,4 +173,40 @@ public class AccountInteractionServiceImplTest {
         verify(vacationDaysService).calculateTotalLeftVacationDays(referenceAccount);
         verify(accountService).getHolidaysAccount(nextYear, person);
     }
+
+    @Test
+    public void createHolidaysAccount() {
+
+        DateMidnight validFrom = new DateMidnight(2014, JANUARY, 1);
+        DateMidnight validTo = new DateMidnight(2014, DECEMBER, 31);
+
+        when(accountService.getHolidaysAccount(2014, person)).thenReturn(Optional.empty());
+
+        Account expectedAccount = sut.updateOrCreateHolidaysAccount(person, validFrom, validTo, TEN, ONE, ZERO, TEN, "comment");
+        assertThat(expectedAccount.getPerson()).isEqualTo(person);
+        assertThat(expectedAccount.getAnnualVacationDays()).isEqualTo(TEN);
+        assertThat(expectedAccount.getVacationDays()).isEqualTo(ONE);
+        assertThat(expectedAccount.getRemainingVacationDays()).isSameAs(ZERO);
+        assertThat(expectedAccount.getRemainingVacationDaysNotExpiring()).isEqualTo(TEN);
+
+        verify(accountService).save(expectedAccount);
+    }
+
+    @Test
+    public void updateHolidaysAccount() {
+
+        DateMidnight validFrom = new DateMidnight(2014, JANUARY, 1);
+        DateMidnight validTo = new DateMidnight(2014, DECEMBER, 31);
+        Account account = new Account(person, validFrom.toDate(), validTo.toDate(), TEN, TEN, TEN, "comment");
+        when(accountService.getHolidaysAccount(2014, person)).thenReturn(Optional.of(account));
+
+        Account expectedAccount = sut.updateOrCreateHolidaysAccount(person, validFrom, validTo, ONE, ONE, ONE, ONE, "new comment");
+        assertThat(expectedAccount.getPerson()).isEqualTo(person);
+        assertThat(expectedAccount.getAnnualVacationDays()).isEqualTo(ONE);
+        assertThat(expectedAccount.getVacationDays()).isEqualTo(ONE);
+        assertThat(expectedAccount.getRemainingVacationDays()).isSameAs(ONE);
+        assertThat(expectedAccount.getRemainingVacationDaysNotExpiring()).isEqualTo(ONE);
+
+        verify(accountService).save(expectedAccount);
+    }
 }


### PR DESCRIPTION
#443

Vielleicht gibt es bessere Möglichkeiten das doppelte erzeugen von Accounts im gleichen Jahr für die selbe Person zu verhindern. Ich hätte auch gedacht, dass das wahrscheinlich nicht vorkommen sollte. Aber das ist neben Test-Code die einzige Stelle wo ein ```new Account(...)``` aufgerufen wird. Und mit dem synchronized sollte sichergestellt werden, dass es zu keiner Race-Condition kommt.