### PR TITLE
Expose count of active persons as metric

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
@@ -1,0 +1,25 @@
+package org.synyx.urlaubsverwaltung.person.metrics;
+
+import io.micrometer.core.instrument.Metrics;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+
+@Component
+class PersonMetrics {
+
+    private static final String METRIC_USERS_ACTIVE = "users.active";
+
+    private final PersonService personService;
+
+    PersonMetrics(PersonService personService) {
+
+        this.personService = personService;
+    }
+
+    @Scheduled(fixedDelay = 300000)
+    void countActiveUsers() {
+        Metrics.gauge(METRIC_USERS_ACTIVE, this.personService.getActivePersons().size());
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,8 +102,8 @@ logging.level.org.springframework.boot.actuate.audit.listener.AuditListener=WARN
 logging.level.org.synyx.urlaubsverwaltung=INFO
 
 # METRICS
-management.endpoints.web.exposure.include=prometheus,health,info
-management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,info
+management.endpoint.prometheus.enabled=false
 
 management.metrics.export.stackdriver.enabled=false
 #management.metrics.export.stackdriver.project-id=

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
@@ -1,0 +1,38 @@
+package org.synyx.urlaubsverwaltung.person.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PersonMetricsTest {
+
+    @Mock
+    private PersonService personService;
+
+    private PersonMetrics sut;
+
+    @Test
+    void countActiveUsers() {
+        Metrics.addRegistry(new SimpleMeterRegistry());
+        sut = new PersonMetrics(personService);
+
+        when(personService.getActivePersons()).thenReturn(List.of(new Person()));
+
+        sut.countActiveUsers();
+
+        Gauge gauge = Metrics.globalRegistry.find("users.active").gauge();
+        assertThat(gauge.value()).isOne();
+    }
+}


### PR DESCRIPTION
To measure the number of active persons in the application we have to only one single source of truth: database
This is the reason why in-application-events are not possible to use in multi instance scenarios for metric calculation (only one instance will update the metric -> out of sync)

### Additionally

This PR changes the default behavior for Prometheus endpoint expose: 
Now on it must be configured to expose endpoint.