### PR TITLE
Fix that a multiple day event ends one day to early

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -58,15 +58,14 @@ class ICalService {
 
         final TimeZone timeZone = new TimeZone(utc);
         final DateTime start = new DateTime(from(startDateTime.toInstant()), timeZone);
+        final DateTime end = new DateTime(from(endDateTime.toInstant()), timeZone);
 
         final VEvent event;
         if (absence.isAllDay() && isSameDay(startDateTime, endDateTime)) {
             event = new VEvent(new Date(start.getTime()), absence.getEventSubject());
         } else if (absence.isAllDay() && !isSameDay(startDateTime, endDateTime)) {
-            final DateTime end = new DateTime(from(endDateTime.minusDays(1).toInstant()), timeZone);
             event = new VEvent(new Date(start), new Date(end), absence.getEventSubject());
         } else {
-            final DateTime end = new DateTime(from(endDateTime.toInstant()), timeZone);
             event = new VEvent(start, end, absence.getEventSubject());
         }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -90,7 +90,7 @@ public class ICalServiceTest {
 
         assertThat(calendar).contains("SUMMARY:Marlene Muster abwesend");
         assertThat(calendar).contains("DTSTART;VALUE=DATE:20190326");
-        assertThat(calendar).contains("DTEND;VALUE=DATE:20190401");
+        assertThat(calendar).contains("DTEND;VALUE=DATE:20190402");
     }
 
     @Test


### PR DESCRIPTION
Hint:
We need to test this in all calendars like google, office, apple, ...

Information:
The end date is non-inclusive and so this needs to be one day more
see https://tools.ietf.org/html/rfc5545

"The "DTEND" property for a "VEVENT" calendar component specifies
the non-inclusive end of the event."

closes #978 