### PR TITLE
Überstundenübersichtsseite modernisieren

### DIFF
--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -803,6 +803,12 @@ overtime.details.hours.1=hat eingetragen:
 overtime.details.hours.2={0} Überstunden
 overtime.details.period=vom {0} bis {1}
 
+overtime.list.title=Überstundeneinträge
+overtime.list.col.icon=Symbol
+overtime.list.col.date=Datum
+overtime.list.col.duration=Überstunden
+overtime.list.col.last-edited=Zuletzt editiert
+
 overtime.error.hoursOrMinutesRequired=Stunden oder Minuten müssen angegeben werden.
 
 # Feedback

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -796,7 +796,6 @@ department.action.delete.success=Die Abteilung <strong>{0}</strong> wurde unwide
 # OVERTIME
 overtime.header.title=Überstundenübersicht von {0}
 overtime.title=Überstunden
-overtime.list=Einträge
 overtime.none=Es wurden bisher noch keine Überstunden eingetragen.
 
 overtime.details.header.title=Überstunden

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -792,6 +792,12 @@ overtime.details.hours.1=has entered:
 overtime.details.hours.2={0} overtime
 overtime.details.period=from {0} to {1}
 
+overtime.list.title=Overtime entries
+overtime.list.col.icon=icon
+overtime.list.col.date=date
+overtime.list.col.duration=duration
+overtime.list.col.last-edited=last edited
+
 overtime.error.hoursOrMinutesRequired=hours or minutes must be given.
 
 # Feedback

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -785,7 +785,6 @@ department.action.delete.success=Department <strong>{0}</strong> has been irrevo
 # OVERTIME
 overtime.header.title=Overtime overview of {0}
 overtime.title=Overtime
-overtime.list=Entries
 overtime.none=There has been no overtime entered yet.
 
 overtime.details.header.title=Overtime

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -71,13 +71,13 @@
                         <p><spring:message code="overtime.none"/></p>
                     </c:when>
                     <c:otherwise>
-                        <table class="list-table bordered-table selectable-table">
+                        <table class="list-table selectable-table tw-text-sm">
                             <tbody>
                             <c:forEach items="${records}" var="record">
                                 <tr onclick="navigate('${URL_PREFIX}/overtime/${record.id}');">
                                     <td class="is-centered state">
                                         <span class="print:tw-hidden">
-                                            <icon:briefcase className="tw-w-4 tw-h-4"/>
+                                            <icon:briefcase className="tw-w-6 tw-h-6"/>
                                         </span>
                                     </td>
                                     <td>

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -86,7 +86,7 @@
                                             <uv:date date="${record.startDate}"/> - <uv:date date="${record.endDate}"/>
                                         </p>
                                     </td>
-                                    <td class="is-centered hidden-xs">
+                                    <td class="is-centered">
                                         <uv:duration duration="${record.duration}"/>
                                     </td>
                                     <td class="print:tw-hidden is-centered hidden-xs">

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -67,6 +67,15 @@
                     </c:when>
                     <c:otherwise>
                         <table class="list-table selectable-table tw-text-sm">
+                            <caption class="tw-sr-only"><spring:message code="overtime.list.title"/></caption>
+                            <thead class="tw-sr-only">
+                                <tr>
+                                    <th scope="col"><spring:message code="overtime.list.col.icon"/></th>
+                                    <th scope="col"><spring:message code="overtime.list.col.date"/></th>
+                                    <th scope="col"><spring:message code="overtime.list.col.duration"/></th>
+                                    <th scope="col"><spring:message code="overtime.list.col.last-edited"/></th>
+                                </tr>
+                            </thead>
                             <tbody>
                             <c:forEach items="${records}" var="record">
                                 <tr onclick="navigate('${URL_PREFIX}/overtime/${record.id}');">

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -27,7 +27,7 @@
 
 <div class="content">
     <div class="container">
-        <div class="row tw-mb-4 lg:tw-mb-6">
+        <div class="row tw-mb-2 lg:tw-mb-4">
             <div class="col-xs-12">
                 <uv:section-heading>
                     <jsp:attribute name="actions">
@@ -46,15 +46,15 @@
                 </uv:section-heading>
             </div>
 
-            <div class="tw-space-y-4 lg:tw-space-y-0">
+            <div class="tw-space-y-2 lg:tw-space-y-0">
                 <div class="col-xs-12 col-sm-12 col-md-4">
-                    <uv:person person="${person}" cssClass="tw-h-32"/>
+                    <uv:person person="${person}" cssClass="tw-h-24 lg:tw-h-32 tw-border-none"/>
                 </div>
                 <div class="col-xs-12 col-md-4">
-                    <uv:overtime-total hours="${overtimeTotal}" cssClass="tw-h-32 tw-items-center"/>
+                    <uv:overtime-total hours="${overtimeTotal}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
                 </div>
                 <div class="col-xs-12 col-md-4">
-                    <uv:overtime-left hours="${overtimeLeft}" cssClass="tw-h-32 tw-items-center"/>
+                    <uv:overtime-left hours="${overtimeLeft}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -61,14 +61,9 @@
 
         <div class="row">
             <div class="col-xs-12">
-                <uv:section-heading>
-                    <h2>
-                        <spring:message code="overtime.list"/>
-                    </h2>
-                </uv:section-heading>
                 <c:choose>
                     <c:when test="${empty records}">
-                        <p><spring:message code="overtime.none"/></p>
+                        <p class="tw-text-center tw-mt-4 lg:tw-mt-8"><spring:message code="overtime.none"/></p>
                     </c:when>
                     <c:otherwise>
                         <table class="list-table selectable-table tw-text-sm">

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -27,7 +27,7 @@
 
 <div class="content">
     <div class="container">
-        <div class="row tw-mb-2 lg:tw-mb-4">
+        <div class="row tw-mb-2">
             <div class="col-xs-12">
                 <uv:section-heading>
                     <jsp:attribute name="actions">
@@ -45,20 +45,22 @@
                     </jsp:body>
                 </uv:section-heading>
             </div>
-
-            <div class="tw-space-y-2 lg:tw-space-y-0">
-                <div class="col-xs-12 col-sm-12 col-md-4">
+        </div>
+        <div class="row lg:tw-mb-8">
+            <div class="sm:tw-flex">
+                <div class="sm:tw-flex-1 lg:tw-flex-none lg:tw-w-1/3">
                     <uv:person person="${person}" cssClass="tw-h-24 lg:tw-h-32 tw-border-none"/>
                 </div>
-                <div class="col-xs-12 col-md-4">
-                    <uv:overtime-total hours="${overtimeTotal}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
-                </div>
-                <div class="col-xs-12 col-md-4">
-                    <uv:overtime-left hours="${overtimeLeft}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
+                <div class="sm:tw-flex-1 lg:tw-flex">
+                    <div class="tw-flex-1">
+                        <uv:overtime-total hours="${overtimeTotal}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
+                    </div>
+                    <div class="tw-flex-1">
+                        <uv:overtime-left hours="${overtimeLeft}" cssClass="tw-h-32 tw-items-center tw-border-none"/>
+                    </div>
                 </div>
             </div>
         </div>
-
         <div class="row">
             <div class="col-xs-12">
                 <c:choose>

--- a/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
+++ b/src/main/webapp/WEB-INF/jsp/overtime/overtime_list.jsp
@@ -82,14 +82,15 @@
                                         <a class="print:tw-hidden" href="${URL_PREFIX}/overtime/${record.id}">
                                             <h4><spring:message code="overtime.title"/></h4>
                                         </a>
-                                        <p><uv:date date="${record.startDate}"/> - <uv:date
-                                            date="${record.endDate}"/></p>
+                                        <p>
+                                            <uv:date date="${record.startDate}"/> - <uv:date date="${record.endDate}"/>
+                                        </p>
                                     </td>
                                     <td class="is-centered hidden-xs">
                                         <uv:duration duration="${record.duration}"/>
                                     </td>
                                     <td class="print:tw-hidden is-centered hidden-xs">
-                                        <div class="tw-flex tw-items-center">
+                                        <div class="tw-flex tw-items-center tw-justify-end">
                                             <icon:clock className="tw-w-4 tw-h-4"/>
                                             &nbsp;<spring:message code="overtime.progress.lastEdited"/>
                                             <uv:date date="${record.lastModificationDate}"/>


### PR DESCRIPTION
Little tweaks on the overtime list page to get a little freshness into the page and show the overtime duration on small devices.

https://www.youtube.com/watch?v=JqgqgcE8Zck

Before:
![overtime-facelift-before](https://user-images.githubusercontent.com/5683677/114451320-62a22700-9bd7-11eb-893a-542d2373bb1a.png)

After:
![overtime-facelift-after](https://user-images.githubusercontent.com/5683677/114451328-659d1780-9bd7-11eb-9f41-a5c8f1fb5da6.png)
