### PR TITLE
Use correct controller advice for each controller exceptions

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/api/AbsenceApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/api/AbsenceApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.application.domain.Application;
 import org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.application.service.ApplicationService;
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
 
-
+@RestControllerAdviceMarker
 @Api("Absences: Get all absences for a certain period")
 @RestController("restApiAbsenceController")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
@@ -16,7 +16,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 /**
  * Handles exceptions and redirects to error page.
  */
-@RestControllerAdvice
+@RestControllerAdvice(annotations = RestControllerAdviceMarker.class)
 public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(NO_CONTENT)

--- a/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/api/ApiExceptionHandlerControllerAdvice.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -22,7 +21,6 @@ public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(NO_CONTENT)
     @ExceptionHandler({NoValidWorkingTimeException.class})
-    @ResponseBody
     public ErrorResponse handleException(IllegalStateException exception) {
 
         return new ErrorResponse(NO_CONTENT, exception);
@@ -30,7 +28,6 @@ public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler({NumberFormatException.class, IllegalArgumentException.class})
-    @ResponseBody
     public ErrorResponse handleException(IllegalArgumentException exception) {
 
         return new ErrorResponse(BAD_REQUEST, exception);
@@ -39,7 +36,6 @@ public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    @ResponseBody
     public ErrorResponse handleException(MethodArgumentTypeMismatchException exception) {
 
         return new ErrorResponse(BAD_REQUEST, exception);
@@ -48,7 +44,6 @@ public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    @ResponseBody
     public ErrorResponse handleException(MissingServletRequestParameterException exception) {
 
         return new ErrorResponse(BAD_REQUEST, exception);
@@ -57,7 +52,6 @@ public class ApiExceptionHandlerControllerAdvice {
 
     @ResponseStatus(HttpStatus.FORBIDDEN)
     @ExceptionHandler(AccessDeniedException.class)
-    @ResponseBody
     public ErrorResponse handleException(AccessDeniedException exception) {
 
         return new ErrorResponse(HttpStatus.FORBIDDEN, exception);

--- a/src/main/java/org/synyx/urlaubsverwaltung/api/RestControllerAdviceMarker.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/api/RestControllerAdviceMarker.java
@@ -1,0 +1,11 @@
+package org.synyx.urlaubsverwaltung.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RestControllerAdviceMarker {
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/AvailabilityApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/AvailabilityApiController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.security.SecurityRules;
@@ -23,7 +24,7 @@ import java.util.Optional;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
-
+@RestControllerAdviceMarker
 @Api("Availabilities: Get all availabilities for a certain person and period")
 @RestController("restApiAvailabilityController")
 @RequestMapping("/api/persons/{personId}")

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/api/DepartmentApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/api/DepartmentApiController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.security.SecurityRules;
 
@@ -15,7 +16,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-
+@RestControllerAdviceMarker
 @Api("Departments: Get information about the departments of the application")
 @RestController("restApiDepartmentController")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/holiday/api/PublicHolidayApiController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
@@ -30,7 +31,7 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 
-
+@RestControllerAdviceMarker
 @Api("Public Holidays: Get information about public holidays")
 @RestController("restApiCalendarController")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.application.domain.Application;
 import org.synyx.urlaubsverwaltung.application.service.ApplicationService;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
@@ -28,7 +29,7 @@ import java.util.Optional;
 import static java.util.stream.Collectors.toList;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.ALLOWED;
 
-
+@RestControllerAdviceMarker
 @Api("Vacations: Get all vacations for a certain period")
 @RestController("restApiVacationController")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationResponse.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/calendar/VacationResponse.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 
 
-public class VacationResponse {
+class VacationResponse {
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(RestApiDateFormat.DATE_PATTERN);
     private String from;
@@ -20,7 +20,7 @@ public class VacationResponse {
     private String type;
     private String status;
 
-    public VacationResponse(Application application) {
+    VacationResponse(Application application) {
 
         this.from = application.getStartDate().format(formatter);
         this.to = application.getEndDate().format(formatter);

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/api/PersonApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/api/PersonApiController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.availability.api.AvailabilityApiController;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
@@ -23,6 +24,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 import static org.synyx.urlaubsverwaltung.availability.api.AvailabilityApiController.AVAILABILITIES;
 
+@RestControllerAdviceMarker
 @Api("Persons: Get information about the persons of the application")
 @RestController("restApiPersonController")
 @RequestMapping(PersonApiController.ROOT_URL)

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/api/SickNoteApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/api/SickNoteApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.sicknote.SickNote;
@@ -25,7 +26,7 @@ import java.util.Optional;
 import static java.util.stream.Collectors.toList;
 import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_OFFICE;
 
-
+@RestControllerAdviceMarker
 @Api("Sick Notes: Get all sick notes for a certain period")
 @RestController("restApiSickNoteController")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewApiController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.security.SecurityRules;
 
 import java.util.List;
 
+@RestControllerAdviceMarker
 @Api("VacationOverview: Get Vacation-Overview Metadata")
 @RestController("restApiVacationOverview")
 @RequestMapping("/api")

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/ViewExceptionHandlerControllerAdvice.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/ViewExceptionHandlerControllerAdvice.java
@@ -3,7 +3,6 @@ package org.synyx.urlaubsverwaltung.web;
 import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -18,7 +17,7 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 /**
  * Handles exceptions and redirects to error page.
  */
-@ControllerAdvice(annotations = Controller.class)
+@ControllerAdvice
 public class ViewExceptionHandlerControllerAdvice {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/api/WorkDayApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.synyx.urlaubsverwaltung.api.ResponseWrapper;
 import org.synyx.urlaubsverwaltung.api.RestApiDateFormat;
+import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
@@ -23,7 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
-
+@RestControllerAdviceMarker
 @Api("Work Days: Get information about work day in a certain period")
 @RestController("restApiWorkDayController")
 @RequestMapping("/api")


### PR DESCRIPTION
@ControllerAdvice components will be ordered in alphabetically order so
the `ApiExceptionHandlerControllerAdvice` will win over the
`ViewException...` and therefore we need a marker annotation until we
catch all exceptions on each controller correctly.


Bug is if we go on the site like /web/person/$number and we have no access we get a json instead of a htlm site.