### PR TITLE
Remove liquibase context from properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,6 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 spring.jpa.hibernate.ddl-auto=none
 
 spring.liquibase.change-log=classpath:/dbchangelogs/changelogmaster.xml
-spring.liquibase.contexts=p
 
 # VIEW -----------------------------------------------------------------------------------------------------------------
 spring.mvc.view.prefix=/WEB-INF/jsp/


### PR DESCRIPTION
Removed liquibase context 'p' that is not needed and used?