### PR TITLE
fix wording of overtime that can be cleared

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -812,7 +812,7 @@ overtime.progress.EDITED=Edited on
 overtime.person.total.1=This year
 overtime.person.total.2=overtime has been entered.
 overtime.person.left.1=Currently there is
-overtime.person.left.2=overtime that can to be cleared.
+overtime.person.left.2=overtime that can be cleared.
 overtime.person.zero=no
 
 gravatar.alt=Gravatar image of {0}


### PR DESCRIPTION
Vorschlag zur Behebung eines Grammatikfehlers in der englischen Beschreibung der verfügbaren Überstunden