### PR TITLE
Stornierte, nicht genehmigte, Anträge auf der Übersicht anzeigen (revoked)

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.util.StringUtils.hasText;
-import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.REVOKED;
 import static org.synyx.urlaubsverwaltung.util.DateUtil.getFirstDayOfYear;
 import static org.synyx.urlaubsverwaltung.util.DateUtil.getLastDayOfYear;
 
@@ -147,9 +146,7 @@ public class OverviewViewController {
 
         // get the person's applications for the given year
         final List<Application> applications =
-            applicationService.getApplicationsForACertainPeriodAndPerson(getFirstDayOfYear(year), getLastDayOfYear(year), person).stream()
-                .filter(input -> !input.hasStatus(REVOKED))
-                .collect(toList());
+            applicationService.getApplicationsForACertainPeriodAndPerson(getFirstDayOfYear(year), getLastDayOfYear(year), person);
 
         if (!applications.isEmpty()) {
             final List<ApplicationForLeave> applicationsForLeave = applications.stream()

--- a/src/main/webapp/WEB-INF/jsp/person/include/overview_app_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/person/include/overview_app_list.jsp
@@ -10,7 +10,7 @@
     <tbody>
     <c:forEach items="${applications}" var="app" varStatus="loopStatus">
         <c:choose>
-            <c:when test="${app.status == 'CANCELLED' || app.status == 'REJECTED'}">
+            <c:when test="${app.status == 'CANCELLED' || app.status == 'REJECTED' || app.status == 'REVOKED'}">
                 <c:set var="CSS_CLASS" value="inactive"/>
             </c:when>
             <c:otherwise>
@@ -42,7 +42,7 @@
                     <c:when test="${app.status == 'REJECTED'}">
                         <icon:ban className="tw-w-6 tw-h-6" />
                     </c:when>
-                    <c:when test="${app.status == 'CANCELLED'}">
+                    <c:when test="${app.status == 'CANCELLED'  || app.status == 'REVOKED'}">
                         <icon:trash className="tw-w-6 tw-h-6" />
                     </c:when>
                     <c:otherwise>&nbsp;</c:otherwise>

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -228,24 +228,28 @@ class OverviewViewControllerTest {
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
         when(workDaysCountService.getWorkDaysCount(any(), any(), any(), eq(person))).thenReturn(ONE);
 
-        final Application revokedApplication = new Application();
-        revokedApplication.setStatus(REVOKED);
-
         final VacationType vacationType = new VacationType();
         vacationType.setCategory(HOLIDAY);
+
+        final Application revokedApplication = new Application();
+        revokedApplication.setStatus(REVOKED);
+        revokedApplication.setVacationType(vacationType);
+        revokedApplication.setPerson(person);
+        revokedApplication.setStartDate(LocalDate.now(UTC).plusDays(1L));
+        revokedApplication.setEndDate(LocalDate.now(UTC).plusDays(2L));
 
         final Application waitingApplication = new Application();
         waitingApplication.setVacationType(vacationType);
         waitingApplication.setPerson(person);
         waitingApplication.setStatus(WAITING);
-        waitingApplication.setStartDate(LocalDate.now(UTC).minusDays(1L));
-        waitingApplication.setEndDate(LocalDate.now(UTC).plusDays(1L));
+        waitingApplication.setStartDate(LocalDate.now(UTC).plusDays(3L));
+        waitingApplication.setEndDate(LocalDate.now(UTC).plusDays(4L));
 
         final Application allowedApplication = new Application();
         allowedApplication.setVacationType(vacationType);
         allowedApplication.setPerson(person);
         allowedApplication.setStatus(ALLOWED);
-        allowedApplication.setStartDate(LocalDate.now(UTC).minusDays(10L));
+        allowedApplication.setStartDate(LocalDate.now(UTC).plusDays(5L));
         allowedApplication.setEndDate(LocalDate.now(UTC).plusDays(10L));
 
         when(applicationService.getApplicationsForACertainPeriodAndPerson(any(), any(), eq(person)))
@@ -263,7 +267,7 @@ class OverviewViewControllerTest {
         final ResultActions resultActions = perform(builder);
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(view().name("person/overview"));
-        resultActions.andExpect(model().attribute("applications", hasSize(2)));
+        resultActions.andExpect(model().attribute("applications", hasSize(3)));
         resultActions.andExpect(model().attribute("sickNotes", hasSize(2)));
         resultActions.andExpect(model().attribute("signedInUser", person));
     }


### PR DESCRIPTION
Mir ist gerade aufgefallen, das wir alle noch nicht genehmigten und dann stornierten Anträge (revoked) nicht auf der Übersichtsseite anzeigen und diese dann dem Benutzer gar nicht mehr zugänglich sind außer er kennt die id und verändert die url.
Damit wir darüber sprechen können habe ich mal diesen PR aufgemacht.