### PR TITLE
Trigger direkt über GitHub Actions zum Releasen 

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,29 @@
+changelog:
+  repository: synyx/urlaubsverwaltung
+  milestone-reference: id
+  sections:
+    - title: "⚠️ Security Issues"
+      labels: ["type: security"]
+      sort: "title"
+    - title: "⭐ Enhancements"
+      labels: ["type: enhancement"]
+      sort: "title"
+    - title: "🐞 Bugs"
+      labels: ["type: bug"]
+      sort: "title"
+    - title: "💥 Breaking Changes"
+      labels: ["type: breaking"]
+      sort: "title"
+    - title: "🚮 Deprecation"
+      labels: ["type: deprecation"]
+      sort: "title"
+    - title: "🔨 Dependency upgrades"
+      labels: ["type: dependencies"]
+      sort: "title"
+    - title: "📝 Documentation"
+      labels: ["type: documentation"]
+      sort: "title"
+  contributors:
+    title: "❤️ Contributors"
+    exclude:
+      names: ["dependabot[bot]"]

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -1,0 +1,30 @@
+name: Urlaubsverwaltung Release Trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version'
+        required: true
+        default: 'x.xx.x'
+      nextVersion:
+        description: 'Next version'
+        required: true
+        default: 'x.xx.x-SNAPSHOT'
+
+jobs:
+  trigger-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Trigger Release
+        run: ./release.sh
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+          NEW_VERSION: ${{ github.event.inputs.nextVersion }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -53,7 +53,7 @@ jobs:
         uses: fregante/setup-git-user@v1
       - name: Commit Release Notes
         run: |
-          git add .chglog/${{ github.event.inputs.milestoneId }}.md
+          git add .chglog/*.md
           git commit -m "Add release notes for ${{ github.event.inputs.milestoneId }}"
       - name: Push Release Notes
         uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -23,6 +23,22 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Cache pom dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            node/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Trigger Release
         run: ./release.sh
         env:

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -3,6 +3,10 @@ name: Urlaubsverwaltung Release Trigger
 on:
   workflow_dispatch:
     inputs:
+      milestoneId:
+        description: 'Milestone ID'
+        required: true
+        default: '1'
       releaseVersion:
         description: 'Release version'
         required: true
@@ -39,6 +43,22 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Create Release Notes
+        uses: docker://decathlon/release-notes-generator-action:3.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTPUT_FOLDER: .chglog
+          USE_MILESTONE_TITLE: "true"
+      - name: Setup git user
+        uses: fregante/setup-git-user@v1
+      - name: Commit Release Notes
+        run: |
+          git add .chglog/${{ github.event.inputs.milestoneId }}.md
+          git commit -m "Add release notes for ${{ github.event.inputs.milestoneId }}"
+      - name: Push Release Notes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.AM_PAT }}
       - name: Trigger Release
         run: ./release.sh
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,14 @@ jobs:
         run: ./mvnw --batch-mode clean verify
       - name: Extract release tag
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/urlaubsverwaltung-}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: Release ${{ steps.vars.outputs.tag }}
-          body: Die Änderungen in dieser Version können im [Changelog](https://github.com/synyx/urlaubsverwaltung/blob/master/CHANGELOG.md) nachgelesen werden.
+          name: Release Urlaubsverwaltung ${{ steps.vars.outputs.version }}
+          body_path: .chglog/${{ steps.vars.outputs.version }}.md
           files: ./target/urlaubsverwaltung-*.war
       - name: Publish docker image to Docker Hub
         run: >


### PR DESCRIPTION
Über den bereitgestellten Workflow kann man nun ein release mit release notes direkt aus der UI bauen.