### PR TITLE
consider 'de-XX' locales for date-fns translations additionally to 'de'

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -68,9 +68,8 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-sonarqube
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-sonarqube
             ${{ runner.os }}-maven-
       - name: Maven clean
         run: ./mvnw clean

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,13 +71,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Maven clean
-        run: ./mvnw clean
       - name: Run SonarCloud analyse
         run: >
           ./mvnw --batch-mode
           -Pcoverage
-          verify
+          clean verify
           sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=synyx

--- a/src/main/webapp/WEB-INF/assets-manifest.json
+++ b/src/main/webapp/WEB-INF/assets-manifest.json
@@ -12,7 +12,7 @@
   "common.css": "/assets/common.b6646766a9417c8af89a.css",
   "common.js": "/assets/common.c6ea545258d2a64f6ecf.min.js",
   "copy_to_clipboard_input.js": "/assets/copy_to_clipboard_input.68ea1e9220cb959cf623.min.js",
-  "date-fns-localized.js": "/assets/date-fns-localized.e84d6f98c17ead4e4194.min.js",
+  "date-fns-localized.js": "/assets/date-fns-localized.095222c1bcb737c010bb.min.js",
   "department_form.js": "/assets/department_form.166c5b05cf851df5056e.min.js",
   "department_list.js": "/assets/department_list.e7747b178eca2cd24331.min.js",
   "fonts/fontawesome-webfont.eot?v=4.7.0": "/assets/fonts/fontawesome-webfont.eot",

--- a/src/main/webapp/bundles/__tests__/date-fns-localized.spec.js
+++ b/src/main/webapp/bundles/__tests__/date-fns-localized.spec.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @urlaubsverwaltung/no-date-fns
 import localeDE from 'date-fns/locale/de';
+// eslint-disable-next-line @urlaubsverwaltung/no-date-fns
+import localeENUS from 'date-fns/locale/en-US';
 import { setLocale } from "../../lib/date-fns/locale-resolver";
 
 jest.mock('../../lib/date-fns/locale-resolver');
@@ -38,6 +40,26 @@ describe('date-fns-localized', () => {
     // the attached `default` part has something to do with JavaScript Module and CommonJS Module compatibility
     // however, I don't care here. therefore just expect an object containing the original locale :o)
     expect(setLocale).toHaveBeenCalledWith(expect.objectContaining(localeDE));
+  });
+
+  test.each([
+    ['en'],
+    ['en-US'],
+  ])('loads date-fn english locale for window.navigator.language=%s', async (givenLanguage) => {
+    navigatorLanguage = givenLanguage;
+
+    require('../date-fns-localized');
+
+    // wait for resolved promise in implementation
+    // which then calls `setLocale`
+    await wait();
+
+    // locale data is dynamically loaded on runtime with `import(..)` by date-fns-localized.js
+    // the loaded locale data module has an attached { "default": (..) } part which the `localeDE` of this test has not.
+    // this is due to babel configuration settings I think. I didn't look for details...
+    // the attached `default` part has something to do with JavaScript Module and CommonJS Module compatibility
+    // however, I don't care here. therefore just expect an object containing the original locale :o)
+    expect(setLocale).not.toHaveBeenCalledWith(expect.objectContaining(localeENUS));
   });
 
   function wait(delay = 0) {

--- a/src/main/webapp/bundles/__tests__/date-fns-localized.spec.js
+++ b/src/main/webapp/bundles/__tests__/date-fns-localized.spec.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @urlaubsverwaltung/no-date-fns
 import localeDE from 'date-fns/locale/de';
-import { setLocale } from "../lib/date-fns/locale-resolver";
+import { setLocale } from "../../lib/date-fns/locale-resolver";
 
-jest.mock('../lib/date-fns/locale-resolver');
+jest.mock('../../lib/date-fns/locale-resolver');
 
 describe('date-fns-localized', () => {
   let navigatorLanguage = '';
@@ -26,7 +26,7 @@ describe('date-fns-localized', () => {
   ])('loads date-fn german locale for window.navigator.language=%s', async (givenLanguage) => {
     navigatorLanguage = givenLanguage;
 
-    require('./date-fns-localized');
+    require('../date-fns-localized');
 
     // wait for resolved promise in implementation
     // which then calls `setLocale`

--- a/src/main/webapp/bundles/date-fns-localized.js
+++ b/src/main/webapp/bundles/date-fns-localized.js
@@ -1,6 +1,6 @@
 import { setLocale } from '../lib/date-fns/locale-resolver'
 
-if (window.navigator.language === 'de') {
+if (window.navigator.language.slice(0, 2) === 'de') {
   import(/* webpackChunkName: "date-fn-locale-de" */'date-fns/locale/de').then(setLocale);
 }
 

--- a/src/main/webapp/bundles/date-fns-localized.spec.js
+++ b/src/main/webapp/bundles/date-fns-localized.spec.js
@@ -1,0 +1,48 @@
+// eslint-disable-next-line @urlaubsverwaltung/no-date-fns
+import localeDE from 'date-fns/locale/de';
+import { setLocale } from "../lib/date-fns/locale-resolver";
+
+jest.mock('../lib/date-fns/locale-resolver');
+
+describe('date-fns-localized', () => {
+  let navigatorLanguage = '';
+  const originalNavigatorLanguage = window.navigator.language;
+
+  Object.defineProperty(window.navigator, 'language', {
+    get() {
+      return navigatorLanguage || originalNavigatorLanguage;
+    }
+  });
+
+  afterEach(() => {
+    navigatorLanguage = '';
+    jest.resetModules();
+  });
+
+  test.each([
+    ['de'],
+    ['de-DE'],
+    ['de-AT'],
+  ])('loads date-fn german locale for window.navigator.language=%s', async (givenLanguage) => {
+    navigatorLanguage = givenLanguage;
+
+    require('./date-fns-localized');
+
+    // wait for resolved promise in implementation
+    // which then calls `setLocale`
+    await wait();
+
+    // locale data is dynamically loaded on runtime with `import(..)` by date-fns-localized.js
+    // the loaded locale data module has an attached { "default": (..) } part which the `localeDE` of this test has not.
+    // this is due to babel configuration settings I think. I didn't look for details...
+    // the attached `default` part has something to do with JavaScript Module and CommonJS Module compatibility
+    // however, I don't care here. therefore just expect an object containing the original locale :o)
+    expect(setLocale).toHaveBeenCalledWith(expect.objectContaining(localeDE));
+  });
+
+  function wait(delay = 0) {
+    return new Promise(resolve => {
+      setTimeout(resolve, delay);
+    })
+  }
+});


### PR DESCRIPTION
closes #960