### PR TITLE
bugfix: fill department description with jstl out tag

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
@@ -101,7 +101,7 @@
                                                      data-trigger="hover"
                                                      data-placement="right"
                                                      title="<spring:message code='department.data.info'/>"
-                                                     data-content="${department.description}">
+                                                     data-content="<c:out value="${department.description}"/>">
                                                     <c:out value="${department.name}"/>
                                                     <icon:information-circle className="tw-w-4 tw-h-4" solid="true" />
                                                 </div>


### PR DESCRIPTION
use `c:out` from jstl core for evaluation of department description
This couses excaping of xml tags instead of allow to manipulate html

* see: https://docs.oracle.com/javaee/5/jstl/1.1/docs/tlddocs/c/out.html
* closes: #1399

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
