### PR TITLE
Add no nofitications for boss role to fix removal of boss role

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonValidator.java
@@ -14,6 +14,16 @@ import org.synyx.urlaubsverwaltung.web.MailAddressValidationUtil;
 import java.util.Collection;
 import java.util.Optional;
 
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_BOSS_ALL;
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_BOSS_DEPARTMENTS;
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_DEPARTMENT_HEAD;
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_OFFICE;
+import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_SECOND_STAGE_AUTHORITY;
+import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
+import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
+
 
 /**
  * This class validate if master data of a {@link Person} is filled correctly.
@@ -57,23 +67,18 @@ class PersonValidator implements Validator {
     @Override
     public void validate(Object target, Errors errors) {
 
-        Person person = (Person) target;
+        final Person person = (Person) target;
 
         if (person.getId() == null) {
             validateUsername(person.getUsername(), errors);
         }
 
         validateName(person.getFirstName(), ATTRIBUTE_FIRST_NAME, errors);
-
         validateName(person.getLastName(), ATTRIBUTE_LAST_NAME, errors);
-
         validateEmail(person.getEmail(), errors);
-
         validatePermissions(person, errors);
-
         validateNotifications(person, errors);
     }
-
 
     void validateUsername(String username, Errors errors) {
 
@@ -89,9 +94,7 @@ class PersonValidator implements Validator {
         }
     }
 
-
     void validateName(String name, String field, Errors errors) {
-
         if (StringUtils.hasText(name)) {
             if (!validateStringLength(name)) {
                 errors.rejectValue(field, ERROR_LENGTH);
@@ -101,9 +104,7 @@ class PersonValidator implements Validator {
         }
     }
 
-
     void validateEmail(String email, Errors errors) {
-
         if (StringUtils.hasText(email)) {
             if (!validateStringLength(email)) {
                 errors.rejectValue(ATTRIBUTE_EMAIL, ERROR_LENGTH);
@@ -117,12 +118,9 @@ class PersonValidator implements Validator {
         }
     }
 
-
     private boolean validateStringLength(String string) {
-
         return string.length() <= MAX_CHARS;
     }
-
 
     void validatePermissions(Person person, Errors errors) {
 
@@ -151,20 +149,18 @@ class PersonValidator implements Validator {
         validateCombinationOfRoles(roles, errors);
     }
 
-
     private void validateCombinationOfRoles(Collection<Role> roles, Errors errors) {
 
-        if (roles.contains(Role.DEPARTMENT_HEAD) && (roles.contains(Role.BOSS) || roles.contains(Role.OFFICE))) {
+        if (roles.contains(DEPARTMENT_HEAD) && (roles.contains(BOSS) || roles.contains(OFFICE))) {
             errors.rejectValue(ATTRIBUTE_PERMISSIONS, ERROR_PERMISSIONS_COMBINATION);
 
             return;
         }
 
-        if (roles.contains(Role.SECOND_STAGE_AUTHORITY) && (roles.contains(Role.BOSS) || roles.contains(Role.OFFICE))) {
+        if (roles.contains(SECOND_STAGE_AUTHORITY) && (roles.contains(BOSS) || roles.contains(OFFICE))) {
             errors.rejectValue(ATTRIBUTE_PERMISSIONS, ERROR_PERMISSIONS_COMBINATION);
         }
     }
-
 
     void validateNotifications(Person person, Errors errors) {
 
@@ -172,27 +168,15 @@ class PersonValidator implements Validator {
         Collection<MailNotification> notifications = person.getNotifications();
 
         if (roles != null) {
-            validateCombinationOfNotificationAndRole(roles, notifications, Role.DEPARTMENT_HEAD,
-                MailNotification.NOTIFICATION_DEPARTMENT_HEAD, errors);
-
-            validateCombinationOfNotificationAndRole(roles, notifications, Role.SECOND_STAGE_AUTHORITY,
-                MailNotification.NOTIFICATION_SECOND_STAGE_AUTHORITY, errors);
-
-            validateCombinationOfNotificationAndRole(roles, notifications, Role.BOSS,
-                MailNotification.NOTIFICATION_BOSS_ALL, errors);
-
-            validateCombinationOfNotificationAndRole(roles, notifications, Role.BOSS,
-                MailNotification.NOTIFICATION_BOSS_DEPARTMENTS, errors);
-
-            validateCombinationOfNotificationAndRole(roles, notifications, Role.OFFICE,
-                MailNotification.NOTIFICATION_OFFICE, errors);
+            validateCombinationOfNotificationAndRole(roles, notifications, DEPARTMENT_HEAD, NOTIFICATION_DEPARTMENT_HEAD, errors);
+            validateCombinationOfNotificationAndRole(roles, notifications, SECOND_STAGE_AUTHORITY, NOTIFICATION_SECOND_STAGE_AUTHORITY, errors);
+            validateCombinationOfNotificationAndRole(roles, notifications, BOSS, NOTIFICATION_BOSS_ALL, errors);
+            validateCombinationOfNotificationAndRole(roles, notifications, BOSS, NOTIFICATION_BOSS_DEPARTMENTS, errors);
+            validateCombinationOfNotificationAndRole(roles, notifications, OFFICE, NOTIFICATION_OFFICE, errors);
         }
     }
 
-
-    private void validateCombinationOfNotificationAndRole(Collection<Role> roles,
-                                                          Collection<MailNotification> notifications, Role role, MailNotification notification, Errors errors) {
-
+    private void validateCombinationOfNotificationAndRole(Collection<Role> roles, Collection<MailNotification> notifications, Role role, MailNotification notification, Errors errors) {
         if (notifications.contains(notification) && !roles.contains(role)) {
             errors.rejectValue("notifications", ERROR_NOTIFICATIONS_COMBINATION);
         }

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -481,6 +481,7 @@ person.form.notifications.DEPARTMENT_HEAD=erh\u00E4lt E-Mail-Benachrichtigung be
 person.form.notifications.SECOND_STAGE_AUTHORITY=erh\u00E4lt E-Mail-Benachrichtigung bei vorl\u00E4ufig genehmigten Urlaubsantr\u00E4gen
 person.form.notifications.BOSS.all=erh\u00E4lt <strong>alle</strong> E-Mail-Benachrichtigung bei neuen Urlaubsantr\u00E4gen
 person.form.notifications.BOSS.departments=erh\u00E4lt E-Mail-Benachrichtigung bei neuen Urlaubsantr\u00E4gen f\u00FCr seine Abteilungen
+person.form.notifications.BOSS.none=erh\u00E4lt <strong>keine</strong> E-Mail-Benachrichtigungen
 person.form.notifications.OFFICE=erh\u00E4lt E-Mail-Benachrichtigung bei genehmigten Urlaubsantr\u00E4gen
 person.form.notifications.OFFICE.overtime=erh\u00E4lt E-Mail-Benachrichtigung beim Eintrag von \u00DCberstunden
 # Notifications Errors

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -474,6 +474,7 @@ person.form.notifications.DEPARTMENT_HEAD=Receives email notification of new vac
 person.form.notifications.SECOND_STAGE_AUTHORITY=Receives email notification on pre-approved vacation requests
 person.form.notifications.BOSS.all=Receives <strong>all</strong> email notifications for new holiday requests
 person.form.notifications.BOSS.departments=Receives email notification for new holiday requests of his departments
+person.form.notifications.BOSS.none=Receives <strong>no</strong> email notifications
 person.form.notifications.OFFICE=Receives email notification for approved vacation requests
 person.form.notifications.OFFICE.overtime=Receives email notification for the entry of overtime
 # Notifications Errors

--- a/src/main/webapp/WEB-INF/jsp/person/person_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/person/person_form.jsp
@@ -241,13 +241,11 @@
                                             <spring:message code="person.form.permissions.roles.SECOND_STAGE_AUTHORITY"/>
                                         </strong>
                                         <label class="mb-2">
-                                            <form:checkbox path="permissions"
-                                                           value="SECOND_STAGE_AUTHORITY"/><spring:message
-                                            code="person.form.permissions.roles.SECOND_STAGE_AUTHORITY.description"/>
+                                            <form:checkbox path="permissions" value="SECOND_STAGE_AUTHORITY"/>
+                                            <spring:message code="person.form.permissions.roles.SECOND_STAGE_AUTHORITY.description"/>
                                         </label>
                                         <label class="ml-5 pb-2">
-                                            <form:checkbox path="notifications"
-                                                           value="NOTIFICATION_SECOND_STAGE_AUTHORITY"/>
+                                            <form:checkbox path="notifications" value="NOTIFICATION_SECOND_STAGE_AUTHORITY"/>
                                             <spring:message code="person.form.notifications.SECOND_STAGE_AUTHORITY"/>
                                         </label>
                                         <label class="${!empty secondStageDepartments ? 'info' : ''}">
@@ -284,6 +282,10 @@
                                         <label>
                                             <form:radiobutton path="notifications" value="NOTIFICATION_BOSS_DEPARTMENTS"/>
                                             <spring:message code="person.form.notifications.BOSS.departments"/>
+                                        </label>
+                                        <label>
+                                            <form:radiobutton path="notifications" value=""/>
+                                            <spring:message code="person.form.notifications.BOSS.none"/>
                                         </label>
                                     </div>
 


### PR DESCRIPTION
Quick fix of #1293. Now you can remove the boss notifications and therefore remove the boss role. This is not the best behaviour but a quick fix until we focus on the rights management.

closes #1293