### PR TITLE
Fix autocompletion for sick note datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### master/unreleased
+* Fix autocompletion for sick note datepicker [#644](https://github.com/synyx/urlaubsverwaltung/pull/644)
+
 ### [urlaubsverwaltung-2.40.2](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.40.2)
 * Allow overtime entries in 0.25 hour steps [#638](https://github.com/synyx/urlaubsverwaltung/pull/638)
 * Fix jquery ui themes import [#639](https://github.com/synyx/urlaubsverwaltung/pull/639)

--- a/src/main/webapp/js/sick-notes/sick-note-form.js
+++ b/src/main/webapp/js/sick-notes/sick-note-form.js
@@ -19,9 +19,9 @@ $(document).ready(async function () {
   }
 
   var onSelect = function (selectedDate) {
-    var $to = $("#from");
+    var $to = $("#to");
 
-    if (this.id === "from") {
+    if (this.id === "from" && $to.val() === "") {
       $to.datepicker("setDate", selectedDate);
     }
   };


### PR DESCRIPTION
If a date is picked and no input is given in the to fields the from date
will be copied into to.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

❗Every contributor has to add herself/himself to [AUTHORS.md](AUTHORS.md) to grant full and irrevocable copyright to the Urlaubsverwaltung, otherwise a contribution is not possible.

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
