### PR TITLE
Rename to PublicHolidayAbsenceProvider

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/AbstractTimedAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/AbstractTimedAbsenceProvider.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 /**
  * This class is used to build a chain of responsibility (https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern)
  * which defines in which order absences are to be checked. This ensures, that multiple overlapping absences for a
- * certain date do not sum up to more than a full day. Priorities are: free time > holidays > sick > vacation
+ * certain date do not sum up to more than a full day. Priorities are: free time > public holidays > sick > vacation
  */
 abstract class AbstractTimedAbsenceProvider {
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
@@ -21,7 +21,7 @@ class FreeTimeAbsenceProvider extends AbstractTimedAbsenceProvider {
     private final WorkingTimeService workingTimeService;
 
     @Autowired
-    FreeTimeAbsenceProvider(HolidayAbsenceProvider nextPriorityProvider, WorkingTimeService workingTimeService) {
+    FreeTimeAbsenceProvider(PublicHolidayAbsenceProvider nextPriorityProvider, WorkingTimeService workingTimeService) {
 
         super(nextPriorityProvider);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProvider.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.synyx.urlaubsverwaltung.availability.api.TimedAbsence.Type.HOLIDAY;
+import static org.synyx.urlaubsverwaltung.availability.api.TimedAbsence.Type.PUBLIC_HOLIDAY;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.period.DayLength.NOON;
 import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
@@ -60,15 +60,15 @@ class PublicHolidayAbsenceProvider extends AbstractTimedAbsenceProvider {
         BigDecimal expectedWorkingDuration = publicHolidaysService.getWorkingDurationOfDate(currentDay,
             getFederalState(currentDay, person));
 
-        boolean fullDayHoliday = expectedWorkingDuration.compareTo(ZERO.getDuration()) == 0;
-        boolean halfDayHoliday = expectedWorkingDuration.compareTo(NOON.getDuration()) == 0;
+        boolean fullDayPublicHoliday = expectedWorkingDuration.compareTo(ZERO.getDuration()) == 0;
+        boolean halfDayPublicHoliday = expectedWorkingDuration.compareTo(NOON.getDuration()) == 0;
 
         TimedAbsence absence = null;
 
-        if (fullDayHoliday) {
-            absence = new TimedAbsence(FULL, HOLIDAY);
-        } else if (halfDayHoliday) {
-            absence = new TimedAbsence(NOON, HOLIDAY);
+        if (fullDayPublicHoliday) {
+            absence = new TimedAbsence(FULL, PUBLIC_HOLIDAY);
+        } else if (halfDayPublicHoliday) {
+            absence = new TimedAbsence(NOON, PUBLIC_HOLIDAY);
         }
 
         return Optional.ofNullable(absence);

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProvider.java
@@ -19,14 +19,14 @@ import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
 
 
 @Service
-class HolidayAbsenceProvider extends AbstractTimedAbsenceProvider {
+class PublicHolidayAbsenceProvider extends AbstractTimedAbsenceProvider {
 
     private final PublicHolidaysService publicHolidaysService;
     private final WorkingTimeService workingTimeService;
 
     @Autowired
-    HolidayAbsenceProvider(SickDayAbsenceProvider nextPriorityProvider, PublicHolidaysService publicHolidaysService,
-                           WorkingTimeService workingTimeService) {
+    PublicHolidayAbsenceProvider(SickDayAbsenceProvider nextPriorityProvider, PublicHolidaysService publicHolidaysService,
+                                 WorkingTimeService workingTimeService) {
 
         super(nextPriorityProvider);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/TimedAbsence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/TimedAbsence.java
@@ -14,7 +14,6 @@ class TimedAbsence {
 
         VACATION,
         SICK_NOTE,
-        WORK,
         FREETIME,
         PUBLIC_HOLIDAY
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/TimedAbsence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/TimedAbsence.java
@@ -16,7 +16,7 @@ class TimedAbsence {
         SICK_NOTE,
         WORK,
         FREETIME,
-        HOLIDAY
+        PUBLIC_HOLIDAY
     }
 
     private final Type type;

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
@@ -29,7 +29,7 @@ public class FreeTimeAbsenceProviderTest {
 
     private FreeTimeAbsenceProvider freeTimeAbsenceProvider;
 
-    private HolidayAbsenceProvider holidayAbsenceProvider;
+    private PublicHolidayAbsenceProvider publicHolidayAbsenceProvider;
     private WorkingTimeService workingTimeService;
     private TimedAbsenceSpans emptyTimedAbsenceSpans;
     private Person testPerson;
@@ -37,13 +37,13 @@ public class FreeTimeAbsenceProviderTest {
     @Before
     public void setUp() {
 
-        holidayAbsenceProvider = mock(HolidayAbsenceProvider.class);
+        publicHolidayAbsenceProvider = mock(PublicHolidayAbsenceProvider.class);
         setupDefaultWorkingTimeService();
 
         emptyTimedAbsenceSpans = new TimedAbsenceSpans(new ArrayList<>());
         testPerson = TestDataCreator.createPerson();
 
-        freeTimeAbsenceProvider = new FreeTimeAbsenceProvider(holidayAbsenceProvider, workingTimeService);
+        freeTimeAbsenceProvider = new FreeTimeAbsenceProvider(publicHolidayAbsenceProvider, workingTimeService);
     }
 
 
@@ -97,7 +97,7 @@ public class FreeTimeAbsenceProviderTest {
 
         freeTimeAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, firstSundayIn2016);
 
-        Mockito.verifyNoMoreInteractions(holidayAbsenceProvider);
+        Mockito.verifyNoMoreInteractions(publicHolidayAbsenceProvider);
     }
 
 
@@ -108,7 +108,7 @@ public class FreeTimeAbsenceProviderTest {
 
         freeTimeAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, standardWorkingDay);
 
-        verify(holidayAbsenceProvider, times(1))
+        verify(publicHolidayAbsenceProvider, times(1))
             .checkForAbsence(emptyTimedAbsenceSpans, testPerson, standardWorkingDay);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
@@ -84,7 +84,7 @@ public class PublicHolidayAbsenceProviderTest {
         List<TimedAbsence> absencesList = updatedTimedAbsenceSpans.getAbsencesList();
 
         Assert.assertEquals("wrong number of absences in list", 1, absencesList.size());
-        Assert.assertEquals("wrong absence type", TimedAbsence.Type.HOLIDAY, absencesList.get(0).getType());
+        Assert.assertEquals("wrong absence type", TimedAbsence.Type.PUBLIC_HOLIDAY, absencesList.get(0).getType());
         Assert.assertEquals("wrong part of day set on absence", DayLength.FULL.name(),
             absencesList.get(0).getPartOfDay());
         Assert.assertTrue("wrong absence ratio", BigDecimal.ONE.compareTo(absencesList.get(0).getRatio()) == 0);

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-public class HolidayAbsenceProviderTest {
+public class PublicHolidayAbsenceProviderTest {
 
-    private HolidayAbsenceProvider holidayAbsenceProvider;
+    private PublicHolidayAbsenceProvider publicHolidayAbsenceProvider;
 
     private SickDayAbsenceProvider sickDayAbsenceProvider;
     private WorkingTimeService workingTimeService;
@@ -48,7 +48,7 @@ public class HolidayAbsenceProviderTest {
         setupWorkingTimeServiceMock();
         setupHolidayServiceMock();
 
-        holidayAbsenceProvider = new HolidayAbsenceProvider(sickDayAbsenceProvider, publicHolidaysService,
+        publicHolidayAbsenceProvider = new PublicHolidayAbsenceProvider(sickDayAbsenceProvider, publicHolidaysService,
             workingTimeService);
     }
 
@@ -78,7 +78,7 @@ public class HolidayAbsenceProviderTest {
     @Test
     public void ensurePersonIsNotAvailableOnHoliDays() {
 
-        TimedAbsenceSpans updatedTimedAbsenceSpans = holidayAbsenceProvider.addAbsence(emptyTimedAbsenceSpans,
+        TimedAbsenceSpans updatedTimedAbsenceSpans = publicHolidayAbsenceProvider.addAbsence(emptyTimedAbsenceSpans,
             testPerson, newYearsDay);
 
         List<TimedAbsence> absencesList = updatedTimedAbsenceSpans.getAbsencesList();
@@ -94,7 +94,7 @@ public class HolidayAbsenceProviderTest {
     @Test
     public void ensureDoesNotCallNextProviderIfAlreadyAbsentForWholeDay() {
 
-        holidayAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, newYearsDay);
+        publicHolidayAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, newYearsDay);
 
         Mockito.verifyNoMoreInteractions(sickDayAbsenceProvider);
     }
@@ -103,7 +103,7 @@ public class HolidayAbsenceProviderTest {
     @Test
     public void ensureCallsSickDayAbsenceProviderIfNotAbsentForHoliday() {
 
-        holidayAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, standardWorkingDay);
+        publicHolidayAbsenceProvider.checkForAbsence(emptyTimedAbsenceSpans, testPerson, standardWorkingDay);
 
         verify(sickDayAbsenceProvider, times(1))
             .checkForAbsence(emptyTimedAbsenceSpans, testPerson, standardWorkingDay);


### PR DESCRIPTION
Also the TimedAbsence type HOLIDAY will be renamed to PUBLIC_HOLIDAY.

This is a breaking change. Maybe something for 4.0?