### PR TITLE
Add thuringia childrens day holiday

### DIFF
--- a/src/main/resources/Holidays_de.xml
+++ b/src/main/resources/Holidays_de.xml
@@ -137,5 +137,10 @@
       <tns:Fixed month="MARCH" day="8" descriptionPropertiesKey="INTERNATIONAL_WOMAN" validFrom="2019"/>
     </tns:Holidays>
   </tns:SubConfigurations>
+  <tns:SubConfigurations hierarchy="th" description="Thüringen">
+    <tns:Holidays>
+      <tns:Fixed month="SEPTEMBER" day="20" descriptionPropertiesKey="CHILDRENS_DAY" validFrom="2019"/>
+    </tns:Holidays>
+  </tns:SubConfigurations>
 </tns:Configuration>
 


### PR DESCRIPTION
This adds the childrens day as holiday for thuringia.
Related newspaper entry: 
https://www.maz-online.de/Nachrichten/Politik/Neuer-Feiertag-in-Thueringen-Weltkindertag-ab-201