### PR TITLE
Replace Oracle JDK with OpenJDK in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ after_success:
   - ./mvnw clean verify jacoco:report coveralls:report
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 branches:
   only:


### PR DESCRIPTION
Since this is an open source project and Oracle isn't very opensourcy, let's switch to open source version of Java, even if it's only for the builds in Travis.