### PR TITLE
Remove draft marker on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body: Die Änderungen in dieser Version können im [Changelog](https://github.com/synyx/urlaubsverwaltung/blob/master/CHANGELOG.md) nachgelesen werden.
-          draft: false
           prerelease: true
       - name: Extract release tag
         id: vars


### PR DESCRIPTION
The next release will be the 4.0 release so we can remove the draft marker.