### PR TITLE
Ldap should used the returned person when saved

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/PersonServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/PersonServiceImpl.java
@@ -35,7 +35,7 @@ class PersonServiceImpl implements PersonService {
     public Person create(String loginName, String lastName, String firstName, String email,
                          List<MailNotification> notifications, List<Role> permissions) {
 
-        Person person = new Person(loginName, lastName, firstName, email);
+        final Person person = new Person(loginName, lastName, firstName, email);
 
         person.setNotifications(notifications);
         person.setPermissions(permissions);

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/LdapSyncService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/LdapSyncService.java
@@ -6,18 +6,19 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
-import org.synyx.urlaubsverwaltung.person.MailNotification;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.person.Role;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Collections.singletonList;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_USER;
+import static org.synyx.urlaubsverwaltung.person.Role.USER;
 
 
 /**
@@ -55,11 +56,10 @@ public class LdapSyncService {
         lastName.ifPresent(person::setLastName);
         mailAddress.ifPresent(person::setEmail);
 
-        personService.save(person);
+        final Person savedPerson = personService.save(person);
+        LOG.info("Successfully synced person data: {}", savedPerson);
 
-        LOG.info("Successfully synced person data: {}", person);
-
-        return person;
+        return savedPerson;
     }
 
 
@@ -79,9 +79,8 @@ public class LdapSyncService {
 
         Assert.notNull(login, "Missing login name!");
 
-        Person person = personService.create(login, lastName.orElse(null), firstName.orElse(null),
-                mailAddress.orElse(null), Collections.singletonList(MailNotification.NOTIFICATION_USER),
-                Collections.singletonList(Role.USER));
+        final Person person = personService.create(login, lastName.orElse(null), firstName.orElse(null),
+                mailAddress.orElse(null), singletonList(NOTIFICATION_USER), singletonList(USER));
 
         LOG.info("Successfully auto-created person: {}", person);
 


### PR DESCRIPTION
<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
