### PR TITLE
fix dependency conflict of guava: bump google api client to 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### master / unreleased
 
+### [urlaubsverwaltung-2.36.1](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.36.0)
+* Bugfix: Dependency Conflicts
+
 ### [urlaubsverwaltung-2.36.0](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.36.0)
 * Upgrade auf Spring Boot 2.1.3 [#501](https://github.com/synyx/urlaubsverwaltung/pull/501) 
 * Fix Bug bei dem die Überstunden trotz Deaktivierung angezeigt wurden [#511](https://github.com/synyx/urlaubsverwaltung/pull/511) 

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <httpclient.version>4.5</httpclient.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-    <google-api-client.version>1.23.0</google-api-client.version>
-    <google-api-services-calendar.version>v3-rev281-1.23.0</google-api-services-calendar.version>
+    <google-api-client.version>1.25.0</google-api-client.version>
+    <google-api-services-calendar.version>v3-rev370-1.25.0</google-api-services-calendar.version>
     <commons-collections.version>3.2.1</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
     <docker-maven-plugin.version>0.28.0</docker-maven-plugin.version>


### PR DESCRIPTION
* conflicts with guava 20.0 of swagger

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
