### PR TITLE
Allow user to get their own data via the api

### DIFF
--- a/src/main/docker/mariadb/Dockerfile
+++ b/src/main/docker/mariadb/Dockerfile
@@ -5,6 +5,8 @@ ENV MYSQL_USER=urlaubsverwaltung \
     MYSQL_PASSWORD=urlaubsverwaltung \
     MYSQL_RANDOM_ROOT_PASSWORD=yes
 
+ADD more-connections.cnf /etc/mysql/conf.d/
+
 HEALTHCHECK --interval=10s --timeout=3s --start-period=15s \
   CMD /usr/bin/mysql --user=urlaubsverwaltung --password=urlaubsverwaltung --execute "SHOW DATABASES;"
 

--- a/src/main/docker/mariadb/more-connections.cnf
+++ b/src/main/docker/mariadb/more-connections.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_connections     = 1000

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/api/AbsenceApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/api/AbsenceApiController.java
@@ -54,7 +54,7 @@ public class AbsenceApiController {
         notes = "Get all absences for a certain period and person"
     )
     @GetMapping("/absences")
-    @PreAuthorize(SecurityRules.IS_OFFICE)
+    @PreAuthorize(SecurityRules.IS_OFFICE + " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)")
     public ResponseWrapper<DayAbsenceList> personsVacations(
         @ApiParam(value = "Year to get the absences for", defaultValue = RestApiDateFormat.EXAMPLE_YEAR)
         @RequestParam("year")

--- a/src/main/java/org/synyx/urlaubsverwaltung/api/config/RestApiSecurityConfig.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/api/config/RestApiSecurityConfig.java
@@ -22,7 +22,6 @@ public class RestApiSecurityConfig extends WebSecurityConfigurerAdapter {
                 .httpBasic()
             .and()
                 .authorizeRequests()
-                    .antMatchers("/api/sicknotes/**").hasAuthority("OFFICE")
                     .antMatchers("/api/**").authenticated()
                     .anyRequest().authenticated();
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiController.java
@@ -55,7 +55,7 @@ public class PublicHolidayApiController {
         value = "Get all public holidays for a certain period", notes = "Get all public holidays for a certain period"
     )
     @GetMapping("/holidays")
-    @PreAuthorize(SecurityRules.IS_OFFICE)
+    @PreAuthorize(SecurityRules.IS_OFFICE + " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)")
     public ResponseWrapper<PublicHolidayListResponse> getPublicHolidays(
         @ApiParam(value = "Year to get the public holidays for", defaultValue = RestApiDateFormat.EXAMPLE_YEAR)
         @RequestParam("year")

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiController.java
@@ -56,7 +56,7 @@ public class VacationApiController {
             + "Information only reachable for users with role office."
     )
     @GetMapping("/vacations")
-    @PreAuthorize(SecurityRules.IS_OFFICE)
+    @PreAuthorize(SecurityRules.IS_OFFICE + " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)")
     public ResponseWrapper<VacationListResponse> vacations(
         @ApiParam(value = "Get vacations for department members of person")
         @RequestParam(value = "departmentMembers", required = false)

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurity.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurity.java
@@ -1,0 +1,43 @@
+package org.synyx.urlaubsverwaltung.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.stereotype.Component;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+
+import java.util.Optional;
+
+@Component
+public class UserApiMethodSecurity {
+
+    private PersonService personService;
+
+    @Autowired
+    public UserApiMethodSecurity(PersonService personService) {
+        this.personService = personService;
+    }
+
+    public boolean isSamePersonId(Authentication authentication, Integer userId) {
+
+        final Optional<Person> person = personService.getPersonByID(userId);
+        if (person.isEmpty()) {
+            return false;
+        }
+
+        boolean allowed = false;
+        if (authentication.getPrincipal() instanceof org.springframework.security.ldap.userdetails.Person) {
+            final String username = ((org.springframework.security.ldap.userdetails.Person) authentication.getPrincipal()).getUsername();
+            allowed = username.equals(person.get().getLoginName());
+        } else if (authentication.getPrincipal() instanceof User) {
+            allowed = ((User) authentication.getPrincipal()).getUsername().equals(person.get().getLoginName());
+        } else if(authentication.getPrincipal() instanceof DefaultOidcUser) {
+            final String username = ((DefaultOidcUser) authentication.getPrincipal()).getIdToken().getSubject();
+            allowed = username.equals(person.get().getLoginName());
+        }
+
+        return allowed;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/simple/SimpleAuthenticationProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/simple/SimpleAuthenticationProvider.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.StandardPasswordEncoder;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -70,7 +71,7 @@ public class SimpleAuthenticationProvider implements AuthenticationProvider {
         if (encoder.matches(rawPassword, userPassword)) {
             LOG.info("User '{}' has signed in with roles: {}", username, grantedAuthorities);
 
-            return new UsernamePasswordAuthenticationToken(username, userPassword, grantedAuthorities);
+            return new UsernamePasswordAuthenticationToken(new User(username, userPassword, grantedAuthorities), userPassword, grantedAuthorities);
         } else {
             LOG.info("User '{}' has tried to sign in with a wrong password", username);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/api/SickNoteApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/api/SickNoteApiController.java
@@ -13,7 +13,6 @@ import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
-import org.synyx.urlaubsverwaltung.security.SecurityRules;
 import org.synyx.urlaubsverwaltung.sicknote.SickNote;
 import org.synyx.urlaubsverwaltung.sicknote.SickNoteService;
 
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
+import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_OFFICE;
 
 
 @Api("Sick Notes: Get all sick notes for a certain period")
@@ -47,7 +47,7 @@ public class SickNoteApiController {
         + "Information only reachable for users with role office."
     )
     @GetMapping("/sicknotes")
-    @PreAuthorize(SecurityRules.IS_OFFICE)
+    @PreAuthorize(IS_OFFICE + " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)")
     public ResponseWrapper<SickNoteListResponse> sickNotes(
         @ApiParam(value = "Start date with pattern yyyy-MM-dd", defaultValue = RestApiDateFormat.EXAMPLE_FIRST_DAY_OF_YEAR)
         @RequestParam(value = "from")

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiController.java
@@ -54,7 +54,7 @@ public class WorkDayApiController {
         notes = "The calculation depends on the working time of the person."
     )
     @GetMapping("/workdays")
-    @PreAuthorize(SecurityRules.IS_OFFICE)
+    @PreAuthorize(SecurityRules.IS_OFFICE + " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)")
     public ResponseWrapper<WorkDayResponse> workDays(
         @ApiParam(value = "Start date with pattern yyyy-MM-dd", defaultValue = RestApiDateFormat.EXAMPLE_YEAR + "-01-01")
         @RequestParam("from")

--- a/src/test/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiControllerSecurityIT.java
@@ -117,6 +117,37 @@ public class PublicHolidayApiControllerSecurityIT {
         resultActions.andExpect(status().isOk());
     }
 
+    @Test
+    @WithMockUser(username = "user")
+    public void getHolidaysWithSameUserIsOk() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+        when(workingTimeService.getFederalStateForPerson(any(Person.class), any(LocalDate.class))).thenReturn(BAYERN);
+
+        final ResultActions resultActions = perform(get("/api/holidays")
+            .param("year", "2016")
+            .param("month", "11")
+            .param("person", "1"));
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "differentUser")
+    public void getHolidaysWithDifferentUserIsForbidden() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+
+        final ResultActions resultActions = perform(get("/api/holidays")
+            .param("year", "2016")
+            .param("month", "11")
+            .param("person", "1"));
+        resultActions.andExpect(status().isForbidden());
+    }
+
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
         return MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build().perform(builder);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiControllerSecurityIT.java
@@ -4,16 +4,23 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.synyx.urlaubsverwaltung.application.service.ApplicationService;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -24,6 +31,13 @@ public class VacationApiControllerSecurityIT {
 
     @Autowired
     private WebApplicationContext context;
+
+    @MockBean
+    private PersonService personService;
+    @MockBean
+    private ApplicationService applicationService;
+    @MockBean
+    private DepartmentService departmentService;
 
     private DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
@@ -108,6 +122,42 @@ public class VacationApiControllerSecurityIT {
             .param("to", dtf.format(now.plusDays(5))));
 
         resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    public void getVacationsForSameUserIsOk() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+
+        final LocalDateTime now = LocalDateTime.now();
+        final ResultActions resultActions = perform(get("/api/vacations")
+            .param("from", dtf.format(now))
+            .param("to", dtf.format(now.plusDays(5)))
+            .param("person", "1")
+        );
+
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "differentUser")
+    public void getVacationsForDifferentUserIsForbidden() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+
+        final LocalDateTime now = LocalDateTime.now();
+        final ResultActions resultActions = perform(get("/api/vacations")
+            .param("from", dtf.format(now))
+            .param("to", dtf.format(now.plusDays(5)))
+            .param("person", "1")
+        );
+
+        resultActions.andExpect(status().isForbidden());
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurityTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurityTest.java
@@ -1,0 +1,127 @@
+package org.synyx.urlaubsverwaltung.security;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserApiMethodSecurityTest {
+
+    private UserApiMethodSecurity sut;
+
+    @Mock
+    private PersonService personService;
+
+    @Before
+    public void setUp() {
+        sut = new UserApiMethodSecurity(personService);
+    }
+
+    @Test
+    public void isSamePersonIdNoPerson() {
+
+        when(personService.getPersonByID(1)).thenReturn(Optional.empty());
+
+        final boolean isSamePerson = sut.isSamePersonId(mock(Authentication.class), 1);
+        assertThat(isSamePerson).isFalse();
+    }
+
+    @Test
+    public void isSamePersonIdWithOidc() {
+
+        final String username = "Hans";
+        final OidcIdToken token = new OidcIdToken("token", Instant.now(), Instant.now(), Map.of(IdTokenClaimNames.SUB, username));
+        final DefaultOidcUser oidcUser = new DefaultOidcUser(List.of(new OidcUserAuthority(token)), token);
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(oidcUser, List.of());
+
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person(username, "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isTrue();
+    }
+
+    @Test
+    public void isNotSamePersonIdWithOidc() {
+
+        final OidcIdToken token = new OidcIdToken("token", Instant.now(), Instant.now(), Map.of(IdTokenClaimNames.SUB, "username"));
+        final DefaultOidcUser oidcUser = new DefaultOidcUser(List.of(new OidcUserAuthority(token)), token);
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(oidcUser, List.of());
+
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person("differentUsername", "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isFalse();
+    }
+
+    @Test
+    public void isSamePersonIdWithSimpleAuthentication() {
+
+        final String username = "Hans";
+        final User user = new User(username, "password", List.of());
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(user, List.of());
+
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person(username, "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isTrue();
+    }
+
+    @Test
+    public void isDifferentPersonIdWithSimpleAuthentication() {
+
+        final User user = new User("username", "password", List.of());
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(user, List.of());
+
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person("differentUsername", "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isFalse();
+    }
+
+    @Test
+    public void isSamePersonIdWithLdap() {
+
+        final String username = "Hans";
+        final org.springframework.security.ldap.userdetails.Person ldapUser = mock(org.springframework.security.ldap.userdetails.Person.class);
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(ldapUser, List.of());
+
+        when(ldapUser.getUsername()).thenReturn(username);
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person(username, "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isTrue();
+    }
+
+    @Test
+    public void isDifferentPersonIdWithLdap() {
+
+        final org.springframework.security.ldap.userdetails.Person ldapUser = mock(org.springframework.security.ldap.userdetails.Person.class);
+        final TestingAuthenticationToken authentication = new TestingAuthenticationToken(ldapUser, List.of());
+
+        when(ldapUser.getUsername()).thenReturn("username");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(new Person("differentUsername", "lastname", "firstName", "email")));
+
+        final boolean isSamePerson = sut.isSamePersonId(authentication, 1);
+        assertThat(isSamePerson).isFalse();
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiControllerSecurityIT.java
@@ -135,6 +135,39 @@ public class WorkDayApiControllerSecurityIT {
         resultActions.andExpect(status().isOk());
     }
 
+    @Test
+    @WithMockUser(username = "user")
+    public void getWorkdaysWithSameUserIsOk() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+        when(workDaysService.getWorkDays(any(), any(), any(), any())).thenReturn(BigDecimal.ONE);
+
+        final ResultActions resultActions = perform(get("/api/workdays")
+            .param("from", "2016-01-04")
+            .param("to", "2016-01-04")
+            .param("length", "FULL")
+            .param("person", "1"));
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "differentUser")
+    public void getWorkdaysWithDifferentUserIsForbidden() throws Exception {
+
+        final Person person = new Person();
+        person.setLoginName("user");
+        when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
+
+        final ResultActions resultActions = perform(get("/api/workdays")
+            .param("from", "2016-01-04")
+            .param("to", "2016-01-04")
+            .param("length", "FULL")
+            .param("person", "1"));
+        resultActions.andExpect(status().isForbidden());
+    }
+
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
         return MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build().perform(builder);
     }


### PR DESCRIPTION
fixes #824

I do not think that this is the best solution, because we create more database interactions with every call to the api. But we document, with the tests, where we need it and it works for now. A better solution could be to have a own UVPrinciple with the id given for every security provider we have.