### PR TITLE
Update send-get-department-vacations-request.js

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,10 +1,6 @@
 name: Urlaubsverwaltung CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Upgrade google api dependencies [#933](https://github.com/synyx/urlaubsverwaltung/pull/933)
 * Remove distribution repository from pom [#936](https://github.com/synyx/urlaubsverwaltung/pull/936)
 * Remove sonatype snapshot repository [#937](https://github.com/synyx/urlaubsverwaltung/pull/937)
-* Upgrade spring boot parent to 2.1.12
 
 ### [urlaubsverwaltung-3.0.1](https://github.com/synyx/urlaubsverwaltung/releases/tag/urlaubsverwaltung-3.0.1)
 * Fix ldap and ad sync can not be enabled [#914](https://github.com/synyx/urlaubsverwaltung/pull/914)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.12.RELEASE</version>
+    <version>2.1.11.RELEASE</version>
   </parent>
 
   <properties>

--- a/src/main/webapp/js/send-get-department-vacations-request.js
+++ b/src/main/webapp/js/send-get-department-vacations-request.js
@@ -33,8 +33,8 @@ export default async function sendGetDepartmentVacationsRequest(urlPrefix, start
 }
 
 function createHtmlForVacation(vacation) {
-  const startDate = format(vacation.from, "dd.MM.yyyy");
-  const endDate = format(vacation.to, "dd.MM.yyyy");
+  const startDate = format(Date.parse(vacation.from), "dd.MM.yyyy");
+  const endDate = format(Date.parse(vacation.to), "dd.MM.yyyy");
   const person = vacation.person.niceName;
 
   let html = `${person}: ${startDate} - ${endDate}`;


### PR DESCRIPTION
date-fns format does not support strings any more - has to parse to Date first...

fixes not showing vacations of department colleagues on new vacation application