### PR TITLE
Remove distribution repository from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,19 +53,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <distributionManagement>
-    <repository>
-      <id>releases.nexus.synyx.de</id>
-      <name>Synyx Nexus: Releases</name>
-      <url>https://nexus.synyx.de/content/repositories/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>snapshots.nexus.synyx.de</id>
-      <name>Synyx Nexus: Snapshots</name>
-      <url>https://nexus.synyx.de/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <repositories>
     <repository>
       <id>sonatype-snapshots</id>


### PR DESCRIPTION
...we do not need this anymore, because the jars are distributed on
github and on dockerhub the docker images.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
