### PR TITLE
fix api result for user without active workingtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### [urlaubsverwaltung-2.44.1](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.44.1)
+* Fix availability and workdays api: Use http status 204 (instead of 500) for no working days present for given user [#728](https://github.com/synyx/urlaubsverwaltung/issues/728)
+
 ### [urlaubsverwaltung-2.44.0](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-2.44.0)
 * Added comment in sick-note creation dialog [#472](https://github.com/synyx/urlaubsverwaltung/issues/472)
 * Quickfix for better overview about department members: add link to department

--- a/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
@@ -9,8 +9,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.synyx.urlaubsverwaltung.availability.api.FreeTimeAbsenceException;
+import org.synyx.urlaubsverwaltung.workingtime.NoValidWorkingTimeException;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 
 /**
@@ -18,6 +21,14 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
  */
 @ControllerAdvice(annotations = RestController.class)
 public class ApiExceptionHandlerControllerAdvice {
+
+    @ResponseStatus(NO_CONTENT)
+    @ExceptionHandler({NoValidWorkingTimeException.class, FreeTimeAbsenceException.class})
+    @ResponseBody
+    public ErrorResponse handleException(IllegalStateException exception) {
+
+        return new ErrorResponse(NO_CONTENT, exception);
+    }
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler({ NumberFormatException.class, IllegalArgumentException.class })

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceException.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceException.java
@@ -1,0 +1,22 @@
+package org.synyx.urlaubsverwaltung.availability.api;
+
+/**
+ * Exception that is thrown when no valid WorkingTime can be found for a period.
+ */
+public class FreeTimeAbsenceException extends IllegalStateException {
+
+    private final String message;
+
+    FreeTimeAbsenceException(String message) {
+
+        super(message);
+
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+
+        return message;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
@@ -70,7 +70,7 @@ class FreeTimeAbsenceProvider extends AbstractTimedAbsenceProvider {
                 currentDay);
 
         if (!workingTimeOrNot.isPresent()) {
-            throw new IllegalStateException("Person " + person + " does not have workingTime configured");
+            throw new FreeTimeAbsenceException("Person " + person + " does not have workingTime configured");
         }
 
         WorkingTime workingTime = workingTimeOrNot.get();

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/NoValidWorkingTimeException.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/NoValidWorkingTimeException.java
@@ -7,7 +7,7 @@ public class NoValidWorkingTimeException extends IllegalStateException {
 
     private final String message;
 
-    public NoValidWorkingTimeException(String message) {
+    NoValidWorkingTimeException(String message) {
 
         super(message);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/AvailabilityControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/AvailabilityControllerTest.java
@@ -11,10 +11,12 @@ import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.api.ApiExceptionHandlerControllerAdvice;
 import org.synyx.urlaubsverwaltung.testdatacreator.TestDataCreator;
+import org.synyx.urlaubsverwaltung.workingtime.NoValidWorkingTimeException;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -62,6 +64,17 @@ public class AvailabilityControllerTest {
         verify(availabilityService)
             .getPersonsAvailabilities(eq(LocalDate.of(2016, 1, 1)),
                 eq(LocalDate.of(2016, 1, 31)), eq(testPerson));
+    }
+
+    @Test
+    public void ensureNoContentAvailabilitiesForGivenPersonWithoutConfiguredWorkingTime() throws Exception {
+
+        when(availabilityService.getPersonsAvailabilities(any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenThrow(NoValidWorkingTimeException.class);
+        perform(get("/api/availabilities")
+            .param("from", "2015-01-01")
+            .param("to", "2015-01-31")
+            .param("person", LOGIN))
+            .andExpect(status().isNoContent());
     }
 
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
@@ -7,9 +7,9 @@ import org.mockito.Mockito;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.settings.FederalState;
+import org.synyx.urlaubsverwaltung.testdatacreator.TestDataCreator;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
-import org.synyx.urlaubsverwaltung.testdatacreator.TestDataCreator;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,6 +77,18 @@ public class FreeTimeAbsenceProviderTest {
         Assert.assertTrue("wrong absence ratio", BigDecimal.ONE.compareTo(absencesList.get(0).getRatio()) == 0);
     }
 
+    @Test(expected = FreeTimeAbsenceException.class)
+    public void ensureExceptionWhenPersonWorkingTimeIsNotAvailable() {
+
+        LocalDate firstSundayIn2016 = LocalDate.of(2016, 1, 3);
+
+        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(testPerson),
+            eq(firstSundayIn2016)))
+            .thenReturn(Optional.empty());
+
+        TimedAbsenceSpans updatedTimedAbsenceSpans = freeTimeAbsenceProvider.addAbsence(emptyTimedAbsenceSpans,
+            testPerson, firstSundayIn2016);
+    }
 
     @Test
     public void ensureDoesNotCallNextProviderIfAlreadyAbsentForWholeDay() {


### PR DESCRIPTION
return 204 (no content) instead of 500 (internal server error)

effected apis:
* /availability
* /workingdays

fixes #728 (for v2.x)

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
