### PR TITLE
 Default Urlaubsanspruch pro UV Instanz über UI-Komponenten pflegbar machen

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Nachstehend alle spezifischen Konfigurationsmöglichkeiten der Urlaubsverwaltung
 
 ```properties
 # account
-uv.account.default-vacation-days=20
+uv.account.default-vacation-days=20 # deprecated - kann über 'Einstellungen' gesetzt werden wenn auf '-1' gesetzt
 uv.account.update.cron=0 0 5 1 1 *
 
 # application

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountProperties.java
@@ -16,17 +16,20 @@ import javax.validation.constraints.NotNull;
 public class AccountProperties {
 
     @NotNull
-    @Min(0)
+    @Min(-1)
     @Max(365)
+    @Deprecated(since = "4.4.0", forRemoval = true)
     private Integer defaultVacationDays = 20;
 
     @Valid
     private Update update = new Update();
 
+    @Deprecated(since = "4.4.0", forRemoval = true)
     public Integer getDefaultVacationDays() {
         return defaultVacationDays;
     }
 
+    @Deprecated(since = "4.4.0", forRemoval = true)
     public void setDefaultVacationDays(Integer defaultVacationDays) {
         this.defaultVacationDays = defaultVacationDays;
     }
@@ -55,5 +58,4 @@ public class AccountProperties {
             this.cron = cron;
         }
     }
-
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettings.java
@@ -9,9 +9,22 @@ import javax.persistence.Embeddable;
 public class AccountSettings {
 
     /**
+     * Based on http://www.gesetze-im-internet.de/burlg/__3.html the default is 24 days
+     */
+    private Integer defaultVacationDays = 24;
+
+    /**
      * Specifies the maximal number of annual vacation days a person can have.
      */
     private Integer maximumAnnualVacationDays = 40;
+
+    public Integer getDefaultVacationDays() {
+        return defaultVacationDays;
+    }
+
+    public void setDefaultVacationDays(Integer defaultVacationDays) {
+        this.defaultVacationDays = defaultVacationDays;
+    }
 
     public Integer getMaximumAnnualVacationDays() {
         return maximumAnnualVacationDays;

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettingsValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettingsValidator.java
@@ -6,8 +6,9 @@ public class AccountSettingsValidator {
 
     private static final String ERROR_MANDATORY_FIELD = "error.entry.mandatory";
     private static final String ERROR_INVALID_ENTRY = "error.entry.invalid";
+    private static final String ERROR_DEFAULT_DAYS_SMALLER_OR_EQUAL_THAN_MAX_DAYS = "settings.account.error.defaultMustBeSmallerOrEqualThanMax";
 
-    private static final int DAYS_PER_YEAR = 366;
+    private static final int DAYS_PER_YEAR = 365;
 
     private AccountSettingsValidator(){
         // private
@@ -20,6 +21,15 @@ public class AccountSettingsValidator {
             errors.rejectValue("accountSettings.maximumAnnualVacationDays", ERROR_MANDATORY_FIELD);
         } else if (maximumAnnualVacationDays < 0 || maximumAnnualVacationDays > DAYS_PER_YEAR) {
             errors.rejectValue("accountSettings.maximumAnnualVacationDays", ERROR_INVALID_ENTRY);
+        }
+
+        final Integer defaultVacationDays = accountSettings.getDefaultVacationDays();
+        if (defaultVacationDays == null) {
+            errors.rejectValue("accountSettings.defaultVacationDays", ERROR_MANDATORY_FIELD);
+        } else if (defaultVacationDays < 0 || defaultVacationDays > DAYS_PER_YEAR) {
+            errors.rejectValue("accountSettings.defaultVacationDays", ERROR_INVALID_ENTRY);
+        } else if (maximumAnnualVacationDays != null && defaultVacationDays > maximumAnnualVacationDays) {
+            errors.rejectValue("accountSettings.defaultVacationDays", ERROR_DEFAULT_DAYS_SMALLER_OR_EQUAL_THAN_MAX_DAYS);
         }
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/settings/SettingsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/settings/SettingsViewController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.synyx.urlaubsverwaltung.account.AccountProperties;
 import org.synyx.urlaubsverwaltung.calendarintegration.GoogleCalendarSettings;
 import org.synyx.urlaubsverwaltung.calendarintegration.providers.CalendarProvider;
 import org.synyx.urlaubsverwaltung.period.DayLength;
@@ -29,16 +30,17 @@ import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_OFFICE;
 @RequestMapping("/web/settings")
 public class SettingsViewController {
 
+    private final AccountProperties accountProperties;
     private final SettingsService settingsService;
     private final List<CalendarProvider> calendarProviders;
     private final SettingsValidator settingsValidator;
     private final Clock clock;
 
     @Autowired
-    public SettingsViewController(SettingsService settingsService,
+    public SettingsViewController(AccountProperties accountProperties, SettingsService settingsService,
                                   List<CalendarProvider> calendarProviders,
                                   SettingsValidator settingsValidator, Clock clock) {
-
+        this.accountProperties = accountProperties;
         this.settingsService = settingsService;
         this.calendarProviders = calendarProviders;
         this.settingsValidator = settingsValidator;
@@ -99,6 +101,8 @@ public class SettingsViewController {
     }
 
     private void fillModel(Model model, Settings settings, String authorizedRedirectUrl) {
+        model.addAttribute("defaultVacationDaysFromSettings", accountProperties.getDefaultVacationDays() == -1);
+
         model.addAttribute("settings", settings);
         model.addAttribute("federalStateTypes", FederalState.values());
         model.addAttribute("dayLengthTypes", DayLength.values());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -116,8 +116,5 @@ management.metrics.export.stackdriver.enabled=false
 #gcp.resourcetype.labels.pod-name=
 #gcp.resourcetype.labels.container-name=
 
-# Application
-# default based on german minimum vacation days http://www.gesetze-im-internet.de/burlg/__3.html
-# uv.account.default-vacation-days=20
 # comma-seperated workingdays (monday=1, tuesday=2, wednesday=3, thursday=4, friday=5, saturday=6, sunday=7)
 # uv.workingtime.default-working-days=1,2,3,4,5

--- a/src/main/resources/dbchangelogs/changelog-4.4.0-accountsettings-default-vacation-days.xml
+++ b/src/main/resources/dbchangelogs/changelog-4.4.0-accountsettings-default-vacation-days.xml
@@ -1,0 +1,21 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+
+  <changeSet author="schneider" id="add_default_vacation_days">
+    <preConditions>
+      <tableExists tableName="Settings"/>
+      <not>
+        <columnExists tableName="Settings" columnName="defaultVacationDays"/>
+      </not>
+    </preConditions>
+
+    <addColumn tableName="Settings">
+      <column name="defaultVacationDays" type="INT(3)" defaultValue="24">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -66,4 +66,5 @@
   <include file="dbchangelogs/changelog-4.0.0-add-timezone.xml"/>
   <include file="dbchangelogs/changelog-4.3.0-increase-application-status-length.xml"/>
   <include file="dbchangelogs/changelog-4.3.0-increase-application-comment-action-length.xml"/>
+  <include file="dbchangelogs/changelog-4.4.0-accountsettings-default-vacation-days.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -627,6 +627,7 @@ settings.tabs.calendar=Kalender Synchronisation (veraltet)
 settings.vacation.title=Einstellungen zu Urlaub
 settings.vacation.description=Die Einstellungen f\u00FCr die Maximalwerte werden zur Validierung von Formularen herangezogen.
 settings.vacation.maximumAnnualVacationDays=Maximale Anzahl der Urlaubstage pro Jahr
+settings.vacation.defaultVacationDays=Anzahl der Urlaubstage pro Jahr
 settings.vacation.maximumMonthsToApplyForLeaveInAdvance=Wieviele Monate im Voraus d\u00FCrfen Mitarbeiter einen Antrag stellen?
 # Reminder Notification
 settings.vacation.remindForWaitingApplications.title=Automatische Erinnerung f\u00FCr wartende Urlaubsantr\u00E4ge
@@ -635,6 +636,8 @@ settings.vacation.remindForWaitingApplications.true=aktivieren
 settings.vacation.remindForWaitingApplications.false=deaktivieren
 settings.vacation.daysBeforeRemindForWaitingApplications=Erinnerungsmail alle x Tage
 settings.vacation.daysBeforeRemindForWaitingApplications.descripton=Diese Einstellung erm\u00F6glicht es die Chefs bzw. Abteilungsleiter auf wartende Urlaubsantr\u00E4ge per Mail aufmerksam zu machen. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+# Account
+settings.account.error.defaultMustBeSmallerOrEqualThanMax=Muss kleiner oder gleich der maximalen Anzahl der Urlaubstage pro Jahr sein
 # Sick Days
 settings.sickDays.title=Einstellungen zu Krankmeldungen
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office Mitarbeiter per E-Mail \u00FCber das Ende der Lohnfortzahlung informiert werden.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -618,6 +618,7 @@ settings.tabs.calendar=Calendar synchronization (deprecated)
 settings.vacation.title=Vacation settings
 settings.vacation.description=The maximum value settings are used to validate forms.
 settings.vacation.maximumAnnualVacationDays=Maximum number of holidays per year
+settings.vacation.defaultVacationDays=Number of holidays per year
 settings.vacation.maximumMonthsToApplyForLeaveInAdvance=How many months in advance can employees request a vacation?
 # Reminder Notification
 settings.vacation.remindForWaitingApplications.title=Automatic reminder for waiting vacation requests
@@ -626,6 +627,8 @@ settings.vacation.remindForWaitingApplications.true=Enable
 settings.vacation.remindForWaitingApplications.false=Disable
 settings.vacation.daysBeforeRemindForWaitingApplications=Reminder mail every x days
 settings.vacation.daysBeforeRemindForWaitingApplications.descripton=This setting allows the supervisors or department heads to alert them of waiting vacation requests by email. This function is only available if the mail delivery is activated and configured.
+# Account
+settings.account.error.defaultMustBeSmallerOrEqualThanMax=have to be equal or smaller than the maximum number of holidays per year
 # Sick Days
 settings.sickDays.title=Sick notes settings
 settings.sickDays.description=The sick pay settings determine when the sick employee and the office staff are informed by email about the end of the sick pay.

--- a/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
@@ -136,6 +136,23 @@
                                 </span>
                             </div>
                             <div class="col-md-8 col-md-pull-4">
+                                <c:if test="${defaultVacationDaysFromSettings}">
+                                <div class="form-group is-required">
+                                    <label class="control-label col-md-4"
+                                           for="accountSettings.defaultVacationDays">
+                                        <spring:message code='settings.vacation.defaultVacationDays'/>:
+                                    </label>
+                                    <div class="col-md-8">
+                                        <form:input id="accountSettings.defaultVacationDays"
+                                                    path="accountSettings.defaultVacationDays"
+                                                    class="form-control" cssErrorClass="form-control error"
+                                                    type="number" step="1"/>
+                                        <uv:error-text>
+                                            <form:errors path="accountSettings.defaultVacationDays" />
+                                        </uv:error-text>
+                                    </div>
+                                </div>
+                                </c:if>
                                 <div class="form-group is-required">
                                     <label class="control-label col-md-4"
                                            for="accountSettings.maximumAnnualVacationDays">

--- a/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
@@ -182,7 +182,7 @@ class SettingsValidatorTest {
 
     // Account settings ------------------------------------------------------------------------------------------------
     @Test
-    void ensureAccountSettingsCanNotBeNull() {
+    void ensureMaximumAnnualVacationDaysAccountSettingsCanNotBeNull() {
 
         final Settings settings = new Settings();
         final AccountSettings accountSettings = settings.getAccountSettings();
@@ -194,7 +194,7 @@ class SettingsValidatorTest {
     }
 
     @Test
-    void ensureAccountSettingsCanNotBeNegative() {
+    void ensureMaximumAnnualVacationDaysAccountSettingsCanNotBeNegative() {
 
         final Settings settings = new Settings();
         final AccountSettings accountSettings = settings.getAccountSettings();
@@ -206,29 +206,62 @@ class SettingsValidatorTest {
     }
 
     @Test
-    void ensureThatMaximumAnnualVacationDaysSmallerThanAYear() {
+    void ensureThatDefaultVacationDaysSmallerThanAYear() {
 
         final Settings settings = new Settings();
-        settings.getAccountSettings().setMaximumAnnualVacationDays(367);
+        settings.getAccountSettings().setDefaultVacationDays(366);
 
         final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
-        verify(mockError).rejectValue("accountSettings.maximumAnnualVacationDays", "error.entry.invalid");
+        verify(mockError).rejectValue("accountSettings.defaultVacationDays", "error.entry.invalid");
     }
 
     @Test
-    void ensureThatAccountSettingsAreSmallerOrEqualsThanMaxInt() {
+    void ensureDefaultVacationDaysAccountSettingsCanNotBeNull() {
 
         final Settings settings = new Settings();
         final AccountSettings accountSettings = settings.getAccountSettings();
-
-        accountSettings.setMaximumAnnualVacationDays(Integer.MAX_VALUE + 1);
+        accountSettings.setDefaultVacationDays(null);
 
         final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
-        verify(mockError).rejectValue("accountSettings.maximumAnnualVacationDays", "error.entry.invalid");
+        verify(mockError).rejectValue("accountSettings.defaultVacationDays", "error.entry.mandatory");
     }
 
+    @Test
+    void ensureDefaultVacationDaysAccountSettingsCanNotBeNegative() {
+
+        final Settings settings = new Settings();
+        final AccountSettings accountSettings = settings.getAccountSettings();
+        accountSettings.setDefaultVacationDays(-1);
+
+        final Errors mockError = mock(Errors.class);
+        settingsValidator.validate(settings, mockError);
+        verify(mockError).rejectValue("accountSettings.defaultVacationDays", "error.entry.invalid");
+    }
+
+    @Test
+    void ensureDefaultVacationDaysSmallerThanAYear() {
+
+        final Settings settings = new Settings();
+        settings.getAccountSettings().setDefaultVacationDays(366);
+
+        final Errors mockError = mock(Errors.class);
+        settingsValidator.validate(settings, mockError);
+        verify(mockError).rejectValue("accountSettings.defaultVacationDays", "error.entry.invalid");
+    }
+
+    @Test
+    void ensureDefaultVacationDaysSmallerMaxDays() {
+
+        final Settings settings = new Settings();
+        settings.getAccountSettings().setMaximumAnnualVacationDays(19);
+        settings.getAccountSettings().setDefaultVacationDays(20);
+
+        final Errors mockError = mock(Errors.class);
+        settingsValidator.validate(settings, mockError);
+        verify(mockError).rejectValue("accountSettings.defaultVacationDays", "settings.account.error.defaultMustBeSmallerOrEqualThanMax");
+    }
 
     // SickNote settings ------------------------------------------------------------------------------------------------
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsViewControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.validation.Errors;
 import org.synyx.urlaubsverwaltung.absence.Absence;
+import org.synyx.urlaubsverwaltung.account.AccountProperties;
 import org.synyx.urlaubsverwaltung.calendarintegration.CalendarSettings;
 import org.synyx.urlaubsverwaltung.calendarintegration.providers.CalendarProvider;
 import org.synyx.urlaubsverwaltung.period.DayLength;
@@ -20,6 +21,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -60,7 +62,7 @@ class SettingsViewControllerTest {
 
     @BeforeEach
     void setUp() {
-        sut = new SettingsViewController(settingsService, CALENDAR_PROVIDER_LIST, settingsValidator, clock);
+        sut = new SettingsViewController(new AccountProperties(), settingsService, CALENDAR_PROVIDER_LIST, settingsValidator, clock);
     }
 
     @Test
@@ -85,6 +87,7 @@ class SettingsViewControllerTest {
             .andExpect(model().attribute("dayLengthTypes", DayLength.values()))
             .andExpect(model().attribute("providers", contains("SomeCalendarProvider", "AnotherCalendarProvider")))
             .andExpect(model().attribute("availableTimezones", containsInAnyOrder(TimeZone.getAvailableIDs())))
+            .andExpect(model().attribute("defaultVacationDaysFromSettings", is(false)))
             .andExpect(model().attribute("authorizedRedirectUrl",
                 sut.getAuthorizedRedirectUrl("http://localhost" + requestUrl, OATUH_REDIRECT_REL)));
     }


### PR DESCRIPTION
closes #1612 
closes #1615 

Mit dieser Änderung brechen wir die Properties. Hier muss man schauen ob man das umgehen kann, sonst müssten wir ggf auf 5.x gehen
-> Vorschlag: Wenn `uv.account.defaultVacationDays` auf `-1` gesetzt wird, wird es in den Settings angeboten, ansonsten wir weiterhin das Property verwendet.