### PR TITLE
Change default security auth mechanism to default

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/security/SecurityConfigurationProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/SecurityConfigurationProperties.java
@@ -15,7 +15,7 @@ public class SecurityConfigurationProperties {
         ACTIVEDIRECTORY
     }
 
-    private AuthenticationProvider auth;
+    private AuthenticationProvider auth = AuthenticationProvider.DEFAULT;
 
     public AuthenticationProvider getAuth() {
         return auth;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,7 +43,7 @@ server.compression.min-response-size=1024
 
 # AUTHENTICATION -------------------------------------------------------------------------------------------------------
 # Choose one: default, ldap, activedirectory, oidc
-uv.security.auth=activedirectory
+uv.security.auth=default
 
 # LDAP / ACTIVE DIRECTORY ATTRIBUTES -----------------------------------------------------------------------------------
 # Attribute that identifies a user by unique username within LDAP / Active Directory


### PR DESCRIPTION
Change the default auth mechanism to 'default' so the application will start and does not ask for ldap/ad/oidc information on the startup. On the other hand we do not know what kind of authorization/authentication mechanism a user will have. So the default should be the best default :)

Hint: Needs to be documented after merge.