### PR TITLE
Update send-get-department-vacations-request.js

### DIFF
--- a/src/main/webapp/js/send-get-department-vacations-request.js
+++ b/src/main/webapp/js/send-get-department-vacations-request.js
@@ -33,8 +33,8 @@ export default async function sendGetDepartmentVacationsRequest(urlPrefix, start
 }
 
 function createHtmlForVacation(vacation) {
-  const startDate = format(vacation.from, "dd.MM.yyyy");
-  const endDate = format(vacation.to, "dd.MM.yyyy");
+  const startDate = format(Date.parse(vacation.from), "dd.MM.yyyy");
+  const endDate = format(Date.parse(vacation.to), "dd.MM.yyyy");
   const person = vacation.person.niceName;
 
   let html = `${person}: ${startDate} - ${endDate}`;


### PR DESCRIPTION
date-fns format does not support strings any more - has to parse to Date first...

fixes not showing vacations of department colleagues on new vacation application
