### PR TITLE
[WIP] added intermediate node process that presents waiting-page

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,3 @@
-web: java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_TOOL_OPTIONS -jar -Dspring.profiles.active=dev target/urlaubsverwaltung-*.war --server.port=$PORT
+web: node src/main/node/waiting.js
+
+#web: java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_TOOL_OPTIONS -jar -Dspring.profiles.active=dev target/urlaubsverwaltung-*.war --server.port=$PORT

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,1 @@
-web: node src/main/node/waiting.js
-
-#web: java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_TOOL_OPTIONS -jar -Dspring.profiles.active=dev target/urlaubsverwaltung-*.war --server.port=$PORT
+web: java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_TOOL_OPTIONS -jar -Dspring.profiles.active=dev target/urlaubsverwaltung-*.war --server.port=$PORT

--- a/app.json
+++ b/app.json
@@ -13,5 +13,7 @@
   "name": "urlaubsverwaltung",
   "repository": "https://github.com/synyx/urlaubsverwaltung",
   "logo": "https://github.com/synyx/urlaubsverwaltung/blob/master/src/main/resources/static/images/urlaubaer.png",
-  "stack": "heroku-18"
+  "stack": "heroku-18",
+  "success_url": "https://synyx.github.io/urlaubsverwaltung-landingpage/",
+  "website": "https://synyx.github.io/urlaubsverwaltung-landingpage/"
 }

--- a/src/main/node/waiting.js
+++ b/src/main/node/waiting.js
@@ -1,6 +1,8 @@
+console.log('start');
+
 const http = require('http');
 
-
+console.log('create server');
 http.createServer(function (req, res) {
   res.write('waiting for dyno!');
   res.end();

--- a/src/main/node/waiting.js
+++ b/src/main/node/waiting.js
@@ -1,0 +1,9 @@
+const http = require('http');
+
+
+http.createServer(function (req, res) {
+  res.write('waiting for dyno!');
+  res.end();
+}).listen(5000);
+
+console.log('started');


### PR DESCRIPTION
Idea:
* start a node process that delivers just once a html-page with javascript that is checking if the urlaubsverwaltung is started and redirects after start to the login
* node-process has to kill itself after delivering the page
* node-process needs to be started by maven (we have a java-dyno, without native node-support)