### PR TITLE
Use default mime types for compression

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,8 +39,6 @@ spring.freemarker.cache=true
 
 # Enable response compression
 server.compression.enabled=true
-# The comma-separated list of mime types that should be compressed
-server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
 # Compress the response only if the response size is at least 1KB
 server.compression.min-response-size=1024
 


### PR DESCRIPTION
We should use the default mime-types for compression because they are almost equal with the benefit of 

Our configuration
```
"text/html", "text/xml", "text/plain", "text/css", "text/javascript", "application/javascript", "application/json"
```

Default from Spring Boot
```
"text/html", "text/xml", "text/plain", "text/css", "text/javascript", "application/javascript", "application/json", "application/xml"
```

so only application/xml is missing and why should be ignore it instead of use the default.