### PR TITLE
Reduce logging on build

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,31 @@
+# DATABASE
+spring.datasource.url=jdbc:mariadb://localhost:3308/urlaubsverwaltung
+spring.datasource.username=urlaubsverwaltung
+spring.datasource.password=urlaubsverwaltung
+
+# see https://stackoverflow.com/questions/32968527/hibernate-sequence-doesnt-exist
+spring.jpa.properties.hibernate.id.new_generator_mappings=false
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+spring.liquibase.change-log=classpath:/dbchangelogs/changelogmaster.xml
+
+# EMAIL
+spring.freemarker.template-loader-path=classpath:/org/synyx/urlaubsverwaltung/core/mail/
+
+# LOGGING
+logging.level.root=warn
+spring.main.banner-mode=off
+logging.file=
+
+# ACTUATOR
+info.app.name=@project.name@
+info.app.version=@project.version@
+
+# SECURITY
+uv.security.auth=default
+
+# CRON JOBS
+uv.cron.updateHolidaysAccounts=0 0 5 1 1 *
+uv.cron.endOfSickPayNotification=0 0 6 * * *
+uv.cron.daysBeforeWaitingApplicationsReminderNotification=0 0 7 * * *
+uv.cron.ldapSync=0 0 1 * * ?

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<configuration>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+  <root level="warn"/>
+</configuration>


### PR DESCRIPTION
* Adds logback-test.xml to only show warning for surefire and failsafe
* Adds test application properties that will only log warning for
  the application in the verify phase

This will decrease the useless logging on build to hopefully 0%. Only warnings and important information will be logged. All the debug and info logging is disabled.

On the other side the application.properties in the test resource directory shows what is at this pointe really needed to start the application.