### PR TITLE
Entfernen von Assert aufrufen

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/Absence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/Absence.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.absence;
 
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.period.Period;
 import org.synyx.urlaubsverwaltung.person.Person;
 
@@ -27,10 +26,6 @@ public class Absence {
     }
 
     public Absence(Person person, Period period, AbsenceTimeConfiguration absenceTimeConfiguration, AbsenceType absenceType) {
-
-        Assert.notNull(person, "Person must be given");
-        Assert.notNull(period, "Period must be given");
-        Assert.notNull(absenceTimeConfiguration, "Time configuration must be given");
 
         this.person = person;
         this.absenceType = absenceType;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/domain/VacationType.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/domain/VacationType.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.application.domain;
 
-import org.springframework.util.Assert;
-
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
@@ -45,7 +43,6 @@ public class VacationType {
     }
 
     public boolean isOfCategory(VacationCategory category) {
-        Assert.notNull(category, "Vacation category must be given");
         return getCategory().equals(category);
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
@@ -2,7 +2,6 @@ package org.synyx.urlaubsverwaltung.application.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.application.dao.ApplicationRepository;
 import org.synyx.urlaubsverwaltung.application.domain.Application;
 import org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus;
@@ -80,8 +79,6 @@ class ApplicationServiceImpl implements ApplicationService {
 
     @Override
     public Duration getTotalOvertimeReductionOfPerson(Person person) {
-        Assert.notNull(person, "Person to get overtime reduction for must be given.");
-
         final BigDecimal overtimeReduction = Optional.ofNullable(applicationRepository.calculateTotalOvertimeReductionOfPerson(person)).orElse(BigDecimal.ZERO);
         return Duration.ofMinutes(overtimeReduction.multiply(BigDecimal.valueOf(60)).longValue());
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatistics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatistics.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.application.statistics;
 
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.application.domain.VacationType;
 import org.synyx.urlaubsverwaltung.application.service.VacationTypeService;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -18,9 +17,6 @@ import static java.math.BigDecimal.ZERO;
  */
 public class ApplicationForLeaveStatistics {
 
-    private static final String VACATION_TYPE_MUST_BE_GIVEN = "Vacation type must be given.";
-    private static final String DAYS_MUST_BE_GIVEN = "Days must be given.";
-
     private final Person person;
 
     private final Map<VacationType, BigDecimal> waitingVacationDays = new HashMap<>();
@@ -30,9 +26,6 @@ public class ApplicationForLeaveStatistics {
     private Duration leftOvertime = Duration.ZERO;
 
     public ApplicationForLeaveStatistics(Person person, VacationTypeService vacationTypeService) {
-
-        Assert.notNull(person, "Person must be given.");
-
         this.person = person;
 
         for (VacationType vacationType : vacationTypeService.getVacationTypes()) {
@@ -78,39 +71,22 @@ public class ApplicationForLeaveStatistics {
     }
 
     public void setLeftVacationDays(BigDecimal leftVacationDays) {
-
-        Assert.notNull(leftVacationDays, DAYS_MUST_BE_GIVEN);
-
         this.leftVacationDays = leftVacationDays;
     }
 
     public void addWaitingVacationDays(VacationType vacationType, BigDecimal waitingVacationDays) {
-
-        Assert.notNull(vacationType, VACATION_TYPE_MUST_BE_GIVEN);
-        Assert.notNull(waitingVacationDays, DAYS_MUST_BE_GIVEN);
-
         BigDecimal currentWaitingVacationDays = getWaitingVacationDays().get(vacationType);
-
         getWaitingVacationDays().put(vacationType, currentWaitingVacationDays.add(waitingVacationDays));
     }
 
     public void addAllowedVacationDays(VacationType vacationType, BigDecimal allowedVacationDays) {
-
-        Assert.notNull(vacationType, VACATION_TYPE_MUST_BE_GIVEN);
-        Assert.notNull(allowedVacationDays, DAYS_MUST_BE_GIVEN);
-
         BigDecimal currentAllowedVacationDays = getAllowedVacationDays().get(vacationType);
-
         getAllowedVacationDays().put(vacationType, currentAllowedVacationDays.add(allowedVacationDays));
     }
 
     public void setLeftOvertime(Duration leftOvertime) {
-
-        Assert.notNull(leftOvertime, "Overtime must be given.");
-
         this.leftOvertime = leftOvertime;
     }
-
 
     public Duration getLeftOvertime() {
         return leftOvertime;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
@@ -55,9 +55,6 @@ public class ApplicationForLeaveStatisticsBuilder {
     }
 
     public ApplicationForLeaveStatistics build(Person person, LocalDate from, LocalDate to) {
-        Assert.notNull(person, "Person must be given");
-        Assert.notNull(from, "From must be given");
-        Assert.notNull(to, "To must be given");
         Assert.isTrue(from.getYear() == to.getYear(), "From and to must be in the same year");
 
         final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(person, vacationTypeService);

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/Overtime.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/Overtime.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.overtime;
 
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.person.Person;
 
 import javax.persistence.Column;
@@ -49,12 +48,6 @@ public class Overtime {
     }
 
     public Overtime(Person person, LocalDate startDate, LocalDate endDate, Duration duration) {
-
-        Assert.notNull(person, "Person must be given.");
-        Assert.notNull(startDate, "Start date must be given.");
-        Assert.notNull(endDate, "End date must be given.");
-        Assert.notNull(duration, "Duration of must be given.");
-
         this.person = person;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -96,30 +89,18 @@ public class Overtime {
     }
 
     public void setPerson(Person person) {
-
-        Assert.notNull(person, "Person must be given.");
-
         this.person = person;
     }
 
     public void setStartDate(LocalDate startDate) {
-
-        Assert.notNull(startDate, "Start date must be given.");
-
         this.startDate = startDate;
     }
 
     public void setEndDate(LocalDate endDate) {
-
-        Assert.notNull(endDate, "End date must be given.");
-
         this.endDate = endDate;
     }
 
     public void setDuration(Duration duration) {
-
-        Assert.notNull(duration, "Duration of overtime must be given.");
-
         this.duration = duration;
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeComment.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeComment.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.overtime;
 
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.comment.AbstractComment;
 import org.synyx.urlaubsverwaltung.person.Person;
 
@@ -37,11 +36,6 @@ public class OvertimeComment extends AbstractComment {
 
     public OvertimeComment(Person author, Overtime overtime, OvertimeCommentAction action, Clock clock) {
         super(clock);
-
-        Assert.notNull(author, "Author must be given.");
-        Assert.notNull(overtime, "Overtime record must be given.");
-        Assert.notNull(action, "Action must be given.");
-
         super.setPerson(author);
 
         this.overtime = overtime;

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
@@ -21,7 +21,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeCommentAction.CREATED;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeCommentAction.EDITED;
 
-
 /**
  * @since 2.11.0
  */
@@ -51,17 +50,11 @@ class OvertimeServiceImpl implements OvertimeService {
 
     @Override
     public List<Overtime> getOvertimeRecordsForPerson(Person person) {
-
-        Assert.notNull(person, "Person to get overtime records for must be given.");
-
         return overtimeRepository.findByPerson(person);
     }
 
     @Override
     public List<Overtime> getOvertimeRecordsForPersonAndYear(Person person, int year) {
-
-        Assert.notNull(person, "Person to get overtime records for must be given.");
-
         return overtimeRepository.findByPersonAndPeriod(person, DateUtil.getFirstDayOfYear(year), DateUtil.getLastDayOfYear(year));
     }
 
@@ -90,24 +83,16 @@ class OvertimeServiceImpl implements OvertimeService {
 
     @Override
     public Optional<Overtime> getOvertimeById(Integer id) {
-
-        Assert.notNull(id, "ID must be given.");
-
         return overtimeRepository.findById(id);
     }
 
     @Override
     public List<OvertimeComment> getCommentsForOvertime(Overtime overtime) {
-
-        Assert.notNull(overtime, "Overtime record to get comments for must be given.");
-
         return overtimeCommentRepository.findByOvertime(overtime);
     }
 
     @Override
     public Duration getTotalOvertimeForPersonAndYear(Person person, int year) {
-
-        Assert.notNull(person, "Person to get total overtime for must be given.");
         Assert.isTrue(year > 0, "Year must be a valid number.");
 
         final List<Overtime> overtimeRecords = getOvertimeRecordsForPersonAndYear(person, year);
@@ -122,9 +107,6 @@ class OvertimeServiceImpl implements OvertimeService {
 
     @Override
     public Duration getLeftOvertimeForPerson(Person person) {
-
-        Assert.notNull(person, "Person to get left overtime for must be given.");
-
         final Duration totalOvertime = getTotalOvertimeForPerson(person);
         final Duration overtimeReduction = applicationService.getTotalOvertimeReductionOfPerson(person);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeForm.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.overtime.web;
 
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.overtime.Overtime;
 import org.synyx.urlaubsverwaltung.person.Person;
 
@@ -38,15 +37,10 @@ public class OvertimeForm {
     }
 
     public OvertimeForm(Person person) {
-
-        Assert.notNull(person, "Person must be given.");
         this.person = person;
     }
 
     public OvertimeForm(Overtime overtime) {
-
-        Assert.notNull(overtime, "Overtime must be given.");
-
         final BigDecimal overtimeHours = overtime.getDuration() == null ? BigDecimal.ZERO : BigDecimal.valueOf((double) overtime.getDuration().toMinutes() / 60);
 
         this.id = overtime.getId();

--- a/src/main/java/org/synyx/urlaubsverwaltung/period/Period.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/period/Period.java
@@ -14,10 +14,6 @@ public class Period {
     private final DayLength dayLength;
 
     public Period(LocalDate startDate, LocalDate endDate, DayLength dayLength) {
-
-        Assert.notNull(startDate, "Start date must be given");
-        Assert.notNull(endDate, "End date must be given");
-        Assert.notNull(dayLength, "Day length must be given");
         Assert.isTrue(!dayLength.equals(DayLength.ZERO), "Day length may not be zero");
 
         boolean isFullDay = dayLength.equals(DayLength.FULL);

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/ldap/LdapPersonContextMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/ldap/LdapPersonContextMapper.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.ldap.userdetails.Person.Essence;
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
-import org.springframework.util.Assert;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.person.Role;
@@ -103,15 +102,12 @@ public class LdapPersonContextMapper implements UserDetailsContextMapper {
      * @return the granted authorities for the person
      */
     Collection<GrantedAuthority> getGrantedAuthorities(Person person) {
-
-        Assert.notNull(person, "Person must be given.");
-
-        Collection<Role> permissions = person.getPermissions();
+        final Collection<Role> permissions = person.getPermissions();
         if (permissions.isEmpty()) {
             throw new IllegalStateException("Every user must have at least one role, data seems to be corrupt.");
         }
 
-        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        final Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
         permissions.forEach(role -> grantedAuthorities.add(role::name));
 
         return grantedAuthorities;

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteType.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteType.java
@@ -1,7 +1,5 @@
 package org.synyx.urlaubsverwaltung.sicknote;
 
-import org.springframework.util.Assert;
-
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
@@ -35,7 +33,6 @@ public class SickNoteType {
     }
 
     public boolean isOfCategory(SickNoteCategory category) {
-        Assert.notNull(category, "Sick note category must be given");
         return getCategory().equals(category);
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceTest.java
@@ -134,26 +134,6 @@ class AbsenceTest {
     }
 
     @Test
-    void ensureThrowsOnNullPeriod() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new Absence(person, null, timeConfiguration));
-    }
-
-    @Test
-    void ensureThrowsOnNullPerson() {
-        Period period = new Period(LocalDate.now(clock), LocalDate.now(clock), DayLength.FULL);
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new Absence(null, period, timeConfiguration));
-    }
-
-    @Test
-    void ensureThrowsOnNullConfiguration() {
-        Period period = new Period(LocalDate.now(clock), LocalDate.now(clock), DayLength.FULL);
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new Absence(person, period, null));
-    }
-
-    @Test
     void ensureCorrectEventSubject() {
 
         LocalDate today = LocalDate.now(clock);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepositoryIT.java
@@ -363,8 +363,8 @@ class ApplicationRepositoryIT extends TestContainersBase {
         final Person savedPerson = personService.save(person);
 
         // correct
-        final LocalDate from = LocalDate.of(2020,5,3);
-        final LocalDate to = LocalDate.of(2020,5,10);
+        final LocalDate from = LocalDate.of(2020, 5, 3);
+        final LocalDate to = LocalDate.of(2020, 5, 10);
         final Application waitingApplication = createApplication(savedPerson, getVacationType(OVERTIME), from, to, FULL);
         waitingApplication.setHolidayReplacement(savedHolidayReplacement);
         waitingApplication.setStatus(WAITING);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/domain/ApplicationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/domain/ApplicationTest.java
@@ -64,39 +64,6 @@ class ApplicationTest {
 
     // Period ----------------------------------------------------------------------------------------------------------
     @Test
-    void ensureThrowsIfTryingToGetPeriodForApplicationWithoutStartDate() {
-
-        Application application = new Application();
-        application.setStartDate(null);
-        application.setEndDate(LocalDate.now(UTC));
-        application.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(application::getPeriod);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForApplicationWithoutEndDate() {
-
-        Application application = new Application();
-        application.setStartDate(LocalDate.now(UTC));
-        application.setEndDate(null);
-        application.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(application::getPeriod);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForApplicationWithoutDayLength() {
-
-        Application application = new Application();
-        application.setStartDate(LocalDate.now(UTC));
-        application.setEndDate(LocalDate.now(UTC));
-        application.setDayLength(null);
-
-        assertThatIllegalArgumentException().isThrownBy(application::getPeriod);
-    }
-
-    @Test
     void ensureGetPeriodReturnsCorrectPeriod() {
 
         LocalDate startDate = LocalDate.now(UTC);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/domain/ApplicationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/domain/ApplicationTest.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.application.domain;
 
 import org.junit.jupiter.api.Test;
-import org.synyx.urlaubsverwaltung.absence.AbsenceMapping;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.period.Period;
 import org.synyx.urlaubsverwaltung.person.Person;

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/domain/VacationTypeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/domain/VacationTypeTest.java
@@ -1,19 +1,12 @@
 package org.synyx.urlaubsverwaltung.application.domain;
 
 import org.junit.jupiter.api.Test;
-import org.synyx.urlaubsverwaltung.absence.AbsenceMapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.synyx.urlaubsverwaltung.application.domain.VacationCategory.HOLIDAY;
 import static org.synyx.urlaubsverwaltung.application.domain.VacationCategory.OVERTIME;
 
 class VacationTypeTest {
-
-    @Test
-    void ensureThrowsIfCheckingCategoryWithNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new VacationType().isOfCategory(null));
-    }
 
     @Test
     void ensureReturnsTrueIfVacationTypeIsOfGivenCategory() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationInteractionServiceImplTest.java
@@ -11,8 +11,8 @@ import org.synyx.urlaubsverwaltung.absence.AbsenceMappingService;
 import org.synyx.urlaubsverwaltung.absence.TimeSettings;
 import org.synyx.urlaubsverwaltung.account.AccountInteractionService;
 import org.synyx.urlaubsverwaltung.application.domain.Application;
-import org.synyx.urlaubsverwaltung.application.domain.ApplicationCommentAction;
 import org.synyx.urlaubsverwaltung.application.domain.ApplicationComment;
+import org.synyx.urlaubsverwaltung.application.domain.ApplicationCommentAction;
 import org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.calendarintegration.CalendarSyncService;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
@@ -1157,15 +1157,15 @@ class ApplicationInteractionServiceImplTest {
         final Application newApplication = createApplication(person, createVacationType(HOLIDAY));
         newApplication.setStatus(WAITING);
         newApplication.setId(applicationId);
-        newApplication.setStartDate(LocalDate.of(2020,10,3));
-        newApplication.setEndDate(LocalDate.of(2020,10,3));
+        newApplication.setStartDate(LocalDate.of(2020, 10, 3));
+        newApplication.setEndDate(LocalDate.of(2020, 10, 3));
         newApplication.setHolidayReplacement(holidayReplacement);
         when(applicationService.save(newApplication)).thenReturn(newApplication);
 
         final Application oldApplication = createApplication(person, createVacationType(HOLIDAY));
         oldApplication.setHolidayReplacement(holidayReplacement);
-        oldApplication.setStartDate(LocalDate.of(2020,10,4));
-        oldApplication.setEndDate(LocalDate.of(2020,10,4));
+        oldApplication.setStartDate(LocalDate.of(2020, 10, 4));
+        oldApplication.setEndDate(LocalDate.of(2020, 10, 4));
 
         final Optional<String> comment = of("Comment");
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceTest.java
@@ -344,7 +344,7 @@ class ApplicationMailServiceTest {
         model.put("dayLength", "FULL");
 
         final String calendarName = "Vertretung für ...";
-        when(messageSource.getMessage("calendar.mail.holiday-replacement.name",  new Object[]{"Theo Fritz"}, Locale.GERMAN)).thenReturn(calendarName);
+        when(messageSource.getMessage("calendar.mail.holiday-replacement.name", new Object[]{"Theo Fritz"}, Locale.GERMAN)).thenReturn(calendarName);
 
         final File file = new File("");
         when(iCalService.getCalendar(eq(calendarName), any())).thenReturn(file);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.ALLOWED;
@@ -65,11 +64,6 @@ class ApplicationServiceImplTest {
     }
 
     // Get total overtime reduction ------------------------------------------------------------------------------------
-    @Test
-    void ensureThrowsIfTryingToGetTotalOvertimeReductionForNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getTotalOvertimeReductionOfPerson(null));
-    }
-
     @Test
     void ensureReturnsZeroIfPersonHasNoApplicationsForLeaveYet() {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -73,16 +73,6 @@ class ApplicationForLeaveStatisticsBuilderTest {
     }
 
     @Test
-    void ensureThrowsIfTheGivenFromDateIsNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.build(mock(Person.class), null, LocalDate.of(2015, 12, 31)));
-    }
-
-    @Test
-    void ensureThrowsIfTheGivenToDateIsNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.build(mock(Person.class), LocalDate.of(2014, 1, 1), null));
-    }
-
-    @Test
     void ensureThrowsIfTheGivenFromAndToDatesAreNotInTheSameYear() {
         assertThatIllegalArgumentException().isThrownBy(() -> sut.build(mock(Person.class), LocalDate.of(2014, 1, 1), LocalDate.of(2015, 1, 1)));
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -68,11 +68,6 @@ class ApplicationForLeaveStatisticsBuilderTest {
     }
 
     @Test
-    void ensureThrowsIfTheGivenPersonIsNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.build(null, LocalDate.of(2015, 1, 1), LocalDate.of(2015, 12, 31)));
-    }
-
-    @Test
     void ensureThrowsIfTheGivenFromAndToDatesAreNotInTheSameYear() {
         assertThatIllegalArgumentException().isThrownBy(() -> sut.build(mock(Person.class), LocalDate.of(2014, 1, 1), LocalDate.of(2015, 1, 1)));
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsTest.java
@@ -15,22 +15,14 @@ import java.util.List;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.when;
-import static org.synyx.urlaubsverwaltung.TestDataCreator.createVacationType;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createVacationTypes;
-import static org.synyx.urlaubsverwaltung.application.domain.VacationCategory.HOLIDAY;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationForLeaveStatisticsTest {
 
     @Mock
     private VacationTypeService vacationTypeService;
-
-    @Test
-    void ensureThrowsIfInitializedWithNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new ApplicationForLeaveStatistics(null, null));
-    }
 
     @Test
     void ensureHasDefaultValues() {
@@ -67,46 +59,7 @@ class ApplicationForLeaveStatisticsTest {
         assertThat(statistics.getLeftVacationDays()).isEqualByComparingTo(ONE);
     }
 
-    @Test
-    void ensureThrowsIfSettingTotalLeftVacationDaysToNull() {
-        final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> statistics.setLeftVacationDays(null));
-    }
-
     // Adding vacation days --------------------------------------------------------------------------------------------
-    @Test
-    void ensureThrowsIfAddingWaitingVacationDaysWithNullVacationType() {
-        final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> statistics.addWaitingVacationDays(null, ONE));
-    }
-
-
-    @Test
-    void ensureThrowsIfAddingWaitingVacationDaysWithNullDays() {
-        final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> statistics.addWaitingVacationDays(createVacationType(HOLIDAY), null));
-    }
-
-    @Test
-    void ensureThrowsIfAddingAllowedVacationDaysWithNullVacationType() {
-        final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> statistics.addAllowedVacationDays(null, ONE));
-    }
-
-    @Test
-    void ensureThrowsIfAddingAllowedVacationDaysWithNullDays() {
-        final ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> statistics.addAllowedVacationDays(createVacationType(HOLIDAY), null));
-    }
-
     @Test
     void ensureCanAddWaitingVacationDays() {
         final List<VacationType> vacationTypes = createVacationTypes();
@@ -183,12 +136,5 @@ class ApplicationForLeaveStatisticsTest {
         ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
         statistics.setLeftOvertime(Duration.ofHours(1));
         assertThat(statistics.getLeftOvertime()).isEqualTo(Duration.ofHours(1));
-    }
-
-    @Test
-    void ensureThrowsIfSettingTotalLeftOvertimeToNull() {
-        ApplicationForLeaveStatistics statistics = new ApplicationForLeaveStatistics(new Person("muster", "Muster", "Marlene", "muster@example.org"), vacationTypeService);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> statistics.setLeftOvertime(null));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveDetailsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveDetailsViewControllerTest.java
@@ -691,7 +691,7 @@ class ApplicationForLeaveDetailsViewControllerTest {
     }
 
     @Test
-    void cancelCancellationRequestApplicationWithValidationErrors() throws Exception{
+    void cancelCancellationRequestApplicationWithValidationErrors() throws Exception {
 
         when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
         when(applicationService.getApplicationById(APPLICATION_ID)).thenReturn(Optional.of(cancellationRequestedApplication()));
@@ -708,7 +708,7 @@ class ApplicationForLeaveDetailsViewControllerTest {
     }
 
     @Test
-    void cancelCancellationRequestApplication() throws Exception{
+    void cancelCancellationRequestApplication() throws Exception {
 
         final Person signedInPerson = personWithRole(OFFICE);
         when(personService.getSignedInUser()).thenReturn(signedInPerson);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormValidatorTest.java
@@ -768,6 +768,7 @@ class ApplicationForLeaveFormValidatorTest {
     }
 
     // Validate maximal overtime reduction -----------------------------------------------------------------------------
+
     /**
      * User tries to make an application (overtime reduction) but has not enough overtime left and minimum overtime is
      * reached.

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeCommentTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeCommentTest.java
@@ -12,31 +12,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createOvertimeRecord;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeCommentAction.CREATED;
 
-
 class OvertimeCommentTest {
 
     private final Clock clock = Clock.systemUTC();
-
-    @Test
-    void ensureThrowsOnNullPerson() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new OvertimeComment(null, createOvertimeRecord(), CREATED, clock));
-    }
-
-
-    @Test
-    void ensureThrowsOnNullOvertime() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new OvertimeComment(new Person("muster", "Muster", "Marlene", "muster@example.org"), null, CREATED, clock));
-    }
-
-
-    @Test
-    void ensureThrowsOnNullAction() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new OvertimeComment(new Person("muster", "Muster", "Marlene", "muster@example.org"), createOvertimeRecord(), null, clock));
-    }
-
 
     @Test
     void ensureCorrectPropertiesAfterInitialization() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeCommentTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeCommentTest.java
@@ -8,9 +8,7 @@ import java.time.Instant;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createOvertimeRecord;
-import static org.synyx.urlaubsverwaltung.overtime.OvertimeCommentAction.CREATED;
 
 class OvertimeCommentTest {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
@@ -154,11 +154,6 @@ class OvertimeServiceImplTest {
         verify(overtimeRepository).findByPerson(person);
     }
 
-    @Test
-    void ensureThrowsIfTryingToGetOvertimeForNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getOvertimeRecordsForPerson(null));
-    }
-
     // Get overtime record by ID ---------------------------------------------------------------------------------------
     @Test
     void ensureGetByIDCallsCorrectDAOMethod() {
@@ -166,11 +161,6 @@ class OvertimeServiceImplTest {
         sut.getOvertimeById(42);
 
         verify(overtimeRepository).findById(42);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetOvertimeByEmptyID() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getOvertimeById(null));
     }
 
     @Test
@@ -183,11 +173,6 @@ class OvertimeServiceImplTest {
     }
 
     // Get overtime records for person and year ------------------------------------------------------------------------
-    @Test
-    void ensureThrowsIfTryingToGetRecordsByPersonAndYearWithNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getOvertimeRecordsForPersonAndYear(null, 2015));
-    }
-
     @Test
     void ensureGetRecordsByPersonAndYearCallsCorrectDAOMethod() {
 
@@ -210,17 +195,7 @@ class OvertimeServiceImplTest {
         verify(commentDAO).findByOvertime(overtime);
     }
 
-    @Test
-    void ensureThrowsIfTryingToGetCommentsForNullOvertime() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getCommentsForOvertime(null));
-    }
-
     // Get total overtime for year -------------------------------------------------------------------------------------
-    @Test
-    void ensureThrowsIfTryingToGetYearOvertimeForNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getTotalOvertimeForPersonAndYear(null, 2016));
-    }
-
     @Test
     void ensureThrowsIfTryingToGetYearOvertimeForNegativeYear() {
         assertThatIllegalArgumentException().isThrownBy(() -> sut.getTotalOvertimeForPersonAndYear(new Person("muster", "Muster", "Marlene", "muster@example.org"), -1));
@@ -270,11 +245,6 @@ class OvertimeServiceImplTest {
     }
 
     // Get left overtime -----------------------------------------------------------------------------------------------
-    @Test
-    void ensureThrowsIfTryingToGetLeftOvertimeForNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getLeftOvertimeForPerson(null));
-    }
-
     @Test
     void ensureReturnsZeroAsLeftOvertimeIfPersonHasNoOvertimeRecordsYet() {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeTest.java
@@ -2,7 +2,6 @@ package org.synyx.urlaubsverwaltung.overtime;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ReflectionUtils;
-import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.person.Person;
 
 import java.lang.reflect.Field;
@@ -12,43 +11,12 @@ import java.util.List;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_USER;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
 
 
 class OvertimeTest {
-
-    @Test
-    void ensureThrowsOnNullPerson() {
-        LocalDate now = LocalDate.now(UTC);
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime(null, now, now, Duration.ofHours(1)));
-    }
-
-    @Test
-    void ensureThrowsOnNullStartDate() {
-        Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        LocalDate now = LocalDate.now(UTC);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime(person, null, now, Duration.ofHours(1)));
-    }
-
-    @Test
-    void ensureThrowsOnNullEndDate() {
-        Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        LocalDate now = LocalDate.now(UTC);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime(person, now, null, Duration.ofHours(1)));
-    }
-
-    @Test
-    void ensureThrowsOnNullNumberOfHours() {
-        Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        LocalDate now = LocalDate.now(UTC);
-
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime(person, now, now, null));
-    }
 
     @Test
     void ensureReturnsCorrectStartDate() {
@@ -136,26 +104,6 @@ class OvertimeTest {
         assertThat(overtime.getLastModificationDate()).isEqualTo(now.minusDays(3));
         overtime.onUpdate();
         assertThat(overtime.getLastModificationDate()).isEqualTo(now);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToSetStartDateToNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime().setStartDate(null));
-    }
-
-    @Test
-    void ensureThrowsIfTryingToSetEndDateToNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime().setEndDate(null));
-    }
-
-    @Test
-    void ensureThrowsIfTryingToSetHoursToNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime().setDuration(null));
-    }
-
-    @Test
-    void ensureThrowsIfTryingToSetPersonToNull() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Overtime().setPerson(null));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormTest.java
@@ -14,7 +14,6 @@ import java.time.ZonedDateTime;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class OvertimeFormTest {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormTest.java
@@ -16,13 +16,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-
 class OvertimeFormTest {
-
-    @Test
-    void ensureThrowsIfInitializedWithNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new OvertimeForm((Person) null));
-    }
 
     @Test
     void ensureCanBeInitializedWithPerson() {
@@ -103,17 +97,6 @@ class OvertimeFormTest {
         overtimeForm.setEndDate(LocalDate.parse("2020-10-30"));
 
         assertThat(overtimeForm.getEndDateIsoValue()).isEqualTo("2020-10-30");
-    }
-
-    @Test
-    void ensureThrowsIfGeneratingOvertimeWithoutCheckingFormAttributes() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new OvertimeForm(new Person("muster", "Muster", "Marlene", "muster@example.org")).generateOvertime());
-    }
-
-
-    @Test
-    void ensureThrowsIfInitializedWithNullOvertime() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new OvertimeForm((Overtime) null));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormValidatorTest.java
@@ -318,7 +318,7 @@ class OvertimeFormValidatorTest {
         overtimeForm.setMinutes(30);
 
         sut.validate(overtimeForm, errors);
-        verify(errors).reject("overtime.data.numberOfHours.error.maxOvertime",new Object[]{Duration.ofHours(16)}, null);
+        verify(errors).reject("overtime.data.numberOfHours.error.maxOvertime", new Object[]{Duration.ofHours(16)}, null);
         verify(settingsService).getSettings();
         verify(overtimeService).getLeftOvertimeForPerson(overtimeForm.getPerson());
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/period/PeriodTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/period/PeriodTest.java
@@ -12,27 +12,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class PeriodTest {
 
     @Test
-    void ensureThrowsOnNullStartDate() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Period(null, LocalDate.now(UTC), DayLength.FULL));
-    }
-
-    @Test
-    void ensureThrowsOnNullEndDate() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Period(LocalDate.now(UTC), null, DayLength.FULL));
-    }
-
-
-    @Test
-    void ensureThrowsOnNullDayLength() {
-        assertThatIllegalArgumentException().isThrownBy(() -> new Period(LocalDate.now(UTC), LocalDate.now(UTC), null));
-    }
-
-
-    @Test
     void ensureThrowsOnZeroDayLength() {
         assertThatIllegalArgumentException().isThrownBy(() -> new Period(LocalDate.now(UTC), LocalDate.now(UTC), DayLength.ZERO));
     }
-
 
     @Test
     void ensureThrowsIfEndDateIsBeforeStartDate() {
@@ -43,20 +25,17 @@ class PeriodTest {
         assertThatIllegalArgumentException().isThrownBy(() -> new Period(startDate, endDateBeforeStartDate, DayLength.FULL));
     }
 
-
     @Test
     void ensureThrowsIfStartAndEndDateAreNotSameForMorningDayLength() {
         LocalDate startDate = LocalDate.now(UTC);
         assertThatIllegalArgumentException().isThrownBy(() -> new Period(startDate, startDate.plusDays(1), DayLength.MORNING));
     }
 
-
     @Test
     void ensureThrowsIfStartAndEndDateAreNotSameForNoonDayLength() {
         LocalDate startDate = LocalDate.now(UTC);
         assertThatIllegalArgumentException().isThrownBy(() -> new Period(startDate, startDate.plusDays(1), DayLength.NOON));
     }
-
 
     @Test
     void ensureCanBeInitializedWithFullDay() {
@@ -70,7 +49,6 @@ class PeriodTest {
         assertThat(period.getEndDate()).isEqualTo(endDate);
         assertThat(period.getDayLength()).isEqualTo(DayLength.FULL);
     }
-
 
     @Test
     void ensureCanBeInitializedWithHalfDay() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/ldap/LdapPersonContextMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/ldap/LdapPersonContextMapperTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -57,11 +56,6 @@ class LdapPersonContextMapperTest {
     @BeforeEach
     void setUp() {
         sut = new LdapPersonContextMapper(personService, ldapUserMapper);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetAuthoritiesForNullPerson() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.getGrantedAuthorities(null));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
@@ -93,43 +93,6 @@ class SickNoteTest {
         assertActive.accept(SickNoteStatus.ACTIVE);
     }
 
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutStartDate() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(null);
-        sickNote.setEndDate(LocalDate.now(UTC));
-        sickNote.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutEndDate() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(LocalDate.now(UTC));
-        sickNote.setEndDate(null);
-        sickNote.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutDayLength() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(LocalDate.now(UTC));
-        sickNote.setEndDate(LocalDate.now(UTC));
-        sickNote.setDayLength(null);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-
     @Test
     void ensureGetPeriodReturnsCorrectPeriod() {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
@@ -26,7 +26,6 @@ class SickNoteTest {
         assertThat(sickNote.getLastEdited()).isEqualTo(LocalDate.now(UTC));
     }
 
-
     @Test
     void ensureAUBIsPresentIfAUBStartDateAndAUBEndDateAreSet() {
 
@@ -37,7 +36,6 @@ class SickNoteTest {
         assertThat(sickNote.isAubPresent()).isTrue();
     }
 
-
     @Test
     void ensureAUBIsNotPresentIfOnlyAUBStartDateIsSet() {
 
@@ -46,7 +44,6 @@ class SickNoteTest {
 
         assertThat(sickNote.isAubPresent()).isFalse();
     }
-
 
     @Test
     void ensureAUBIsNotPresentIfOnlyAUBEndDateIsSet() {
@@ -57,13 +54,11 @@ class SickNoteTest {
         assertThat(sickNote.isAubPresent()).isFalse();
     }
 
-
     @Test
     void ensureAUBIsNotPresentIfNoAUBPeriodIsSet() {
 
         assertThat(new SickNote().isAubPresent()).isFalse();
     }
-
 
     @Test
     void ensureIsNotActiveForInactiveStatus() {
@@ -79,7 +74,6 @@ class SickNoteTest {
         assertNotActive.accept(SickNoteStatus.CONVERTED_TO_VACATION);
     }
 
-
     @Test
     void ensureIsActiveForActiveStatus() {
 
@@ -91,6 +85,39 @@ class SickNoteTest {
         };
 
         assertActive.accept(SickNoteStatus.ACTIVE);
+    }
+
+    @Test
+    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutStartDate() {
+
+        SickNote sickNote = new SickNote();
+        sickNote.setStartDate(null);
+        sickNote.setEndDate(LocalDate.now(UTC));
+        sickNote.setDayLength(DayLength.FULL);
+
+        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
+    }
+
+    @Test
+    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutEndDate() {
+
+        SickNote sickNote = new SickNote();
+        sickNote.setStartDate(LocalDate.now(UTC));
+        sickNote.setEndDate(null);
+        sickNote.setDayLength(DayLength.FULL);
+
+        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
+    }
+
+    @Test
+    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutDayLength() {
+
+        SickNote sickNote = new SickNote();
+        sickNote.setStartDate(LocalDate.now(UTC));
+        sickNote.setEndDate(LocalDate.now(UTC));
+        sickNote.setDayLength(null);
+
+        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
@@ -10,7 +10,6 @@ import java.util.function.Consumer;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 
 /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTest.java
@@ -88,39 +88,6 @@ class SickNoteTest {
     }
 
     @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutStartDate() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(null);
-        sickNote.setEndDate(LocalDate.now(UTC));
-        sickNote.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutEndDate() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(LocalDate.now(UTC));
-        sickNote.setEndDate(null);
-        sickNote.setDayLength(DayLength.FULL);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-    @Test
-    void ensureThrowsIfTryingToGetPeriodForSickNoteWithoutDayLength() {
-
-        SickNote sickNote = new SickNote();
-        sickNote.setStartDate(LocalDate.now(UTC));
-        sickNote.setEndDate(LocalDate.now(UTC));
-        sickNote.setDayLength(null);
-
-        assertThatIllegalArgumentException().isThrownBy(sickNote::getPeriod);
-    }
-
-    @Test
     void ensureGetPeriodReturnsCorrectPeriod() {
 
         LocalDate startDate = LocalDate.now(UTC);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTypeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteTypeTest.java
@@ -13,12 +13,6 @@ import static org.synyx.urlaubsverwaltung.sicknote.SickNoteCategory.SICK_NOTE_CH
 class SickNoteTypeTest {
 
     @Test
-    void ensureThrowsIfCheckingCategoryWithNull() {
-        assertThatIllegalArgumentException()
-            .isThrownBy(() -> new SickNoteType().isOfCategory(null));
-    }
-
-    @Test
     void ensureReturnsTrueIfTypeIsOfGivenCategory() {
 
         final SickNoteType sickNoteType = new SickNoteType();


### PR DESCRIPTION
Wir wollen nicht passiv programmieren und Asserts, welche lediglich einen Fehler werfen, nicht im Code haben. Wir gehen davon aus, dass keine `null` Werte übergeben werden.