### PR TITLE
use 'host.docker.internal' instead of ip for ui tests

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ApplicationForLeaveCreateIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ApplicationForLeaveCreateIT.java
@@ -68,7 +68,7 @@ class ApplicationForLeaveCreateIT extends TestContainersBase {
 
         final RemoteWebDriver webDriver = browserContainer.getWebDriver();
 
-        webDriver.get("http://172.17.0.1:" + port + "/login");
+        webDriver.get("http://host.docker.internal:" + port + "/login");
         assertThat(webDriver.getTitle()).isEqualTo("Login");
 
         webDriver.findElementById("username").sendKeys(person.getUsername());


### PR DESCRIPTION
#1369 

using the IP doesn't work on my macos.
hopefully 'host.docker.internal' works on other machines  (^‿^)

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
