### PR TITLE
Filter unwanted applications for overview

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -232,6 +232,7 @@ public class AbsenceOverviewViewController {
         } else if (sickNote == null) {
             return applications.stream()
                 .filter(application -> isDateInPeriod(date, application.getPeriod()))
+                .filter(application -> isAllowedOrPending(application.getStatus()))
                 .findFirst()
                 .map(this::getAbsenceOverviewDayType)
                 .orElse(null);
@@ -371,6 +372,21 @@ public class AbsenceOverviewViewController {
         }
 
         return startDate.isBefore(date) && date.isBefore(endDate);
+    }
+
+    private static boolean isAllowedOrPending(ApplicationStatus status) {
+        switch (status) {
+            case WAITING:
+            case TEMPORARY_ALLOWED:
+            case ALLOWED:
+            case ALLOWED_CANCELLATION_REQUESTED:
+                return true;
+            case REJECTED:
+            case CANCELLED:
+            case REVOKED:
+            default:
+                return false;
+        }
     }
 
     private LocalDate getStartDate(Integer year, String month) {


### PR DESCRIPTION
When the absence type for each day of the absence overview is determined, the first application of the given user that fits the date is selected. The status of the application is not considered. This behavior can lead to wrong absence types and therefore "empty" cells in the overview - e.g. when a rejected application and granted application match the same date. 

This PR adds a method which filters rejected, cancelled and revoked applications.

Resolves #1896 
