### PR TITLE
Generische Darstellung von Abwesenheiten beim Kalendersync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### master/unreleased
+* Make event subjects for calendar sync more generic [#198](https://github.com/synyx/urlaubsverwaltung/issues/198) + [#654](https://github.com/synyx/urlaubsverwaltung/issues/654)
 
 ### [urlaubsverwaltung-2.42.3](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.42.3)
 * Fix login issues caused by missing ldap security configuration

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
@@ -19,7 +19,6 @@ import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceTimeConfig
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceType;
 import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
-import org.synyx.urlaubsverwaltung.mail.MailService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.Role;
 import org.synyx.urlaubsverwaltung.settings.CalendarSettings;
@@ -46,7 +45,6 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
     private final ApplicationService applicationService;
     private final AccountInteractionService accountInteractionService;
     private final ApplicationCommentService commentService;
-    private final MailService mailService;
     private final ApplicationMailService applicationMailService;
     private final CalendarSyncService calendarSyncService;
     private final AbsenceMappingService absenceMappingService;
@@ -57,7 +55,6 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
     public ApplicationInteractionServiceImpl(ApplicationService applicationService,
                                              ApplicationCommentService commentService,
                                              AccountInteractionService accountInteractionService,
-                                             MailService mailService,
                                              ApplicationMailService applicationMailService, CalendarSyncService calendarSyncService,
                                              AbsenceMappingService absenceMappingService,
                                              SettingsService settingsService,
@@ -66,7 +63,6 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
         this.applicationService = applicationService;
         this.commentService = commentService;
         this.accountInteractionService = accountInteractionService;
-        this.mailService = mailService;
         this.applicationMailService = applicationMailService;
         this.calendarSyncService = calendarSyncService;
         this.absenceMappingService = absenceMappingService;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
@@ -17,7 +17,6 @@ import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMapping;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMappingService;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceTimeConfiguration;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceType;
-import org.synyx.urlaubsverwaltung.calendarintegration.absence.EventType;
 import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.mail.MailService;
@@ -119,7 +118,7 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
         AbsenceTimeConfiguration timeConfiguration = new AbsenceTimeConfiguration(calendarSettings);
 
         Optional<String> eventId = calendarSyncService.addAbsence(new Absence(application.getPerson(),
-                    application.getPeriod(), EventType.WAITING_APPLICATION, timeConfiguration));
+                    application.getPeriod(), timeConfiguration));
 
         eventId.ifPresent(s -> absenceMappingService.create(application.getId(), AbsenceType.VACATION, s));
 
@@ -231,7 +230,7 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
             CalendarSettings calendarSettings = settingsService.getSettings().getCalendarSettings();
             AbsenceTimeConfiguration timeConfiguration = new AbsenceTimeConfiguration(calendarSettings);
             calendarSyncService.update(new Absence(applicationForLeave.getPerson(), applicationForLeave.getPeriod(),
-                    EventType.ALLOWED_APPLICATION, timeConfiguration), absenceMapping.get().getEventId());
+                    timeConfiguration), absenceMapping.get().getEventId());
         }
 
         return applicationForLeave;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImpl.java
@@ -223,16 +223,6 @@ public class ApplicationInteractionServiceImpl implements ApplicationInteraction
             applicationMailService.notifyHolidayReplacement(applicationForLeave);
         }
 
-        Optional<AbsenceMapping> absenceMapping = absenceMappingService.getAbsenceByIdAndType(
-                applicationForLeave.getId(), AbsenceType.VACATION);
-
-        if (absenceMapping.isPresent()) {
-            CalendarSettings calendarSettings = settingsService.getSettings().getCalendarSettings();
-            AbsenceTimeConfiguration timeConfiguration = new AbsenceTimeConfiguration(calendarSettings);
-            calendarSyncService.update(new Absence(applicationForLeave.getPerson(), applicationForLeave.getPeriod(),
-                    timeConfiguration), absenceMapping.get().getEventId());
-        }
-
         return applicationForLeave;
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/Absence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/Absence.java
@@ -19,19 +19,16 @@ public class Absence {
     private final ZonedDateTime startDate;
     private final ZonedDateTime endDate;
     private final Person person;
-    private final EventType eventType;
     private final boolean isAllDay;
 
-    public Absence(Person person, Period period, EventType eventType,
-        AbsenceTimeConfiguration absenceTimeConfiguration) {
+    public Absence(Person person, Period period,
+                   AbsenceTimeConfiguration absenceTimeConfiguration) {
 
         Assert.notNull(person, "Person must be given");
         Assert.notNull(period, "Period must be given");
-        Assert.notNull(eventType, "Type of absence must be given");
         Assert.notNull(absenceTimeConfiguration, "Time configuration must be given");
 
         this.person = person;
-        this.eventType = eventType;
 
         ZonedDateTime periodStartDate = period.getStartDate().atStartOfDay(UTC);
         ZonedDateTime periodEndDate = period.getEndDate().atStartOfDay(UTC);
@@ -58,11 +55,6 @@ public class Absence {
             default:
                 throw new IllegalArgumentException("Invalid day length!");
         }
-    }
-
-    public EventType getEventType() {
-
-        return eventType;
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/Absence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/Absence.java
@@ -92,19 +92,7 @@ public class Absence {
 
     public String getEventSubject() {
 
-        switch (eventType) {
-            case ALLOWED_APPLICATION:
-                return String.format("Urlaub %s", person.getNiceName());
-
-            case WAITING_APPLICATION:
-                return String.format("Antrag auf Urlaub %s", person.getNiceName());
-
-            case SICKNOTE:
-                return String.format("%s krank", person.getNiceName());
-
-            default:
-                throw new IllegalStateException("Event type is not properly set.");
-        }
+        return String.format("%s abwesend", person.getNiceName());
     }
 
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/EventType.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/EventType.java
@@ -1,8 +1,0 @@
-package org.synyx.urlaubsverwaltung.calendarintegration.absence;
-
-public enum EventType {
-
-    ALLOWED_APPLICATION,
-    WAITING_APPLICATION,
-    SICKNOTE
-}

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProvider.java
@@ -47,8 +47,8 @@ public class GoogleCalendarSyncProvider implements CalendarProvider {
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
-    public static final String APPLICATION_NAME = "Urlaubsverwaltung";
-    protected static final String GOOGLEAPIS_OAUTH2_V4_TOKEN = "https://www.googleapis.com/oauth2/v4/token";
+    private static final String APPLICATION_NAME = "Urlaubsverwaltung";
+    private static final String GOOGLEAPIS_OAUTH2_V4_TOKEN = "https://www.googleapis.com/oauth2/v4/token";
 
     private Calendar googleCalendarClient;
     private int refreshTokenHashCode;

--- a/src/main/java/org/synyx/urlaubsverwaltung/settings/web/GoogleCalendarOAuthHandshakeController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/settings/web/GoogleCalendarOAuthHandshakeController.java
@@ -104,11 +104,7 @@ public class GoogleCalendarOAuthHandshakeController {
             LOG.error("Exception while handling OAuth2 callback ({}) Redirecting to google connection status page.", e.getMessage(), e);
         }
 
-        StringBuilder buf = new StringBuilder();
-        buf.append("redirect:/web/settings");
-        buf.append("#calendar");
-
-        return buf.toString();
+        return "redirect:/web/settings#calendar";
     }
 
     private static HttpResponse checkGoogleCalendar(Calendar client, Settings settings) throws IOException {

--- a/src/main/java/org/synyx/urlaubsverwaltung/settings/web/GoogleCalendarOAuthHandshakeController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/settings/web/GoogleCalendarOAuthHandshakeController.java
@@ -35,13 +35,14 @@ import java.util.Collections;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
-import static org.synyx.urlaubsverwaltung.calendarintegration.providers.google.GoogleCalendarSyncProvider.APPLICATION_NAME;
 
 @Controller
 @RequestMapping("/web")
 public class GoogleCalendarOAuthHandshakeController {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private static final String APPLICATION_NAME = "Urlaubsverwaltung";
 
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteInteractionServiceImpl.java
@@ -12,7 +12,6 @@ import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMapping;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMappingService;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceTimeConfiguration;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceType;
-import org.synyx.urlaubsverwaltung.calendarintegration.absence.EventType;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.settings.CalendarSettings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
@@ -69,7 +68,7 @@ class SickNoteInteractionServiceImpl implements SickNoteInteractionService {
         AbsenceTimeConfiguration timeConfiguration = new AbsenceTimeConfiguration(calendarSettings);
 
         Optional<String> eventId = calendarSyncService.addAbsence(new Absence(sickNote.getPerson(),
-                    sickNote.getPeriod(), EventType.SICKNOTE, timeConfiguration));
+                    sickNote.getPeriod(), timeConfiguration));
 
         eventId.ifPresent(s -> absenceMappingService.create(sickNote.getId(), AbsenceType.SICKNOTE, s));
 
@@ -94,7 +93,7 @@ class SickNoteInteractionServiceImpl implements SickNoteInteractionService {
         if (absenceMapping.isPresent()) {
             CalendarSettings calendarSettings = settingsService.getSettings().getCalendarSettings();
             AbsenceTimeConfiguration timeConfiguration = new AbsenceTimeConfiguration(calendarSettings);
-            calendarSyncService.update(new Absence(sickNote.getPerson(), sickNote.getPeriod(), EventType.SICKNOTE,
+            calendarSyncService.update(new Absence(sickNote.getPerson(), sickNote.getPeriod(),
                     timeConfiguration), absenceMapping.get().getEventId());
         }
 
@@ -124,7 +123,7 @@ class SickNoteInteractionServiceImpl implements SickNoteInteractionService {
             CalendarSettings calendarSettings = settingsService.getSettings().getCalendarSettings();
 
             calendarSyncService.update(new Absence(application.getPerson(), application.getPeriod(),
-                    EventType.ALLOWED_APPLICATION, new AbsenceTimeConfiguration(calendarSettings)), eventId);
+                    new AbsenceTimeConfiguration(calendarSettings)), eventId);
             absenceMappingService.delete(absenceMapping.get());
             absenceMappingService.create(application.getId(), AbsenceType.VACATION, eventId);
         }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
@@ -213,7 +213,7 @@ public class ApplicationInteractionServiceImplTest {
 
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, boss);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment, boss);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -236,10 +236,10 @@ public class ApplicationInteractionServiceImplTest {
     }
 
 
-    private void assertCalendarSyncIsExecuted() {
+    private void assertNoCalendarSyncIsExecuted() {
 
-        verify(calendarSyncService).update(any(Absence.class), anyString());
-        verify(absenceMappingService).getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION));
+        verifyZeroInteractions(calendarSyncService);
+        verifyZeroInteractions(absenceMappingService);
     }
 
 
@@ -269,7 +269,7 @@ public class ApplicationInteractionServiceImplTest {
 
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, boss);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment, boss);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -293,7 +293,7 @@ public class ApplicationInteractionServiceImplTest {
 
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, boss);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment, boss);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -360,7 +360,7 @@ public class ApplicationInteractionServiceImplTest {
             departmentHead);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment,
             departmentHead);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -453,7 +453,7 @@ public class ApplicationInteractionServiceImplTest {
             departmentHead);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment,
             departmentHead);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -482,7 +482,7 @@ public class ApplicationInteractionServiceImplTest {
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, secondStage);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment,
             secondStage);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -511,7 +511,7 @@ public class ApplicationInteractionServiceImplTest {
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, secondStage);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment,
             secondStage);
-        assertCalendarSyncIsExecuted();
+        assertNoCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
     }
 
@@ -538,8 +538,8 @@ public class ApplicationInteractionServiceImplTest {
         assertApplicationForLeaveHasChangedStatus(applicationForLeave, ApplicationStatus.ALLOWED, person, secondStage);
         assertApplicationForLeaveAndCommentAreSaved(applicationForLeave, ApplicationAction.ALLOWED, comment,
             secondStage);
-        assertCalendarSyncIsExecuted();
         assertAllowedNotificationIsSent(applicationForLeave);
+        verifyZeroInteractions(calendarSyncService);
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
@@ -20,7 +20,6 @@ import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMapping;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceMappingService;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceType;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
-import org.synyx.urlaubsverwaltung.mail.MailService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.Role;
@@ -62,8 +61,6 @@ public class ApplicationInteractionServiceImplTest {
     @Mock
     private AccountInteractionService accountInteractionService;
     @Mock
-    private MailService mailService;
-    @Mock
     private ApplicationMailService applicationMailService;
     @Mock
     private CalendarSyncService calendarSyncService;
@@ -81,8 +78,7 @@ public class ApplicationInteractionServiceImplTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         service = new ApplicationInteractionServiceImpl(applicationService, commentService, accountInteractionService,
-            mailService, applicationMailService, calendarSyncService, absenceMappingService, settingsService,
-                departmentService);
+            applicationMailService, calendarSyncService, absenceMappingService, settingsService, departmentService);
     }
 
 
@@ -206,7 +202,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setStatus(WAITING);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, boss)).thenReturn(new ApplicationComment(person));
 
         service.allow(applicationForLeave, boss, comment);
@@ -262,7 +257,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setTwoStageApproval(false);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, boss)).thenReturn(new ApplicationComment(person));
 
         service.allow(applicationForLeave, boss, comment);
@@ -286,7 +280,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setTwoStageApproval(true);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, boss)).thenReturn(new ApplicationComment(person));
 
         service.allow(applicationForLeave, boss, comment);
@@ -314,7 +307,7 @@ public class ApplicationInteractionServiceImplTest {
 
         verifyZeroInteractions(applicationService);
         verifyZeroInteractions(commentService);
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
         verifyZeroInteractions(calendarSyncService);
         verifyZeroInteractions(absenceMappingService);
     }
@@ -351,7 +344,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setStatus(WAITING);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, departmentHead)).thenReturn(new ApplicationComment(person));
 
         service.allow(applicationForLeave, departmentHead, comment);
@@ -423,7 +415,7 @@ public class ApplicationInteractionServiceImplTest {
 
         verifyZeroInteractions(applicationService);
         verifyZeroInteractions(commentService);
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
         verifyZeroInteractions(calendarSyncService);
         verifyZeroInteractions(absenceMappingService);
     }
@@ -442,10 +434,7 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setStatus(ApplicationStatus.TEMPORARY_ALLOWED);
         applicationForLeave.setTwoStageApproval(false);
 
-
         when(commentService.create(any(), any(), any(), any())).thenReturn(new ApplicationComment(person));
-        AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), any())).thenReturn(of(absenceMapping));
 
         service.allow(applicationForLeave, departmentHead, comment);
 
@@ -473,7 +462,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setStatus(WAITING);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, secondStage)).thenReturn(new ApplicationComment(person));
 
 
@@ -501,10 +489,7 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setTwoStageApproval(true);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, secondStage)).thenReturn(new ApplicationComment(person));
-
-
 
         service.allow(applicationForLeave, secondStage, comment);
 
@@ -530,7 +515,6 @@ public class ApplicationInteractionServiceImplTest {
         applicationForLeave.setTwoStageApproval(true);
 
         AbsenceMapping absenceMapping = TestDataCreator.anyAbsenceMapping();
-        when(absenceMappingService.getAbsenceByIdAndType(isNull(), eq(AbsenceType.VACATION))).thenReturn(of(absenceMapping));
         when(commentService.create(applicationForLeave, ApplicationAction.ALLOWED, comment, secondStage)).thenReturn(new ApplicationComment(person));
 
         service.allow(applicationForLeave, secondStage, comment);
@@ -760,7 +744,7 @@ public class ApplicationInteractionServiceImplTest {
         verify(commentService)
             .create(eq(applicationForLeave), eq(ApplicationAction.REVOKED), eq(comment), eq(person));
 
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
     }
 
 
@@ -833,7 +817,7 @@ public class ApplicationInteractionServiceImplTest {
         verify(commentService)
             .create(eq(applicationForLeave), eq(ApplicationAction.CANCELLED), eq(comment), eq(person));
 
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
     }
 
 
@@ -963,7 +947,7 @@ public class ApplicationInteractionServiceImplTest {
 
         verify(applicationForLeave, never()).setRemindDate(any(LocalDate.class));
         verifyZeroInteractions(applicationService);
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
     }
 
 
@@ -979,7 +963,7 @@ public class ApplicationInteractionServiceImplTest {
 
         verify(applicationForLeave, never()).setRemindDate(any(LocalDate.class));
         verifyZeroInteractions(applicationService);
-        verifyZeroInteractions(mailService);
+        verifyZeroInteractions(applicationMailService);
     }
 
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarMailServiceTest.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.verify;
-import static org.synyx.urlaubsverwaltung.calendarintegration.absence.EventType.ALLOWED_APPLICATION;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,7 +45,7 @@ public class CalendarMailServiceTest {
         final LocalDate endDate = LocalDate.of(2019, 5, 10);
         final Period period = new Period(startDate, endDate, FULL);
 
-        final Absence absence = new Absence(new Person(), period, ALLOWED_APPLICATION, absenceTimeConfiguration);
+        final Absence absence = new Absence(new Person(), period, absenceTimeConfiguration);
 
         Map<String, Object> model = new HashMap<>();
         model.put("calendar", calendarName);
@@ -73,7 +72,7 @@ public class CalendarMailServiceTest {
         final LocalDate endDate = LocalDate.of(2019, 5, 10);
         final Period period = new Period(startDate, endDate, FULL);
 
-        final Absence absence = new Absence(new Person(), period, ALLOWED_APPLICATION, absenceTimeConfiguration);
+        final Absence absence = new Absence(new Person(), period, absenceTimeConfiguration);
 
         Map<String, Object> model = new HashMap<>();
         model.put("calendar", calendarName);

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/AbsenceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/AbsenceTest.java
@@ -199,15 +199,10 @@ public class AbsenceTest {
         LocalDate today = LocalDate.now(UTC);
         Period period = new Period(today, today, DayLength.FULL);
 
-        BiConsumer<EventType, String> assertCorrectEventSubject = (type, subject) -> {
-            Absence absence = new Absence(person, period, type, timeConfiguration);
+        Absence absence = new Absence(person, period, EventType.WAITING_APPLICATION, timeConfiguration);
 
-            assertThat(absence.getEventType(), is(type));
-            assertThat(absence.getEventSubject(), is(subject));
-        };
+        Assert.assertNotNull("Event subject must not be null", absence.getEventSubject());
+        Assert.assertEquals("Wrong event subject", "Marlene Muster abwesend", absence.getEventSubject());
 
-        assertCorrectEventSubject.accept(EventType.WAITING_APPLICATION, "Antrag auf Urlaub Marlene Muster");
-        assertCorrectEventSubject.accept(EventType.ALLOWED_APPLICATION, "Urlaub Marlene Muster");
-        assertCorrectEventSubject.accept(EventType.SICKNOTE, "Marlene Muster krank");
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/AbsenceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/absence/AbsenceTest.java
@@ -48,17 +48,15 @@ public class AbsenceTest {
 
         Period period = new Period(start, end, DayLength.FULL);
 
-        Absence absence = new Absence(person, period, EventType.WAITING_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertNotNull("Start date must not be null", absence.getStartDate());
         Assert.assertNotNull("End date must not be null", absence.getEndDate());
         Assert.assertNotNull("Person must not be null", absence.getPerson());
-        Assert.assertNotNull("Event type must not be null", absence.getEventType());
 
         Assert.assertEquals("Wrong start date", start.atStartOfDay(UTC), absence.getStartDate());
         Assert.assertEquals("Wrong end date", end.atStartOfDay(UTC).plusDays(1), absence.getEndDate());
         Assert.assertEquals("Wrong person", person, absence.getPerson());
-        Assert.assertEquals("Wrong event type", EventType.WAITING_APPLICATION, absence.getEventType());
     }
 
 
@@ -71,17 +69,15 @@ public class AbsenceTest {
 
         Period period = new Period(start, end, DayLength.FULL);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertNotNull("Start date must not be null", absence.getStartDate());
         Assert.assertNotNull("End date must not be null", absence.getEndDate());
         Assert.assertNotNull("Person must not be null", absence.getPerson());
-        Assert.assertNotNull("Event type must not be null", absence.getEventType());
 
         Assert.assertEquals("Wrong start date", start.atStartOfDay(UTC), absence.getStartDate());
         Assert.assertEquals("Wrong end date", end.atStartOfDay(UTC).plusDays(1), absence.getEndDate());
         Assert.assertEquals("Wrong person", person, absence.getPerson());
-        Assert.assertEquals("Wrong event type", EventType.ALLOWED_APPLICATION, absence.getEventType());
     }
 
 
@@ -95,7 +91,7 @@ public class AbsenceTest {
 
         Period period = new Period(today.toLocalDate(), today.toLocalDate(), DayLength.MORNING);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertEquals("Should start at 8 am", start, absence.getStartDate());
         Assert.assertEquals("Should end at 12 pm", end, absence.getEndDate());
@@ -112,7 +108,7 @@ public class AbsenceTest {
 
         Period period = new Period(today.toLocalDate(), today.toLocalDate(), DayLength.NOON);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertEquals("Should start at 12 pm", start, absence.getStartDate());
         Assert.assertEquals("Should end at 4 pm", end, absence.getEndDate());
@@ -127,7 +123,7 @@ public class AbsenceTest {
 
         Period period = new Period(start, end, DayLength.FULL);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertTrue("Should be all day", absence.isAllDay());
     }
@@ -140,7 +136,7 @@ public class AbsenceTest {
 
         Period period = new Period(today, today, DayLength.MORNING);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertFalse("Should be not all day", absence.isAllDay());
     }
@@ -153,7 +149,7 @@ public class AbsenceTest {
 
         Period period = new Period(today, today, DayLength.NOON);
 
-        Absence absence = new Absence(person, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertFalse("Should be not all day", absence.isAllDay());
     }
@@ -162,7 +158,7 @@ public class AbsenceTest {
     @Test(expected = IllegalArgumentException.class)
     public void ensureThrowsOnNullPeriod() {
 
-        new Absence(person, null, EventType.ALLOWED_APPLICATION, timeConfiguration);
+        new Absence(person, null, timeConfiguration);
     }
 
 
@@ -171,16 +167,7 @@ public class AbsenceTest {
 
         Period period = new Period(LocalDate.now(UTC), LocalDate.now(UTC), DayLength.FULL);
 
-        new Absence(null, period, EventType.ALLOWED_APPLICATION, timeConfiguration);
-    }
-
-
-    @Test(expected = IllegalArgumentException.class)
-    public void ensureThrowsOnNullEventType() {
-
-        Period period = new Period(LocalDate.now(UTC), LocalDate.now(UTC), DayLength.FULL);
-
-        new Absence(person, period, null, timeConfiguration);
+        new Absence(null, period, timeConfiguration);
     }
 
 
@@ -189,7 +176,7 @@ public class AbsenceTest {
 
         Period period = new Period(LocalDate.now(UTC), LocalDate.now(UTC), DayLength.FULL);
 
-        new Absence(person, period, EventType.ALLOWED_APPLICATION, null);
+        new Absence(person, period, null);
     }
 
 
@@ -199,7 +186,7 @@ public class AbsenceTest {
         LocalDate today = LocalDate.now(UTC);
         Period period = new Period(today, today, DayLength.FULL);
 
-        Absence absence = new Absence(person, period, EventType.WAITING_APPLICATION, timeConfiguration);
+        Absence absence = new Absence(person, period, timeConfiguration);
 
         Assert.assertNotNull("Event subject must not be null", absence.getEventSubject());
         Assert.assertEquals("Wrong event subject", "Marlene Muster abwesend", absence.getEventSubject());

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProviderServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProviderServiceTest.java
@@ -39,10 +39,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.synyx.urlaubsverwaltung.calendarintegration.providers.google.GoogleCalendarSyncProvider.APPLICATION_NAME;
-import static org.synyx.urlaubsverwaltung.calendarintegration.providers.google.GoogleCalendarSyncProvider.GOOGLEAPIS_OAUTH2_V4_TOKEN;
 
 public class GoogleCalendarSyncProviderServiceTest {
+
+    private static final String APPLICATION_NAME = "Urlaubsverwaltung";
+    private static final String GOOGLEAPIS_OAUTH2_V4_TOKEN = "https://www.googleapis.com/oauth2/v4/token";
 
     private static String CLIENT_ID;
     private static String CLIENT_SECRET;

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProviderServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/providers/google/GoogleCalendarSyncProviderServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.synyx.urlaubsverwaltung.calendarintegration.CalendarMailService;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.Absence;
 import org.synyx.urlaubsverwaltung.calendarintegration.absence.AbsenceTimeConfiguration;
-import org.synyx.urlaubsverwaltung.calendarintegration.absence.EventType;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.period.Period;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -132,13 +131,13 @@ public class GoogleCalendarSyncProviderServiceTest {
         Period period = new Period(LocalDate.now(UTC), LocalDate.now(UTC), DayLength.MORNING);
 
         AbsenceTimeConfiguration config = new AbsenceTimeConfiguration(mock(CalendarSettings.class));
-        Absence absence = new Absence(person, period, EventType.WAITING_APPLICATION, config);
+        Absence absence = new Absence(person, period, config);
 
         int eventsBeforeAdd = getCalendarEventCount();
         String eventId = googleCalendarSyncProvider.add(absence, calendarSettings).get();
         int eventsAfterAdd = getCalendarEventCount();
 
-        Absence absenceUpdate = new Absence(person, period, EventType.SICKNOTE, config);
+        Absence absenceUpdate = new Absence(person, period, config);
         googleCalendarSyncProvider.update(absenceUpdate, eventId, calendarSettings);
         int eventsAfterUpdate = getCalendarEventCount();
 


### PR DESCRIPTION
Einfacher Fix für #198 und #654 

Termine, die über den Kalendersync angelegt werden, werden nun generisch dargestellt mit "abwesend" statt "krank" oder "Urlaub".

Hinweis: Dies gilt auch für Urlaubsanträge, die noch nicht genehmigt wurden.