### PR TITLE
Fix parsing of existing vacation requests

### DIFF
--- a/src/main/webapp/WEB-INF/assets-manifest.json
+++ b/src/main/webapp/WEB-INF/assets-manifest.json
@@ -2,7 +2,7 @@
   "account_form.js": "/assets/account_form.4fbc21e6d5a0f4f9e7e3.min.js",
   "app_detail.js": "/assets/app_detail.3ea511dbf2e78cc2fecf.min.js",
   "app_detail~app_form~person_overview.js": "/assets/app_detail~app_form~person_overview.53f58c5a47dfd80d4b77.min.js",
-  "app_form.js": "/assets/app_form.36e6a792e0ad18e1680e.min.js",
+  "app_form.js": "/assets/app_form.6617be5d9a771d5614cc.min.js",
   "app_form~overtime_form~person_overview~sick_note_form.css": "/assets/app_form~overtime_form~person_overview~sick_note_form.22b5114bc2e954327921.css",
   "app_form~overtime_form~person_overview~sick_note_form.js": "/assets/app_form~overtime_form~person_overview~sick_note_form.4d9d67e0b94da7e82aa3.min.js",
   "app_form~overtime_form~sick_note_form.css": "/assets/app_form~overtime_form~sick_note_form.0d235f7d7547fa60aee7.css",

--- a/src/main/webapp/js/send-get-department-vacations-request.js
+++ b/src/main/webapp/js/send-get-department-vacations-request.js
@@ -1,6 +1,6 @@
 // disabling date-fns#format is ok since we're formatting dates for api requests
 // eslint-disable-next-line @urlaubsverwaltung/no-date-fns
-import { isAfter, format } from 'date-fns'
+import { isAfter, format, parseISO } from 'date-fns'
 import { getJSON } from "../js/fetch"
 
 export default async function sendGetDepartmentVacationsRequest(urlPrefix, startDate, endDate, personId, elementSelector) {
@@ -33,8 +33,8 @@ export default async function sendGetDepartmentVacationsRequest(urlPrefix, start
 }
 
 function createHtmlForVacation(vacation) {
-  const startDate = format(Date.parse(vacation.from), "dd.MM.yyyy");
-  const endDate = format(Date.parse(vacation.to), "dd.MM.yyyy");
+  const startDate = format(parseISO(vacation.from), "dd.MM.yyyy");
+  const endDate = format(parseISO(vacation.to), "dd.MM.yyyy");
   const person = vacation.person.niceName;
 
   let html = `${person}: ${startDate} - ${endDate}`;


### PR DESCRIPTION
The Mozilla JavaScript reference states that

> It is not recommended to use `Date.parse` as until ES5, parsing of
> strings was entirely implementation dependent. There are still many
> differences in how different hosts parse date strings, therefore date
> strings should be manually parsed (a library can help if many
> different formats are to be accommodated).

Specifically in this case, date strings like '2020-08-12' were parsed as
December 8 at least in some situations (probably depending on user agent
and user’s locale settings).

Fixes #1135

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
