### PR TITLE
Improve department overview

### DIFF
--- a/src/main/css/components/form.css
+++ b/src/main/css/components/form.css
@@ -152,6 +152,10 @@ textarea.error {
   background-color: #e8efd1;
 }
 
+.department--member.is-inactive {
+  background-color: #fff4ea;
+}
+
 .department--member:last-child {
   border-bottom: none;
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentFormMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentFormMapper.java
@@ -2,19 +2,10 @@ package org.synyx.urlaubsverwaltung.department.web;
 
 import org.synyx.urlaubsverwaltung.department.Department;
 
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
-
 final class DepartmentDepartmentFormMapper {
 
     private DepartmentDepartmentFormMapper() {
         // prevents init
-    }
-
-    static List<DepartmentForm> mapToDepartmentForm(List<Department> departments) {
-
-        return departments.stream().map(DepartmentDepartmentFormMapper::mapToDepartmentForm).collect(toList());
     }
 
     static DepartmentForm mapToDepartmentForm(Department department) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentFormMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentFormMapper.java
@@ -6,15 +6,15 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-final class DepartmentMapper {
+final class DepartmentDepartmentFormMapper {
 
-    private DepartmentMapper() {
+    private DepartmentDepartmentFormMapper() {
         // prevents init
     }
 
     static List<DepartmentForm> mapToDepartmentForm(List<Department> departments) {
 
-        return departments.stream().map(DepartmentMapper::mapToDepartmentForm).collect(toList());
+        return departments.stream().map(DepartmentDepartmentFormMapper::mapToDepartmentForm).collect(toList());
     }
 
     static DepartmentForm mapToDepartmentForm(Department department) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapper.java
@@ -1,0 +1,34 @@
+package org.synyx.urlaubsverwaltung.department.web;
+
+import org.synyx.urlaubsverwaltung.department.Department;
+import org.synyx.urlaubsverwaltung.person.Role;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+final class DepartmentDepartmentOverviewDtoMapper {
+
+    private DepartmentDepartmentOverviewDtoMapper() {
+        // prevents init
+    }
+
+    static List<DepartmentOverviewDto> mapToDepartmentOverviewDtos(List<Department> departments) {
+
+        return departments.stream().map(DepartmentDepartmentOverviewDtoMapper::mapToDepartmentOverviewDto).collect(toList());
+    }
+
+    static DepartmentOverviewDto mapToDepartmentOverviewDto(Department department) {
+
+        final DepartmentOverviewDto departmentOverviewDto = new DepartmentOverviewDto();
+        departmentOverviewDto.setId(department.getId());
+        departmentOverviewDto.setName(department.getName());
+        departmentOverviewDto.setDescription(department.getDescription());
+        departmentOverviewDto.setActiveMembersCount((int) department.getMembers().stream().filter(member -> !member.hasRole(Role.INACTIVE)).count());
+        departmentOverviewDto.setInactiveMembersCount((int) department.getMembers().stream().filter(member -> member.hasRole(Role.INACTIVE)).count());
+        departmentOverviewDto.setLastModification(department.getLastModification());
+        departmentOverviewDto.setTwoStageApproval(department.isTwoStageApproval());
+
+        return departmentOverviewDto;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDto.java
@@ -1,0 +1,103 @@
+package org.synyx.urlaubsverwaltung.department.web;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class DepartmentOverviewDto {
+
+    private Integer id;
+    private String name;
+    private String description;
+    private LocalDate lastModification;
+    private boolean twoStageApproval;
+    private int activeMembersCount;
+    private int inactiveMembersCount;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getLastModification() {
+        return lastModification;
+    }
+
+    public void setLastModification(LocalDate lastModification) {
+        this.lastModification = lastModification;
+    }
+
+    public boolean isTwoStageApproval() {
+        return twoStageApproval;
+    }
+
+    public void setTwoStageApproval(boolean twoStageApproval) {
+        this.twoStageApproval = twoStageApproval;
+    }
+
+    public int getActiveMembersCount() {
+        return activeMembersCount;
+    }
+
+    public void setActiveMembersCount(int activeMembersCount) {
+        this.activeMembersCount = activeMembersCount;
+    }
+
+    public int getInactiveMembersCount() {
+        return inactiveMembersCount;
+    }
+
+    public void setInactiveMembersCount(int inactiveMembersCount) {
+        this.inactiveMembersCount = inactiveMembersCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DepartmentOverviewDto that = (DepartmentOverviewDto) o;
+        return twoStageApproval == that.twoStageApproval
+            && activeMembersCount == that.activeMembersCount
+            && inactiveMembersCount == that.inactiveMembersCount
+            && Objects.equals(id, that.id)
+            && Objects.equals(name, that.name)
+            && Objects.equals(description, that.description)
+            && Objects.equals(lastModification, that.lastModification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, lastModification, twoStageApproval, activeMembersCount, inactiveMembersCount);
+    }
+
+    @Override
+    public String toString() {
+        return "DepartmentOverviewDto{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            ", description='" + description + '\'' +
+            ", lastModification=" + lastModification +
+            ", twoStageApproval=" + twoStageApproval +
+            ", activeMembersCount=" + activeMembersCount +
+            ", inactiveMembersCount=" + inactiveMembersCount +
+            '}';
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDto.java
@@ -74,18 +74,12 @@ public class DepartmentOverviewDto {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DepartmentOverviewDto that = (DepartmentOverviewDto) o;
-        return twoStageApproval == that.twoStageApproval
-            && activeMembersCount == that.activeMembersCount
-            && inactiveMembersCount == that.inactiveMembersCount
-            && Objects.equals(id, that.id)
-            && Objects.equals(name, that.name)
-            && Objects.equals(description, that.description)
-            && Objects.equals(lastModification, that.lastModification);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, lastModification, twoStageApproval, activeMembersCount, inactiveMembersCount);
+        return Objects.hash(id);
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -70,7 +70,7 @@ public class DepartmentViewController {
     @GetMapping("/department/new")
     public String newDepartmentForm(Model model) {
 
-        final List<Person> persons = getActivePersons();
+        final List<Person> persons = personService.getActivePersons();
 
         model.addAttribute(DEPARTMENT, new DepartmentForm());
         model.addAttribute(PERSONS_ATTRIBUTE, persons);
@@ -156,7 +156,8 @@ public class DepartmentViewController {
 
     private boolean returnModelErrorAttributes(DepartmentForm departmentForm, Errors errors, Model model) {
         if (errors.hasErrors()) {
-            final List<Person> persons = getActivePersons();
+
+            final List<Person> persons = personService.getActivePersons();
 
             model.addAttribute(DEPARTMENT, departmentForm);
             model.addAttribute(PERSONS_ATTRIBUTE, persons);
@@ -164,11 +165,6 @@ public class DepartmentViewController {
             return true;
         }
         return false;
-    }
-
-    private List<Person> getActivePersons() {
-
-        return personService.getActivePersons();
     }
 
     private List<Person> getInactiveDepartmentMembersAndAllActivePersons(List<Person> departmentMembers) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -17,10 +17,12 @@ import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
 import org.synyx.urlaubsverwaltung.person.web.PersonPropertyEditor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentFormMapper.mapToDepartment;
 import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentFormMapper.mapToDepartmentForm;
@@ -68,7 +70,7 @@ public class DepartmentViewController {
     @GetMapping("/department/new")
     public String newDepartmentForm(Model model) {
 
-        final List<Person> persons = getPersons();
+        final List<Person> persons = getActivePersons();
 
         model.addAttribute(DEPARTMENT, new DepartmentForm());
         model.addAttribute(PERSONS_ATTRIBUTE, persons);
@@ -104,7 +106,7 @@ public class DepartmentViewController {
             .orElseThrow(() -> new UnknownDepartmentException(departmentId));
         model.addAttribute(DEPARTMENT, mapToDepartmentForm(department));
 
-        final List<Person> persons = getPersons();
+        final List<Person> persons = getInactiveDepartmentMembersAndAllActivePersons(department.getMembers());
         model.addAttribute(PERSONS_ATTRIBUTE, persons);
 
         return DEPARTMENT_DEPARTMENT_FORM;
@@ -154,7 +156,7 @@ public class DepartmentViewController {
 
     private boolean returnModelErrorAttributes(DepartmentForm departmentForm, Errors errors, Model model) {
         if (errors.hasErrors()) {
-            final List<Person> persons = getPersons();
+            final List<Person> persons = getActivePersons();
 
             model.addAttribute(DEPARTMENT, departmentForm);
             model.addAttribute(PERSONS_ATTRIBUTE, persons);
@@ -164,7 +166,19 @@ public class DepartmentViewController {
         return false;
     }
 
-    private List<Person> getPersons() {
+    private List<Person> getActivePersons() {
+
         return personService.getActivePersons();
+    }
+
+    private List<Person> getInactiveDepartmentMembersAndAllActivePersons(List<Person> departmentMembers) {
+
+        final List<Person> persons = departmentMembers.stream()
+            .filter(person -> person.getPermissions().contains(Role.INACTIVE))
+            .collect(Collectors.toList());
+
+        persons.addAll(personService.getActivePersons());
+
+        return persons;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -22,8 +22,9 @@ import org.synyx.urlaubsverwaltung.person.web.PersonPropertyEditor;
 import java.util.List;
 import java.util.Optional;
 
-import static org.synyx.urlaubsverwaltung.department.web.DepartmentMapper.mapToDepartment;
-import static org.synyx.urlaubsverwaltung.department.web.DepartmentMapper.mapToDepartmentForm;
+import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentFormMapper.mapToDepartment;
+import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentFormMapper.mapToDepartmentForm;
+import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentOverviewDtoMapper.mapToDepartmentOverviewDtos;
 import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_BOSS_OR_OFFICE;
 import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_OFFICE;
 
@@ -58,7 +59,7 @@ public class DepartmentViewController {
 
         final List<Department> departments = departmentService.getAllDepartments();
 
-        model.addAttribute("departments", mapToDepartmentForm(departments));
+        model.addAttribute("departments", mapToDepartmentOverviewDtos(departments));
 
         return "department/department_list";
     }

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -782,6 +782,7 @@ department.members.inactive=Inaktive
 department.members.description=Abteilungsleiter können die Urlaubsanträge der Benutzer der Abteilung einsehen und genehmigen/ablehnen. Damit jemand Abteilungsleiter werden kann, muss er die entsprechende Berechtigung haben.
 department.members.person=Mitglieder der Abteilung
 department.members.assigned=gehört zur Abteilung
+department.members.assigned.inactive=Inaktiv
 department.members.departmentHead=ist Abteilungsleiter
 department.members.secondStageAuthority=ist verantwortlich für die Freigabe vorläufig genehmigter Anträge
 department.members.secondStageAuthority.description=Für einen zweistufigen Genehmigungsprozess muss ein Freigabe Verantwortlicher mit der entsprechenden Berechtigung in die Abteilung aufgenommen werden.

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -474,7 +474,7 @@ error.entry.commentTooLong=Der Kommentar darf nur 200 Zeichen lang sein.
 # PERSON LIST
 person.overview.header.title=Benutzerübersicht
 persons.active=Aktive Benutzer
-persons.inactive=Deaktivierte Benutzer
+persons.inactive=Inaktive Benutzer
 persons.none=Es gibt keine Benutzer.
 
 persons.account.vacation.entitlement.year=Anspruch pro Jahr
@@ -777,6 +777,8 @@ department.data.twoStageApproval.help=Zweistufiger Genehmigungsprozess: Anträge
 department.data.lastModification=Letzte Änderung
 # Members
 department.members=Mitarbeiter
+department.members.active=Aktive
+department.members.inactive=Inaktive
 department.members.description=Abteilungsleiter können die Urlaubsanträge der Benutzer der Abteilung einsehen und genehmigen/ablehnen. Damit jemand Abteilungsleiter werden kann, muss er die entsprechende Berechtigung haben.
 department.members.person=Mitglieder der Abteilung
 department.members.assigned=gehört zur Abteilung

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -772,6 +772,7 @@ department.members.inactive=inactive
 department.members.description=Department heads can view and approve / reject the leave requests of department users. For someone to become a department head, he must have the appropriate authorization.
 department.members.person=Members of the department
 department.members.assigned=belongs to the department
+department.members.assigned.inactive=inactive
 department.members.departmentHead=is department head
 department.members.secondStageAuthority=is responsible for the release of interim authorized claims
 department.members.secondStageAuthority.description=For a two-stage approval process, a release owner with the appropriate authority must be included in the department.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -766,7 +766,9 @@ department.data.twoStageApproval.help=Two-stage approval process: Claims are pro
 department.data.lastModification=Last modification
 
 # Members
-department.members=Employee
+department.members=Employees
+department.members.active=active
+department.members.inactive=inactive
 department.members.description=Department heads can view and approve / reject the leave requests of department users. For someone to become a department head, he must have the appropriate authorization.
 department.members.person=Members of the department
 department.members.assigned=belongs to the department

--- a/src/main/webapp/WEB-INF/jsp/department/department_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/department/department_form.jsp
@@ -165,8 +165,9 @@
                             <div class="col-md-9">
                                 <div class="department--members">
                                     <c:forEach items="${persons}" var="person">
+                                        <c:set var="IS_INACTIVE" value="${fn:contains(person.permissions, 'INACTIVE')}"/>
                                         <c:set var="IS_MEMBER" value="${fn:contains(department.members, person)}"/>
-                                        <c:set var="MEMBER_CSS_CLASS" value="${IS_MEMBER ? 'is-assigned' : ''}"/>
+                                        <c:set var="MEMBER_CSS_CLASS" value="${IS_MEMBER ? ( IS_INACTIVE ? 'is-inactive' : 'is-assigned') : ''}"/>
 
                                         <div class="department--member ${MEMBER_CSS_CLASS}">
                                             <div class="department--member-image">
@@ -183,6 +184,14 @@
                                                 <p class="department--member-info tw-mb-2">
                                                     <c:out value="${person.niceName}"/>
                                                 </p>
+                                                <c:choose>
+                                                    <c:when test="${IS_INACTIVE}">
+                                                    <div class="tw-flex tw-items-center">
+                                                        <icon:information-circle className="tw-text-yellow-300 tw-w-5 tw-h-5 tw-m-0 tw-mr-1" solid="true"/>
+                                                        <spring:message code="department.members.assigned.inactive"/>
+                                                    </div>
+                                                    </c:when>
+                                                </c:choose>
                                                 <div>
                                                     <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
                                                         <form:checkbox path="members" value="${person}" cssClass="tw-m-0 tw-mr-2" />

--- a/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
@@ -79,6 +79,7 @@
                             <tr>
                                 <th scope="col" class="sortable-field"><spring:message code="department.data.name"/></th>
                                 <th scope="col" class="sortable-field"><spring:message code="department.members"/></th>
+                                <th scope="col" class="sortable-field"><spring:message code='department.data.twoStageApproval'/></th>
                                 <th scope="col" class="sortable-field"><spring:message code='department.data.lastModification'/></th>
                                 <sec:authorize access="hasAuthority('OFFICE')">
                                     <th scope="col"><%-- placeholder to ensure correct number of th --%></th>
@@ -124,6 +125,10 @@
                                         </c:if>
 
                                     </td>
+                                    <td class="is-centered hidden-xs">
+                                        <c:if test="${department.twoStageApproval}">
+                                            <icon:check className="tw-w-5 tw-h-5" solid="true" />
+                                        </c:if>
                                     </td>
                                     <td class="hidden-xs">
                                         <uv:date date="${department.lastModification}"/>

--- a/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/department/department_list.jsp
@@ -107,10 +107,23 @@
                                         </c:choose>
                                     </td>
                                     <td class="hidden-xs">
-                                        <a href="${URL_PREFIX}/person?active=true&department=${department.id}">
-                                            <c:out value="${fn:length(department.members)}"/>
-                                            <spring:message code="department.members"/>
-                                        </a>
+                                        <c:if test="${department.activeMembersCount > 0}">
+                                            <a href="${URL_PREFIX}/person?active=true&department=${department.id}">
+                                                <c:out value="${department.activeMembersCount}"/>
+                                                <spring:message code="department.members.active"/>
+                                            </a>
+                                        </c:if>
+                                        <c:if test="${department.activeMembersCount > 0 && department.inactiveMembersCount > 0}">
+                                            <c:out value="/"/>
+                                        </c:if>
+                                        <c:if test="${department.inactiveMembersCount > 0}">
+                                            <a href="${URL_PREFIX}/person?active=false&department=${department.id}">
+                                                <c:out value="${department.inactiveMembersCount}"/>
+                                                <spring:message code="department.members.inactive"/>
+                                            </a>
+                                        </c:if>
+
+                                    </td>
                                     </td>
                                     <td class="hidden-xs">
                                         <uv:date date="${department.lastModification}"/>

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
@@ -39,38 +39,4 @@ class DepartmentDepartmentOverviewDtoMapperTest {
         assertThat(departmentOverviewDto.getActiveMembersCount()).isEqualTo(1);
         assertThat(departmentOverviewDto.getInactiveMembersCount()).isEqualTo(2);
     }
-
-    @Test
-    void ensureEquals() {
-
-        DepartmentOverviewDto d1 = new DepartmentOverviewDto();
-        d1.setId(1);
-        d1.setName("d1");
-        DepartmentOverviewDto d2 = new DepartmentOverviewDto();
-        d2.setId(1);
-        d2.setName("d2");
-        DepartmentOverviewDto d3 = new DepartmentOverviewDto();
-        d3.setId(2);
-        d3.setName("d3");
-
-        assertThat(d1).isEqualTo(d2);
-        assertThat(d1).isNotEqualTo(d3);
-    }
-
-    @Test
-    void ensureHashCode() {
-
-        DepartmentOverviewDto d1 = new DepartmentOverviewDto();
-        d1.setId(1);
-        d1.setName("d1");
-        DepartmentOverviewDto d2 = new DepartmentOverviewDto();
-        d2.setId(1);
-        d2.setName("d2");
-        DepartmentOverviewDto d3 = new DepartmentOverviewDto();
-        d3.setId(2);
-        d3.setName("d3");
-
-        assertThat(d1.hashCode()).isEqualTo(d2.hashCode());
-        assertThat(d1.hashCode()).isNotEqualTo(d3.hashCode());
-    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
@@ -1,0 +1,42 @@
+package org.synyx.urlaubsverwaltung.department.web;
+
+import org.junit.jupiter.api.Test;
+import org.synyx.urlaubsverwaltung.department.Department;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.Role;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DepartmentDepartmentOverviewDtoMapperTest {
+
+    @Test
+    void ensureMapping() {
+
+        final Department department = new Department();
+        department.setId(42);
+        final Person activePerson = new Person();
+        activePerson.setPermissions(Set.of(Role.USER));
+        final Person inactivePerson = new Person();
+        inactivePerson.setPermissions(Set.of(Role.INACTIVE));
+        department.setMembers(List.of(activePerson, inactivePerson, inactivePerson));
+        department.setDescription("Some department info");
+        department.setName("Department");
+        department.setTwoStageApproval(true);
+
+        final LocalDate now = LocalDate.now();
+        department.setLastModification(now);
+
+        final DepartmentOverviewDto departmentOverviewDto = DepartmentDepartmentOverviewDtoMapper.mapToDepartmentOverviewDto(department);
+
+        assertThat(departmentOverviewDto.getId()).isEqualTo(42);
+        assertThat(departmentOverviewDto.getDescription()).isEqualTo("Some department info");
+        assertThat(departmentOverviewDto.getName()).isEqualTo("Department");
+        assertThat(departmentOverviewDto.getLastModification()).isEqualTo(now);
+        assertThat(departmentOverviewDto.getActiveMembersCount()).isEqualTo(1);
+        assertThat(departmentOverviewDto.getInactiveMembersCount()).isEqualTo(2);
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentDepartmentOverviewDtoMapperTest.java
@@ -39,4 +39,38 @@ class DepartmentDepartmentOverviewDtoMapperTest {
         assertThat(departmentOverviewDto.getActiveMembersCount()).isEqualTo(1);
         assertThat(departmentOverviewDto.getInactiveMembersCount()).isEqualTo(2);
     }
+
+    @Test
+    void ensureEquals() {
+
+        DepartmentOverviewDto d1 = new DepartmentOverviewDto();
+        d1.setId(1);
+        d1.setName("d1");
+        DepartmentOverviewDto d2 = new DepartmentOverviewDto();
+        d2.setId(1);
+        d2.setName("d2");
+        DepartmentOverviewDto d3 = new DepartmentOverviewDto();
+        d3.setId(2);
+        d3.setName("d3");
+
+        assertThat(d1).isEqualTo(d2);
+        assertThat(d1).isNotEqualTo(d3);
+    }
+
+    @Test
+    void ensureHashCode() {
+
+        DepartmentOverviewDto d1 = new DepartmentOverviewDto();
+        d1.setId(1);
+        d1.setName("d1");
+        DepartmentOverviewDto d2 = new DepartmentOverviewDto();
+        d2.setId(1);
+        d2.setName("d2");
+        DepartmentOverviewDto d3 = new DepartmentOverviewDto();
+        d3.setId(2);
+        d3.setName("d3");
+
+        assertThat(d1.hashCode()).isEqualTo(d2.hashCode());
+        assertThat(d1.hashCode()).isNotEqualTo(d3.hashCode());
+    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDtoTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentOverviewDtoTest.java
@@ -1,0 +1,44 @@
+package org.synyx.urlaubsverwaltung.department.web;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DepartmentOverviewDtoTest {
+
+    @Test
+    void ensureEquals() {
+
+        final DepartmentOverviewDto d1 = new DepartmentOverviewDto();
+        d1.setId(1);
+        d1.setName("d1");
+        final DepartmentOverviewDto d2 = new DepartmentOverviewDto();
+        d2.setId(1);
+        d2.setName("d2");
+        final DepartmentOverviewDto d3 = new DepartmentOverviewDto();
+        d3.setId(2);
+        d3.setName("d3");
+
+        assertThat(d1)
+            .isEqualTo(d2)
+            .isNotEqualTo(d3);
+    }
+
+    @Test
+    void ensureHashCode() {
+
+        final DepartmentOverviewDto d1 = new DepartmentOverviewDto();
+        d1.setId(1);
+        d1.setName("d1");
+        final DepartmentOverviewDto d2 = new DepartmentOverviewDto();
+        d2.setId(1);
+        d2.setName("d2");
+        final DepartmentOverviewDto d3 = new DepartmentOverviewDto();
+        d3.setId(2);
+        d3.setName("d3");
+
+        assertThat(d1.hashCode())
+            .isEqualTo(d2.hashCode())
+            .isNotEqualTo(d3.hashCode());
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
@@ -12,6 +12,7 @@ import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
 
 import java.util.List;
 import java.util.Optional;
@@ -142,15 +143,27 @@ class DepartmentViewControllerTest {
     @Test
     void editDepartmentAddsDepartmentAndActivePersonsToModel() throws Exception {
 
+        final Person activePerson = new Person();
+        final Person inactivePerson = inactivePerson();
+
+        List<Person> departmentMembers = List.of(activePerson, inactivePerson);
         final Department department = new Department();
+        department.setMembers(departmentMembers);
         when(departmentService.getDepartmentById(SOME_DEPARTMENT_ID)).thenReturn(Optional.of(department));
 
-        List<Person> persons = List.of(new Person());
-        when(personService.getActivePersons()).thenReturn(persons);
+        List<Person> activePersons = List.of(activePerson);
+        when(personService.getActivePersons()).thenReturn(activePersons);
 
         perform(get("/web/department/" + SOME_DEPARTMENT_ID + "/edit"))
             .andExpect(model().attribute(DEPARTMENT_ATTRIBUTE, mapToDepartmentForm(department)))
-            .andExpect(model().attribute(PERSONS_ATTRIBUTE, persons));
+            .andExpect(model().attribute(PERSONS_ATTRIBUTE, List.of(inactivePerson, activePerson)));
+    }
+
+    private Person inactivePerson() {
+        final Person inactivePerson = new Person();
+        inactivePerson.setPermissions(List.of(Role.INACTIVE));
+
+        return inactivePerson;
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
@@ -34,7 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
-import static org.synyx.urlaubsverwaltung.department.web.DepartmentMapper.mapToDepartmentForm;
+import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentFormMapper.mapToDepartmentForm;
+import static org.synyx.urlaubsverwaltung.department.web.DepartmentDepartmentOverviewDtoMapper.mapToDepartmentOverviewDtos;
 
 @ExtendWith(MockitoExtension.class)
 class DepartmentViewControllerTest {
@@ -65,7 +66,7 @@ class DepartmentViewControllerTest {
         when(departmentService.getAllDepartments()).thenReturn(departments);
 
         perform(get("/web/department"))
-            .andExpect(model().attribute("departments", mapToDepartmentForm(departments)));
+            .andExpect(model().attribute("departments", mapToDepartmentOverviewDtos(departments)));
     }
 
     @Test


### PR DESCRIPTION
* [x] ~Es werden keine Emails an inaktive Benutzer versendet~ wir schon [hier](http://github.com/synyx/urlaubsverwaltung/blob/1400-improve-department-overview/src/main/java/org/synyx/urlaubsverwaltung/person/PersonServiceImpl.java#L151) sichergestellt: 
* [x] Inaktive Benutzer werden explizit in der in der Abteilungsansicht dargestellt.
* [x] Inaktive Benutzer werden in der Abteilungsübersicht explizit gezählt.

Zusätzlich noch eine Spalte für den zweistufigen Genehmigungsprozess

![2021-04-09_17-37](https://user-images.githubusercontent.com/142107/114205895-12b72c00-995b-11eb-9963-fe10c1d173fe.png)

![2021-04-16_17-20](https://user-images.githubusercontent.com/142107/115046757-1fe29680-9ed8-11eb-9433-c5e9268c243d.png)

fixes #1400 