### PR TITLE
Define end of life for version 3.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We will support the following version with security fixes.
 
 | Version | Supported          | End of Life (EOL) |
 | ------- | ------------------ | ----------------- |
-| 3.x     | :white_check_mark: | -                 |
+| 3.x     | :white_check_mark: | 31.12.2020        |
 | 2.x     | :x:                | 31.12.2019        |
 | < 1.0   | :x:                | 15.08.2015        |
 


### PR DESCRIPTION
Nach der 3.5 wollen wir auf die 4.x gehen und deshalb würde ich schonmal EOL für 3.x ankündigen.

Passt das aus eurer Sicht?
