### PR TITLE
WIP: introduce pre-compiled jsps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,47 @@
         <version>2.5.3</version>
       </plugin>
 
+      <!--
+        run jsp compilation as part of build process
+        so we save huge amount on-demand compilation time
+        in multi-tenant container based deployment
+      -->
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-jspc-maven-plugin</artifactId>
+        <version>9.4.32.v20200930</version>
+        <executions>
+          <execution>
+            <id>jspc</id>
+            <goals>
+              <goal>jspc</goal>
+            </goals>
+            <configuration>
+              <mergeFragment>true</mergeFragment>
+              <sourceVersion>${java.version}</sourceVersion>
+              <targetVersion>${java.version}</targetVersion>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <!-- replace jetty jspc with tomcat jspc -->
+          <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>${tomcat.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <!-- include jspc generated web.xml into war file -->
+          <webXml>${project.basedir}/target/web.xml</webXml>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspConfiguration.java
@@ -1,0 +1,27 @@
+package org.synyx.urlaubsverwaltung.web.jsp.config;
+
+import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Configuration
+@ConditionalOnProperty(value = "uv.template-engine.jsp.use-precompiled", havingValue = "true")
+@EnableConfigurationProperties(JspProperties.class)
+public class JspConfiguration {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+    private static final String WEB_XML = "/WEB-INF/web.xml";
+
+    @Bean
+    public ServletContextInitializer registerPreCompiledJsps() {
+        LOG.info("Application will use precompiled JSPs!");
+        return new JspServletRegistrator(WEB_XML);
+    }
+
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspProperties.java
@@ -1,0 +1,19 @@
+package org.synyx.urlaubsverwaltung.web.jsp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("uv.template-engine.jsp")
+public class JspProperties {
+
+    private boolean usePrecompiled = false;
+
+    public boolean usePrecompiled() {
+        return usePrecompiled;
+    }
+
+    public void setUsePrecompiled(boolean usePrecompiled) {
+        this.usePrecompiled = usePrecompiled;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspServletRegistrator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/jsp/config/JspServletRegistrator.java
@@ -1,0 +1,76 @@
+package org.synyx.urlaubsverwaltung.web.jsp.config;
+
+import org.apache.tomcat.util.descriptor.web.ServletDef;
+import org.apache.tomcat.util.descriptor.web.WebXml;
+import org.apache.tomcat.util.descriptor.web.WebXmlParser;
+import org.slf4j.Logger;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.xml.sax.InputSource;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
+import java.io.InputStream;
+import java.util.function.BiConsumer;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class JspServletRegistrator implements ServletContextInitializer {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+    private static final int LOAD_ON_STARTUP = 99;
+
+    private final String webXmlPath;
+
+    public JspServletRegistrator(String webXmlPath) {
+        this.webXmlPath = webXmlPath;
+    }
+
+    private WebXml parseWebXml(ServletContext servletContext) {
+
+        InputStream inputStream = servletContext.getResourceAsStream(webXmlPath);
+
+        if (inputStream == null) {
+            throw new IllegalStateException(String.format("Could not read %s!", webXmlPath));
+        }
+
+        WebXmlParser parser = new WebXmlParser(false, false, true);
+        WebXml webXml = new WebXml();
+
+        boolean success = parser.parseWebXml(new InputSource(inputStream), webXml, false);
+        if (!success) {
+            throw new IllegalStateException("Something went wrong registering precompiled JSPs");
+        }
+
+        LOG.info("Parsed {} including {} servlets and {} servletMappings!", webXmlPath, webXml.getServlets().size(), webXml.getServletMappings().size());
+
+        return webXml;
+    }
+
+    private BiConsumer<String, String> addUrlMappingToServlet(ServletContext servletContext) {
+        return (urlPattern, servletClass) -> {
+            LOG.info("Mapping servlet: urlPattern={} -> servletClass={}", urlPattern, servletClass);
+            servletContext.getServletRegistration(servletClass).addMapping(urlPattern);
+        };
+    }
+
+    private BiConsumer<String, ServletDef> registerServlet(ServletContext servletContext) {
+        return (key, servletDef) -> {
+            final String servletName = servletDef.getServletName();
+            final String servletClass = servletDef.getServletClass();
+
+            LOG.info("Registering precompiled JSP: servletName={} -> servletClass={}", servletName, servletClass);
+            ServletRegistration.Dynamic servletRegistration = servletContext.addServlet(servletName, servletClass);
+            servletRegistration.setLoadOnStartup(LOAD_ON_STARTUP);
+        };
+    }
+
+    @Override
+    public void onStartup(ServletContext servletContext) {
+        WebXml webXml = parseWebXml(servletContext);
+
+        webXml.getServlets().forEach(registerServlet(servletContext));
+        webXml.getServletMappings().forEach(addUrlMappingToServlet(servletContext));
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -89,6 +89,9 @@ uv.security.oidc.client-id=
 uv.security.oidc.client-secret=
 uv.security.oidc.logout-uri=
 
+# JSP template engine---------------------------------------------------------------------------------------------------
+uv.template-engine.jsp.use-precompiled=false
+
 # ACTUATOR -------------------------------------------------------------------------------------------------------------
 info.app.name=@project.name@
 info.app.version=@project.version@

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0"
+         metadata-complete="true">
+  <session-config>
+    <cookie-config>
+    </cookie-config>
+  </session-config>
+</web-app>


### PR DESCRIPTION
Using pre-compiled jsps is disabled by default.
To enable using pre-compiled jsps run application with
`uv.template-engine.jsp.use-precompiled=true`