### PR TITLE
Fix broken links in mails

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/core/application/domain/Application.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/application/domain/Application.java
@@ -160,6 +160,12 @@ public class Application extends AbstractPersistable<Integer> {
      */
     private BigDecimal hours;
 
+    @Override
+    public void setId(Integer id) { // NOSONAR - make it public instead of protected
+
+        super.setId(id);
+    }
+
     public String getAddress() {
 
         return address;

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/overtime/Overtime.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/overtime/Overtime.java
@@ -96,6 +96,11 @@ public class Overtime extends AbstractPersistable<Integer> {
         return hours;
     }
 
+    @Override
+    public void setId(Integer id) { // NOSONAR - make it public instead of protected
+
+        super.setId(id);
+    }
 
     public void setPerson(Person person) {
 

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_office.ftl
@@ -1,6 +1,6 @@
 Hallo Office,
 
-es liegt ein neuer genehmigter Antrag vor: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+es liegt ein neuer genehmigter Antrag vor: ${settings.baseLinkURL}web/application/${application.id?c}
 
 <#if (comment.text)??>
 Kommentar von ${comment.person.niceName} zum Antrag: ${comment.text}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_user.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_user.ftl
@@ -9,4 +9,4 @@ Kommentar von ${comment.person.niceName} zum Antrag: ${comment.text}
 
 </#if>
 
-Link zum Antrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Link zum Antrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/application_cancellation_request.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/application_cancellation_request.ftl
@@ -8,4 +8,4 @@ Kommentar zur Stornierung von ${comment.person.niceName} zum Antrag: ${comment.t
 
 </#if>
 
-Es handelt sich um folgenden Urlaubsantrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Es handelt sich um folgenden Urlaubsantrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cancelled_by_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cancelled_by_office.ftl
@@ -8,4 +8,4 @@ Kommentar zur Stornierung von ${comment.person.niceName} zum Antrag: ${comment.t
 
 </#if>
 
-Es handelt sich um folgenden Urlaubsantrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Es handelt sich um folgenden Urlaubsantrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/confirm.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/confirm.ftl
@@ -22,4 +22,4 @@ Anschrift/Telefon während des Urlaubs: ${application.address}
 Kommentar: ${comment.text}
 </#if>
 
-Link zum Antrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Link zum Antrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cron_remind.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/cron_remind.ftl
@@ -3,7 +3,7 @@ Hallo ${recipient.niceName},
 Die folgenden gestellten Urlaubsanträge warten auf ihre Bearbeitung:
 
 <#list applicationList as application>
-Antrag von ${application.person.niceName} vom ${application.applicationDate.toString("dd.MM.yyyy")}: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Antrag von ${application.person.niceName} vom ${application.applicationDate.toString("dd.MM.yyyy")}: ${settings.baseLinkURL}web/application/${application.id?c}
 </#list>
 
 Ohne eine Bearbeitung kann es passieren, dass weitere Erinnerungen folgen ;-)

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_application_by_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_application_by_office.ftl
@@ -22,4 +22,4 @@ Anschrift/Telefon während des Urlaubs: ${application.address}
 Kommentar: ${comment.text}
 </#if>
 
-Link zum Antrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Link zum Antrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_applications.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_applications.ftl
@@ -1,6 +1,6 @@
 Hallo ${recipient.niceName},
 
-es liegt ein neuer zu genehmigender Antrag vor: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+es liegt ein neuer zu genehmigender Antrag vor: ${settings.baseLinkURL}web/application/${application.id?c}
 
 ----------------------------------------------------------------------------------------------
 

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/overtime_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/overtime_office.ftl
@@ -1,6 +1,6 @@
 Hallo Office,
 
-es wurden Überstunden erfasst: ${settings.baseLinkURL}web/overtime/<#if overtime.id??>${overtime.id}</#if>
+es wurden Überstunden erfasst: ${settings.baseLinkURL}web/overtime/${overtime.id?c}
 
 Mitarbeiter: ${overtime.person.niceName}
 

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/refer.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/refer.ftl
@@ -3,4 +3,4 @@ Hallo ${recipient.niceName},
 ${sender.niceName} bittet dich um Hilfe bei der Entscheidung über einen Urlaubsantrag von ${application.person.niceName}.
 Bitte kümmere dich um die Entscheidung dieses Antrags oder halte ggf. nochmals Rücksprache mit ${sender.niceName}.
 
-Den Urlaubsantrag findest du hier: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Den Urlaubsantrag findest du hier: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/rejected.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/rejected.ftl
@@ -6,4 +6,4 @@ dein am ${application.applicationDate.toString("dd.MM.yyyy")} gestellter Antrag 
 Begründung: ${comment.text}
 
 </#if>
-Link zum Antrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Link zum Antrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind.ftl
@@ -3,4 +3,4 @@ Hallo ${recipient.niceName},
 ${application.person.niceName} bittet darum, dass sich jemand um den am ${application.applicationDate.toString("dd.MM.yyyy")} gestellten Urlaubsantrag kümmert,
 andernfalls kann es passieren, dass ihr weitere Erinnerungen erhaltet ;-)
 
-Den Urlaubsantrag findet ihr hier: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Den Urlaubsantrag findet ihr hier: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/sicknote_converted.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/sicknote_converted.ftl
@@ -3,4 +3,4 @@ Hallo ${application.person.niceName},
 ${application.applier.niceName} hat deine Krankmeldung zu Urlaub umgewandelt.
 Es handelt sich um folgenden Zeitraum: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}
 
-Für Details siehe: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Für Details siehe: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_second_stage_authority.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_second_stage_authority.ftl
@@ -1,6 +1,6 @@
 Hallo ${recipient.niceName},
 
-es liegt ein neuer zu genehmigender Antrag vor: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+es liegt ein neuer zu genehmigender Antrag vor: ${settings.baseLinkURL}web/application/${application.id?c}
 
 Der Antrag wurde bereits vorläufig genehmigt und muss nun noch endgültig freigegeben werden.
 <#if (comment.text)??>

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_user.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_user.ftl
@@ -9,4 +9,4 @@ Kommentar von ${comment.person.niceName} zum Antrag: ${comment.text}
 </#if>
 Es handelt sich um den Zeitraum von ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
 
-Link zum Antrag: ${settings.baseLinkURL}web/application/<#if application.id??>${application.id}</#if>
+Link zum Antrag: ${settings.baseLinkURL}web/application/${application.id?c}

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceIntegrationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceIntegrationTest.java
@@ -159,6 +159,7 @@ public class MailServiceIntegrationTest {
 
         DateMidnight now = DateMidnight.now();
         Application application = new Application();
+        application.setId(1234);
         application.setPerson(person);
         application.setVacationType(TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "Erholungsurlaub"));
         application.setDayLength(DayLength.FULL);
@@ -269,7 +270,7 @@ public class MailServiceIntegrationTest {
         assertTrue(contentDepartmentHead.contains("Hallo " + recipient.getNiceName()));
         assertTrue(contentDepartmentHead.contains(niceName));
         assertTrue(contentDepartmentHead.contains("es liegt ein neuer zu genehmigender Antrag vor"));
-        assertTrue(contentDepartmentHead.contains("http://urlaubsverwaltung/web/application/"));
+        assertTrue(contentDepartmentHead.contains("http://urlaubsverwaltung/web/application/1234"));
         assertTrue("No comment in mail content", contentDepartmentHead.contains(comment.getText()));
         assertTrue("Wrong comment author", contentDepartmentHead.contains(comment.getPerson().getNiceName()));
     }
@@ -312,6 +313,7 @@ public class MailServiceIntegrationTest {
 
         String content = (String) message.getContent();
 
+        assertTrue(content.contains("es liegt ein neuer zu genehmigender Antrag vor: http://urlaubsverwaltung/web/application/1234"));
         assertTrue(content.contains("Marlene Muster: 05.11.2015 bis 06.11.2015"));
         assertTrue(content.contains("Niko Schmidt: 04.11.2015 bis 04.11.2015"));
     }
@@ -349,6 +351,7 @@ public class MailServiceIntegrationTest {
         assertTrue(contentUser.contains("gestellter Antrag wurde von Hugo Boss genehmigt"));
         assertTrue("No comment in mail content", contentUser.contains(comment.getText()));
         assertTrue("Wrong comment author", contentUser.contains(comment.getPerson().getNiceName()));
+        assertTrue(contentUser.contains("Link zum Antrag: http://urlaubsverwaltung/web/application/1234"));
 
         // get email office
         Message msgOffice = inboxOffice.get(0);
@@ -367,6 +370,7 @@ public class MailServiceIntegrationTest {
         assertTrue(contentOfficeMail.contains("Erholungsurlaub"));
         assertTrue("No comment in mail content", contentOfficeMail.contains(comment.getText()));
         assertTrue("Wrong comment author", contentOfficeMail.contains(comment.getPerson().getNiceName()));
+        assertTrue(contentOfficeMail.contains("es liegt ein neuer genehmigter Antrag vor: http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -401,6 +405,7 @@ public class MailServiceIntegrationTest {
             "Bitte beachte, dass dieser erst noch von einem entsprechend Verantwortlichen freigegeben werden muss"));
         assertTrue("No comment in mail content", contentUser.contains(comment.getText()));
         assertTrue("Wrong comment author", contentUser.contains(comment.getPerson().getNiceName()));
+        assertTrue(contentUser.contains("Link zum Antrag: http://urlaubsverwaltung/web/application/1234"));
 
         // get email office
         Message msgSecondStage = inboxSecondStage.get(0);
@@ -413,8 +418,8 @@ public class MailServiceIntegrationTest {
 
         // check content of office email
         String contentSecondStageMail = (String) msgSecondStage.getContent();
-        assertTrue(contentSecondStageMail.contains(
-            "Der Antrag wurde bereits vorläufig genehmigt und muss nun noch endgültig freigegeben werden"));
+        assertTrue(contentSecondStageMail.contains("es liegt ein neuer zu genehmigender Antrag vor: http://urlaubsverwaltung/web/application/1234"));
+        assertTrue(contentSecondStageMail.contains("Der Antrag wurde bereits vorläufig genehmigt und muss nun noch endgültig freigegeben werden"));
         assertTrue(contentSecondStageMail.contains("Lieschen Müller"));
         assertTrue(contentSecondStageMail.contains("Erholungsurlaub"));
         assertTrue("No comment in mail content", contentSecondStageMail.contains(comment.getText()));
@@ -445,6 +450,7 @@ public class MailServiceIntegrationTest {
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Lieschen Müller"));
         assertTrue(content.contains("wurde leider von Hugo Boss abgelehnt"));
+        assertTrue(content.contains("Link zum Antrag: http://urlaubsverwaltung/web/application/1234"));
         assertTrue("No comment in mail content", content.contains(comment.getText()));
         assertTrue("Wrong comment author", content.contains(comment.getPerson().getNiceName()));
     }
@@ -476,6 +482,7 @@ public class MailServiceIntegrationTest {
         assertTrue(content.contains("dein Urlaubsantrag wurde erfolgreich eingereicht"));
         assertTrue("No comment in mail content", content.contains(comment.getText()));
         assertTrue("Wrong comment author", content.contains(comment.getPerson().getNiceName()));
+        assertTrue(content.contains("Link zum Antrag: http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -507,6 +514,7 @@ public class MailServiceIntegrationTest {
         assertTrue(content.contains("dein Urlaubsantrag wurde von Marlene Muster für dich storniert"));
         assertTrue("No comment in mail content", content.contains(comment.getText()));
         assertTrue("Wrong comment author", content.contains(comment.getPerson().getNiceName()));
+        assertTrue(content.contains("Es handelt sich um folgenden Urlaubsantrag: http://urlaubsverwaltung/web/application/1234"));
     }
 
     @Test
@@ -536,6 +544,7 @@ public class MailServiceIntegrationTest {
         assertTrue(content.contains("Marlene Muster hat einen Urlaubsantrag für dich gestellt"));
         assertTrue("No comment in mail content", content.contains(comment.getText()));
         assertTrue("Wrong comment author", content.contains(comment.getPerson().getNiceName()));
+        assertTrue(content.contains("Link zum Antrag: http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -760,6 +769,7 @@ public class MailServiceIntegrationTest {
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Office"));
         assertTrue(content.contains("hat beantragt den bereits genehmigten Urlaub"));
+        assertTrue(content.contains("Es handelt sich um folgenden Urlaubsantrag: http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -786,7 +796,7 @@ public class MailServiceIntegrationTest {
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Max Muster"));
         assertTrue(content.contains("Rick Grimes bittet dich um Hilfe bei der Entscheidung über einen Urlaubsantrag"));
-        assertTrue(content.contains("http://urlaubsverwaltung/web/application/"));
+        assertTrue(content.contains("http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -815,6 +825,7 @@ public class MailServiceIntegrationTest {
         // check content of email
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Hugo Boss"));
+        assertTrue(content.contains("Den Urlaubsantrag findet ihr hier: http://urlaubsverwaltung/web/application/1234"));
     }
 
 
@@ -870,6 +881,7 @@ public class MailServiceIntegrationTest {
 
         for (Application application : applications) {
             assertTrue(content.contains(application.getApplier().getNiceName()));
+            assertTrue(content.contains("http://urlaubsverwaltung/web/application/1234"));
         }
     }
 
@@ -899,6 +911,7 @@ public class MailServiceIntegrationTest {
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Lieschen Müller"));
         assertTrue(content.contains("Marlene Muster hat deine Krankmeldung zu Urlaub umgewandelt"));
+        assertTrue(content.contains("Für Details siehe: http://urlaubsverwaltung/web/application/1234"));
     }
 
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceIntegrationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceIntegrationTest.java
@@ -980,6 +980,6 @@ public class MailServiceIntegrationTest {
         String content = (String) msg.getContent();
         assertTrue(content.contains("Hallo Office"));
         assertTrue(content.contains("es wurden Überstunden erfasst"));
-        assertTrue(content.contains("http://urlaubsverwaltung/web/overtime/"));
+        assertTrue(content.contains("http://urlaubsverwaltung/web/overtime/1234"));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/test/TestDataCreator.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/test/TestDataCreator.java
@@ -104,7 +104,9 @@ public final class TestDataCreator {
         DateMidnight startDate = DateMidnight.now();
         DateMidnight endDate = startDate.plusDays(7);
 
-        return new Overtime(person, startDate, endDate, BigDecimal.ONE);
+        Overtime overtime = new Overtime(person, startDate, endDate, BigDecimal.ONE);
+        overtime.setId(1234);
+        return overtime;
     }
 
     // Application for leave -------------------------------------------------------------------------------------------


### PR DESCRIPTION
#487 changed velocity to freemarker templates. Freemarker formats numbers with localization in mind.

This change is using an explicit number to string formater to prevent localized formated numbers in mails.