### PR TITLE
Fix empty start/end date in period and that start must be before end

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/web/FilterPeriod.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/FilterPeriod.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.web;
 
-import org.springframework.util.Assert;
-
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
@@ -32,8 +30,6 @@ public class FilterPeriod {
         } catch (DateTimeParseException exception) {
             throw new IllegalArgumentException(exception.getMessage());
         }
-
-        Assert.isTrue(endDate.isAfter(startDate) || endDate.isEqual(startDate), "Start date must be before end date");
     }
 
     public LocalDate getStartDate() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/FilterPeriod.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/FilterPeriod.java
@@ -6,6 +6,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.format.DateTimeParseException;
+import java.util.Optional;
 
 import static java.time.LocalDate.parse;
 import static java.time.format.DateTimeFormatter.ofPattern;
@@ -52,11 +53,15 @@ public class FilterPeriod {
     }
 
     public String getStartDateAsString() {
-        return getStartDate().format(ofPattern(DD_MM_YYYY));
+        return Optional.ofNullable(getStartDate())
+            .map(localDate -> localDate.format(ofPattern(DD_MM_YYYY)))
+            .orElse("");
     }
 
     public String getEndDateAsString() {
-        return getEndDate().format(ofPattern(DD_MM_YYYY));
+        return Optional.ofNullable(getEndDate())
+            .map(localDate -> localDate.format(ofPattern(DD_MM_YYYY)))
+            .orElse("");
     }
 
     @Override

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/FilterPeriodTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/FilterPeriodTest.java
@@ -58,12 +58,6 @@ class FilterPeriodTest {
     }
 
     @Test
-    void ensureThrowsIfInitializedWithEndDateStringThatIsBeforeStartDateString() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new FilterPeriod("21.12.2015", "19.05.2015"));
-    }
-
-    @Test
     void ensureDatesCanBeParsedFromString() {
 
         final LocalDate startDate = LocalDate.of(2015, MAY, 19);

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/FilterPeriodTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/FilterPeriodTest.java
@@ -75,6 +75,26 @@ class FilterPeriodTest {
     }
 
     @Test
+    void ensureStartDateSetterIsOk() {
+
+        final FilterPeriod filterPeriod = new FilterPeriod("", "19.05.2199");
+        filterPeriod.setStartDate(null);
+
+        assertThat(filterPeriod.getStartDateAsString()).isEmpty();
+        assertThat(filterPeriod.getEndDateAsString()).isEqualTo("19.05.2199");
+    }
+
+    @Test
+    void ensureEndDateSetterIsOk() {
+
+        final FilterPeriod filterPeriod = new FilterPeriod("19.05.1899", "");
+        filterPeriod.setEndDate(null);
+
+        assertThat(filterPeriod.getStartDateAsString()).isEqualTo("19.05.1899");
+        assertThat(filterPeriod.getEndDateAsString()).isEmpty();
+    }
+
+    @Test
     void ensureThrowsIfTryingToParseDatesWithUnsupportedFormat() {
 
         Consumer<String> assertDateFormatNotSupported = (dateString) -> {


### PR DESCRIPTION
closes #1467
closes #1468

This pull request provides a better experience for the user but is not the best solution for the filter period. We should take a deeper look at it in the near future.