### PR TITLE
fix application for leave editing

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveForm.java
@@ -324,10 +324,12 @@ public class ApplicationForLeaveForm {
 
         public ApplicationForLeaveForm.Builder hoursAndMinutes(Duration hours) {
 
-            final BigDecimal overtimeReduction = hours == null ? BigDecimal.ZERO : BigDecimal.valueOf((double) hours.toMinutes() / 60);
+            if (hours != null) {
+                final BigDecimal overtimeReduction = BigDecimal.valueOf((double) hours.toMinutes() / 60);
+                this.hours = overtimeReduction.setScale(0, RoundingMode.DOWN).abs();
+                this.minutes = overtimeReduction.remainder(BigDecimal.ONE).multiply(BigDecimal.valueOf(60)).setScale(0, RoundingMode.HALF_EVEN).abs().intValueExact();
+            }
 
-            this.hours = overtimeReduction.setScale(0, RoundingMode.DOWN).abs();
-            this.minutes = overtimeReduction.remainder(BigDecimal.ONE).multiply(BigDecimal.valueOf(60)).setScale(0, RoundingMode.HALF_EVEN).abs().intValueExact();
             return this;
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormValidator.java
@@ -300,11 +300,15 @@ public class ApplicationForLeaveFormValidator implements Validator {
 
     private void validateOvertimeReduction(ApplicationForLeaveForm applicationForLeave, Settings settings, Errors errors) {
 
+        final boolean isOvertime = OVERTIME.equals(applicationForLeave.getVacationType().getCategory());
+        if (!isOvertime) {
+            return;
+        }
+
         final BigDecimal hours = applicationForLeave.getHours();
         final Integer minutes = applicationForLeave.getMinutes();
-        final boolean isOvertime = OVERTIME.equals(applicationForLeave.getVacationType().getCategory());
         final boolean overtimeFunctionIsActive = settings.getOvertimeSettings().isOvertimeActive();
-        final boolean overtimeReductionInputRequiredButNotProvided = isOvertime && overtimeFunctionIsActive && (hours == null && minutes == null);
+        final boolean overtimeReductionInputRequiredButNotProvided = overtimeFunctionIsActive && (hours == null && minutes == null);
 
         if (overtimeReductionInputRequiredButNotProvided && !errors.hasFieldErrors(ATTRIBUTE_HOURS)) {
             errors.rejectValue(ATTRIBUTE_HOURS, ERROR_MISSING_HOURS);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/web/ApplicationForLeaveFormTest.java
@@ -61,6 +61,16 @@ class ApplicationForLeaveFormTest {
     }
 
     @Test
+    void ensureSettingNullHourDurationWithBuilderDoesNotSetHoursAndMinutes() {
+        final ApplicationForLeaveForm form = new ApplicationForLeaveForm.Builder()
+            .hoursAndMinutes(null)
+            .build();
+
+        assertThat(form.getHours()).isNull();
+        assertThat(form.getMinutes()).isNull();
+    }
+
+    @Test
     void ensureGeneratedApplicationForLeaveWithDecimalOvertimeReduction() {
 
         final VacationType overtime = TestDataCreator.createVacationType(VacationCategory.OVERTIME);


### PR DESCRIPTION
* stunden und Minuten Eingabefeld ist jetzt leer wenn noch nichts eingegeben wurde
  * vorher wurde "nichts" zu "0" gesetzt
* auf `overtime` nur validieren wenn es sich auch um `overtime` handelt


fixes #1934