### PR TITLE
Default constructor of SickNoteConvertForm needs to be public...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### master/unreleased
 * Add missing fmt import in overview [#628](https://github.com/synyx/urlaubsverwaltung/pull/628)
+* Fix sicknote to vacation converting [#635](https://github.com/synyx/urlaubsverwaltung/pull/635)
 
 ### [urlaubsverwaltung-2.40.0](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.40.0)
 * Improve input fields [#597](https://github.com/synyx/urlaubsverwaltung/pull/597)

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/web/SickNoteConvertForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/web/SickNoteConvertForm.java
@@ -18,18 +18,13 @@ import static java.time.ZoneOffset.UTC;
 public class SickNoteConvertForm {
 
     private Person person;
-
     private DayLength dayLength;
-
     private LocalDate startDate;
-
     private LocalDate endDate;
-
     private VacationType vacationType;
-
     private String reason;
 
-    SickNoteConvertForm() {
+    public SickNoteConvertForm() {
 
         // needed for Spring magic
     }


### PR DESCRIPTION
...to get instantiated by spring mvc to add properties through setters
because no sickNote is available as hidden input

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

❗Every contributor has to add herself/himself to [AUTHORS.md](AUTHORS.md) to grant full and irrevocable copyright to the Urlaubsverwaltung, otherwise a contribution is not possible.

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
