### PR TITLE
Upgrade jollyday to 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add default workdays to the configuration properties [828](https://github.com/synyx/urlaubsverwaltung/pull/828)
 * Upgrade spring boot parent to 2.1.9
 * Upgrade google api client to 1.25.0
+* Upgrade jollyday to 0.5.9
 * rename loginName to username [839](https://github.com/synyx/urlaubsverwaltung/pull/839)
 
 ### [urlaubsverwaltung-3.0.0.RC7](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-3.0.0.RC7)

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <java.version>11</java.version>
     <mail.version>1.4.7</mail.version>
     <mock-javamail.version>1.9</mock-javamail.version>
-    <jollyday.version>0.5.8</jollyday.version>
+    <jollyday.version>0.5.9</jollyday.version>
     <ews-java-api.version>2.0</ews-java-api.version>
     <httpcore.version>4.4.1</httpcore.version>
     <httpclient.version>4.5</httpclient.version>


### PR DESCRIPTION
https://github.com/svendiedrichsen/jollyday/commits/v_0_5_9

damit können wir den Weltkindertag wieder rausnehmen. der ist hier dabei.


<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
