### PR TITLE
Build correct url of login button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### master / unreleased
 * Bugfix: Fehlende englische Übersetzung für die Urlaubsübersicht [#559](https://github.com/synyx/urlaubsverwaltung/pull/559)
+* Bugfix: Falls der 'server.servlet.context-path' gesetzt wird kann man sich nicht einloggen [#565](https://github.com/synyx/urlaubsverwaltung/pull/565)
 
 ### [urlaubsverwaltung-2.38.2](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.38.2)
 * Bugfix: Fehlerhafte Übersetzung in den Email-Templates des Urlaubtypes [#560](https://github.com/synyx/urlaubsverwaltung/pull/560)

--- a/src/main/webapp/WEB-INF/jsp/login/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/login.jsp
@@ -42,7 +42,8 @@
 
             <div class="login">
 
-                <form method="post" class="login--form" action="/login">
+                <spring:url var="LOGIN" value="/login"/>
+                <form method="post" class="login--form" action="${LOGIN}">
                     <c:if test="${param.login_error != null}">
                         <div id="login--error" class="alert alert-danger">
                           <spring:message code="login.form.error"/>


### PR DESCRIPTION
see #307 

tested with server.servlet.context-path set to "/something" then the login will be at "/something/login" and it is possible to login. If this fix will not be available. Nobody can login if using context-path.