### PR TITLE
Filter old absences for iCal share by configurable property

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/config/ICalProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/config/ICalProperties.java
@@ -1,0 +1,28 @@
+package org.synyx.urlaubsverwaltung.calendar.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.Min;
+
+@Component
+@ConfigurationProperties("uv.ical")
+@Validated
+public class ICalProperties {
+
+    /**
+     * Defines how many days in past iCal calendar sharing should provide absences. Defaults to one year (356 days).
+     */
+    @Min(value = 0, message = "Number of days in past to sync absences with iCal calendar sharing must be positive")
+    private Integer daysInPast = 356;
+
+    public Integer getDaysInPast() {
+        return daysInPast;
+    }
+
+    public void setDaysInPast(Integer daysInPast) {
+        this.daysInPast = daysInPast;
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -118,3 +118,5 @@ management.metrics.export.stackdriver.enabled=false
 # uv.workingtime.default-working-days=1,2,3,4,5
 # Enable/disable new user creation in application
 # uv.person.can-be-manipulated=false
+# Defines how many days in past iCal calendar sharing should provide absences. Defaults to one year (356 days).
+# uv.ical.days-in-past=356


### PR DESCRIPTION
For long-running urlaubsverwaltung instances the iCal calendar share
could include abscences of many years in past. This lead to huge
ics-files and stumbling clients.

Allow configuring number of days in past absence should be included in
iCal calendar share with property:

`uv.ical.days-in-past` (default: 356 days)

resolves #1275