### PR TITLE
OidcIdToken expiresAt should be consistently later than issuedAt

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurityTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurityTest.java
@@ -50,7 +50,8 @@ public class UserApiMethodSecurityTest {
     public void isSamePersonIdWithOidc() {
 
         final String username = "Hans";
-        final OidcIdToken token = new OidcIdToken("token", Instant.now(), Instant.now(), Map.of(IdTokenClaimNames.SUB, username));
+        final Instant now = Instant.now();
+        final OidcIdToken token = new OidcIdToken("token", now, now.plusSeconds(60), Map.of(IdTokenClaimNames.SUB, username));
         final DefaultOidcUser oidcUser = new DefaultOidcUser(List.of(new OidcUserAuthority(token)), token);
         final TestingAuthenticationToken authentication = new TestingAuthenticationToken(oidcUser, List.of());
 
@@ -63,7 +64,8 @@ public class UserApiMethodSecurityTest {
     @Test
     public void isNotSamePersonIdWithOidc() {
 
-        final OidcIdToken token = new OidcIdToken("token", Instant.now(), Instant.now().plusSeconds(5), Map.of(IdTokenClaimNames.SUB, "username"));
+        final Instant now = Instant.now();
+        final OidcIdToken token = new OidcIdToken("token", now, now.plusSeconds(60), Map.of(IdTokenClaimNames.SUB, "username"));
         final DefaultOidcUser oidcUser = new DefaultOidcUser(List.of(new OidcUserAuthority(token)), token);
         final TestingAuthenticationToken authentication = new TestingAuthenticationToken(oidcUser, List.of());
 


### PR DESCRIPTION
...this only worked because, most of the time, the double instant.now
calls are a little bit different.
