### PR TITLE
Translation of vacationtype quickfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### master / unreleased
+* Bugfix: Fehlerhafte Übersetzung in den Email-Templates des Urlaubtypes [#560](https://github.com/synyx/urlaubsverwaltung/pull/560)
 
 ### [urlaubsverwaltung-2.38.1](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.38.1)
 * Bugfix: Fehlende englishe Übersetzung für Exchange (EWS) URL ergänzt [#557](https://github.com/synyx/urlaubsverwaltung/pull/557)

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.ofNullable;
+
 
 /**
  * Implementation of interface {@link MailService}.
@@ -63,8 +65,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
 
-        Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+        Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application, ofNullable(comment));
         model.put("departmentVacations",
             departmentService.getApplicationsForLeaveOfMembersInDepartmentsOfPerson(application.getPerson(),
                 application.getStartDate(), application.getEndDate()));
@@ -134,7 +135,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
         model.put("departmentVacations",
             departmentService.getApplicationsForLeaveOfMembersInDepartmentsOfPerson(application.getPerson(),
                 application.getStartDate(), application.getEndDate()));
@@ -156,7 +157,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
 
         // Inform user that the application for leave has been allowed
         String textUser = mailBuilder.buildMailBody("allowed_user", model, LOCALE);
@@ -178,7 +179,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
         String text = mailBuilder.buildMailBody("rejected", model, LOCALE);
         mailSender.sendEmail(mailSettings, RecipientUtil.getMailAddresses(application.getPerson()),
             getTranslation("subject.application.rejected"), text);
@@ -207,7 +208,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
         String text = mailBuilder.buildMailBody("confirm", model, LOCALE);
         mailSender.sendEmail(mailSettings, RecipientUtil.getMailAddresses(application.getPerson()),
             getTranslation("subject.application.applied.user"), text);
@@ -219,7 +220,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
         String text = mailBuilder.buildMailBody("new_application_by_office", model, LOCALE);
         mailSender.sendEmail(mailSettings, RecipientUtil.getMailAddresses(application.getPerson()),
             getTranslation("subject.application.appliedByOffice"), text);
@@ -231,7 +232,7 @@ class MailServiceImpl implements MailService {
 
         MailSettings mailSettings = getMailSettings();
         Map<String, Object> model = createModelForApplicationStatusChangeMail(mailSettings, application,
-                Optional.ofNullable(comment));
+            ofNullable(comment));
 
         String text = mailBuilder.buildMailBody("cancelled_by_office", model, LOCALE);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImpl.java
@@ -107,6 +107,7 @@ class MailServiceImpl implements MailService {
 
         Map<String, Object> model = new HashMap<>();
         model.put("application", application);
+        model.put("vacationType", getTranslation(application.getVacationType().getCategory().getMessageKey()));
         model.put("dayLength", getTranslation(application.getDayLength().name()));
         model.put("settings", mailSettings);
 

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/allowed_office.ftl
@@ -13,7 +13,7 @@ Informationen zum Urlaubsantrag:
 Mitarbeiter: ${application.person.niceName}
 Antragsdatum: ${application.applicationDate.toString("dd.MM.yyyy")}
 Zeitraum des beantragten Urlaubs: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
-Art des Urlaubs: ${application.vacationType.messageKey}
+Art des Urlaubs: ${vacationType}
 <#if (application.reason)??>
 Grund: ${application.reason}
 </#if>

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/confirm.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/confirm.ftl
@@ -8,7 +8,7 @@ Informationen zum Urlaubsantrag:
 
 Antragsdatum: ${application.applicationDate.toString("dd.MM.yyyy")}
 Zeitraum des beantragten Urlaubs: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
-Art des Urlaubs: ${application.vacationType.messageKey}
+Art des Urlaubs: ${vacationType}
 <#if (application.reason)??>
 Grund: ${application.reason}
 </#if>

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_application_by_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_application_by_office.ftl
@@ -8,7 +8,7 @@ Informationen zum Urlaubsantrag:
 
 Antragsdatum: ${application.applicationDate.toString("dd.MM.yyyy")}
 Zeitraum des beantragten Urlaubs: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
-Art des Urlaubs: ${application.vacationType.messageKey}
+Art des Urlaubs: ${vacationType}
 <#if (application.reason)??>
 Grund: ${application.reason}
 </#if>

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_applications.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/new_applications.ftl
@@ -9,7 +9,7 @@ Informationen zum Urlaubsantrag:
 Mitarbeiter: ${application.person.niceName}
 Datum der Antragsstellung: ${application.applicationDate.toString("dd.MM.yyyy")}
 Zeitraum des beantragten Urlaubs: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
-Art des Urlaubs: ${application.vacationType.messageKey}
+Art des Urlaubs: ${vacationType}
 <#if (application.reason)??>
 Grund: ${application.reason}
 </#if>

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_second_stage_authority.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/temporary_allowed_second_stage_authority.ftl
@@ -14,7 +14,7 @@ Informationen zum Urlaubsantrag:
 Mitarbeiter: ${application.person.niceName}
 Datum der Antragsstellung: ${application.applicationDate.toString("dd.MM.yyyy")}
 Zeitraum des beantragten Urlaubs: ${application.startDate.toString("dd.MM.yyyy")} bis ${application.endDate.toString("dd.MM.yyyy")}, ${dayLength}
-Art des Urlaubs: ${application.vacationType.messageKey}
+Art des Urlaubs: ${vacationType}
 <#if application.reason?has_content>
 Grund: ${application.reason}
 </#if>

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImplIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImplIT.java
@@ -162,7 +162,7 @@ public class MailServiceImplIT {
         Application application = new Application();
         application.setId(1234);
         application.setPerson(person);
-        application.setVacationType(TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "Erholungsurlaub"));
+        application.setVacationType(TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "application.data.vacationType.holiday"));
         application.setDayLength(DayLength.FULL);
         application.setApplicationDate(now);
         application.setStartDate(now);
@@ -270,6 +270,7 @@ public class MailServiceImplIT {
         String contentDepartmentHead = (String) msg.getContent();
         assertTrue(contentDepartmentHead.contains("Hallo " + recipient.getNiceName()));
         assertTrue(contentDepartmentHead.contains(niceName));
+        assertTrue(contentDepartmentHead.contains("Erholungsurlaub"));
         assertTrue(contentDepartmentHead.contains("es liegt ein neuer zu genehmigender Antrag vor"));
         assertTrue(contentDepartmentHead.contains("http://urlaubsverwaltung/web/application/1234"));
         assertTrue("No comment in mail content", contentDepartmentHead.contains(comment.getText()));
@@ -290,7 +291,7 @@ public class MailServiceImplIT {
     public void ensureNotificationAboutNewApplicationContainsInformationAboutDepartmentVacations()
         throws MessagingException, IOException {
 
-        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "Urlaub");
+        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "application.data.vacationType.holiday");
 
         Person departmentMember = TestDataCreator.createPerson("muster", "Marlene", "Muster", "mmuster@foo.de");
         Application departmentApplication = TestDataCreator.createApplication(departmentMember, vacationType,

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImplIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/mail/MailServiceImplIT.java
@@ -39,14 +39,13 @@ import javax.mail.internet.InternetAddress;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,9 +67,8 @@ public class MailServiceImplIT {
         try {
             Properties messageProperties = PropertiesUtil.load("messages_de.properties");
 
-            Map<String, String> messages = messageProperties.entrySet().stream().collect(Collectors.toMap(e ->
-                    e.getKey().toString(),
-                e -> e.getValue().toString()));
+            Map<String, String> messages = messageProperties.entrySet().stream()
+                .collect(toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
 
             MESSAGE_SOURCE.addMessages(messages, Locale.GERMAN);
         } catch (IOException e) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/core/mail/RecipientServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/core/mail/RecipientServiceTest.java
@@ -197,7 +197,7 @@ public class RecipientServiceTest {
     }
 
     private Application getHolidayApplication(Person normalUser) {
-        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "Erholungsurlaub");
+        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "application.data.vacationType.holiday");
         return TestDataCreator.createApplication(normalUser, vacationType);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/test/TestDataCreator.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/test/TestDataCreator.java
@@ -120,7 +120,7 @@ public final class TestDataCreator {
     public static Application createApplication(Person person, DateMidnight startDate, DateMidnight endDate,
                                                 DayLength dayLength) {
 
-        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "Erholungsurlaub");
+        VacationType vacationType = TestDataCreator.createVacationType(VacationCategory.HOLIDAY, "application.data.vacationType.holiday");
 
         Application application = new Application();
         application.setPerson(person);
@@ -243,15 +243,15 @@ public final class TestDataCreator {
 
     public static VacationType createVacationType(VacationCategory category) {
 
-        return createVacationType(category, category.toString());
+        return createVacationType(category, category.getMessageKey());
     }
 
-    public static VacationType createVacationType(VacationCategory category, String displayName) {
+    public static VacationType createVacationType(VacationCategory category, String messageKey) {
 
         VacationType vacationType = new VacationType();
 
         vacationType.setCategory(category);
-        vacationType.setMessageKey(displayName);
+        vacationType.setMessageKey(messageKey);
 
         return vacationType;
     }
@@ -263,24 +263,24 @@ public final class TestDataCreator {
         VacationType vacationType1 = new VacationType();
         vacationType1.setId(1000);
         vacationType1.setCategory(VacationCategory.HOLIDAY);
-        vacationType1.setMessageKey("Erholungsurlaub");
+        vacationType1.setMessageKey("application.data.vacationType.holiday");
         vacationTypes.add(vacationType1);
 
         VacationType vacationType2 = new VacationType();
         vacationType2.setCategory(VacationCategory.SPECIALLEAVE);
-        vacationType2.setMessageKey("Sonderurlaub");
+        vacationType2.setMessageKey("application.data.vacationType.specialleave");
         vacationType2.setId(2000);
         vacationTypes.add(vacationType2);
 
         VacationType vacationType3 = new VacationType();
         vacationType3.setCategory(VacationCategory.UNPAIDLEAVE);
-        vacationType3.setMessageKey("Unbezahlter Urlaub");
+        vacationType3.setMessageKey("application.data.vacationType.unpaidleave");
         vacationType3.setId(3000);
         vacationTypes.add(vacationType3);
 
         VacationType vacationType4 = new VacationType();
         vacationType4.setCategory(VacationCategory.OVERTIME);
-        vacationType4.setMessageKey("Überstundenabbau");
+        vacationType4.setMessageKey("application.data.vacationType.overtime");
         vacationType4.setId(4000);
         vacationTypes.add(vacationType4);
 


### PR DESCRIPTION
fix email template translation of vacationtype. I do not know if this is the best option, but it does work and the tests will fail if not. So we should take some time to evaluate how spring wants to use freemarker as email templates with i18n