### PR TITLE
fix person metric

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/PersonRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/PersonRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 interface PersonRepository extends JpaRepository<Person, Integer> {
 
     Optional<Person> findByUsername(String username);
+
+    int countByPermissionsNotContaining(Role permission);
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/PersonService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/PersonService.java
@@ -124,4 +124,12 @@ public interface PersonService {
      * if no other active person with {@link Role#OFFICE} is available.
      */
     Person appointAsOfficeUserIfNoOfficeUserPresent(Person person);
+
+    /**
+     * Returns the number of all users that do not have the role INACTIVE.
+     * These users are called active users.
+     *
+     * @return number of active users
+     */
+    int numberOfActivePersons();
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/PersonServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/PersonServiceImpl.java
@@ -197,6 +197,11 @@ class PersonServiceImpl implements PersonService {
         return savedPerson;
     }
 
+    @Override
+    public int numberOfActivePersons() {
+        return personRepository.countByPermissionsNotContaining(INACTIVE);
+    }
+
     private Comparator<Person> personComparator() {
         return Comparator.comparing(p -> p.getNiceName().toLowerCase());
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
@@ -1,25 +1,33 @@
 package org.synyx.urlaubsverwaltung.person.metrics;
 
-import io.micrometer.core.instrument.Metrics;
-import org.springframework.scheduling.annotation.Scheduled;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
 class PersonMetrics {
 
     private static final String METRIC_USERS_ACTIVE = "users.active";
+    private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final PersonService personService;
 
-    PersonMetrics(PersonService personService) {
+    PersonMetrics(PersonService personService, MeterRegistry meterRegistry) {
 
         this.personService = personService;
+
+        Gauge.builder(METRIC_USERS_ACTIVE, this::countActiveUsers).register(meterRegistry);
     }
 
-    @Scheduled(fixedDelay = 300000)
-    void countActiveUsers() {
-        Metrics.gauge(METRIC_USERS_ACTIVE, this.personService.getActivePersons().size());
+    int countActiveUsers() {
+        final int activeUsersCount = this.personService.getActivePersons().size();
+        LOG.debug("active users count is {}", activeUsersCount);
+        return activeUsersCount;
     }
 
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetrics.java
@@ -25,9 +25,8 @@ class PersonMetrics {
     }
 
     int countActiveUsers() {
-        final int activeUsersCount = this.personService.getActivePersons().size();
+        final int activeUsersCount = this.personService.numberOfActivePersons();
         LOG.debug("active users count is {}", activeUsersCount);
         return activeUsersCount;
     }
-
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
@@ -1,0 +1,47 @@
+package org.synyx.urlaubsverwaltung.person;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.synyx.urlaubsverwaltung.TestContainersBase;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.synyx.urlaubsverwaltung.person.Role.INACTIVE;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.USER;
+
+@SpringBootTest
+@Transactional
+class PersonRepositoryIT extends TestContainersBase {
+
+    @Autowired
+    private PersonRepository sut;
+
+    @Autowired
+    private PersonService personService;
+
+    @Test
+    void countPersonByPermissionsIsNot() {
+
+        final Person marlene = new Person("marlene", "Muster", "Marlene", "muster@example.org");
+        marlene.setPermissions(List.of(USER, INACTIVE));
+        personService.save(marlene);
+
+        final Person peter = new Person("peter", "Muster", "Peter", "peter@example.org");
+        peter.setPermissions(List.of(USER, OFFICE));
+        personService.save(peter);
+
+        final Person bettina = new Person("bettina", "Muster", "bettina", "bettina@example.org");
+        bettina.setPermissions(List.of(USER));
+        personService.save(bettina);
+
+        final int countOfActivePersons = sut.countByPermissionsNotContaining(INACTIVE);
+        assertThat(countOfActivePersons).isEqualTo(2);
+    }
+}
+
+
+

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/PersonServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/PersonServiceImplTest.java
@@ -421,4 +421,13 @@ class PersonServiceImplTest {
         sut.save(activePerson);
         verifyNoInteractions(applicationEventPublisher);
     }
+
+    @Test
+    void numberOfActivePersons() {
+
+        when(personRepository.countByPermissionsNotContaining(INACTIVE)).thenReturn(2);
+
+        final int numberOfActivePersons = sut.numberOfActivePersons();
+        assertThat(numberOfActivePersons).isEqualTo(2);
+    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.person.metrics;
 
 import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,14 +24,16 @@ class PersonMetricsTest {
 
     @Test
     void countActiveUsers() {
-        Metrics.addRegistry(new SimpleMeterRegistry());
-        sut = new PersonMetrics(personService);
+        final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+        sut = new PersonMetrics(personService, registry);
 
         when(personService.getActivePersons()).thenReturn(List.of(new Person()));
 
-        sut.countActiveUsers();
+        final int countActiveUsers = sut.countActiveUsers();
 
-        Gauge gauge = Metrics.globalRegistry.find("users.active").gauge();
+        assertThat(countActiveUsers).isOne();
+        Gauge gauge = registry.find("users.active").gauge();
         assertThat(gauge.value()).isOne();
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/metrics/PersonMetricsTest.java
@@ -6,10 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -20,20 +17,18 @@ class PersonMetricsTest {
     @Mock
     private PersonService personService;
 
-    private PersonMetrics sut;
-
     @Test
     void countActiveUsers() {
         final SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
-        sut = new PersonMetrics(personService, registry);
+        final PersonMetrics sut = new PersonMetrics(personService, registry);
 
-        when(personService.getActivePersons()).thenReturn(List.of(new Person()));
+        when(personService.numberOfActivePersons()).thenReturn(1);
 
         final int countActiveUsers = sut.countActiveUsers();
-
         assertThat(countActiveUsers).isOne();
-        Gauge gauge = registry.find("users.active").gauge();
+
+        final Gauge gauge = registry.find("users.active").gauge();
         assertThat(gauge.value()).isOne();
     }
 }


### PR DESCRIPTION
* person metric was only updated once during startup
* add debug logging

### How to test

Prepare prometheus endpoint to check `users_active`-metric:

```yaml
management.endpoints.web.exposure.include=…,prometheus
management.endpoint.prometheus.enabled=true
```
Then inactivate or activate users in user settings.
<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
