### PR TITLE
Anpassen von verschiedenen Farbschemata in den Fehlerfarben und Input-Buttons

### DIFF
--- a/src/main/css/components/form.css
+++ b/src/main/css/components/form.css
@@ -21,8 +21,8 @@
 .input-group {
   @apply tw-rounded-md !important;
   @apply tw-border;
-  @apply tw-border-gray-400;
   @apply tw-transition;
+  border-color: #ccc;
 }
 
 .input-group.has-error {
@@ -41,7 +41,7 @@
   @apply tw-border-0 !important;
   /* however, left border should still be visible */
   @apply tw-border-l-2 !important;
-  @apply tw-border-gray-300 !important;
+  border-color: #ccc;
 }
 
 .input-group:focus-within {

--- a/src/main/javascript/components/datepicker/datepicker.css
+++ b/src/main/javascript/components/datepicker/datepicker.css
@@ -43,3 +43,36 @@ duet-date-picker.error {
 .duet-date__day.is-today::before {
   border-radius: 0;
 }
+
+.duet-date__toggle {
+  /* use (nearly) same width like 'overtime minute input' */
+  min-width: 3.25rem;
+  /* disable duet box-shadow */
+  box-shadow: none;
+  height: 100%;
+  top: 0;
+  right: 0;
+}
+
+.duet-date__input-wrapper:focus-within .duet-date__toggle {
+  top: 1px;
+  right: 1px;
+  height: calc(100% - 2px);
+  min-width: calc(3.25rem - 1px);
+}
+
+.duet-date__input,
+.duet-date__toggle {
+  /* ring-0 is required to enable transition to ring-x of the focused element */
+  @apply tw-ring-0;
+  @apply tw-transition;
+  @apply tw-duration-150;
+  @apply tw-ease-in-out;
+}
+
+.duet-date__input:focus,
+.duet-date__toggle:focus {
+  box-shadow: none !important;
+  @apply tw-ring-2 !important;
+  @apply tw-ring-blue-300 !important;
+}

--- a/src/main/webapp/WEB-INF/assets-manifest.json
+++ b/src/main/webapp/WEB-INF/assets-manifest.json
@@ -5,7 +5,7 @@
   "account_form~app_detail~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_no~95889e93.js": "/assets/account_form~app_detail~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_no~95889e93.97e9a11c513a15ec9a41.min.js",
   "account_form~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_notes~workingtime_form.css": "/assets/account_form~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_notes~workingtime_form.6ac24571733aff972892.css",
   "account_form~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_notes~workingtime_form.js": "/assets/account_form~app_form~app_statistics~overtime_form~person_overview~sick_note_form~sick_notes~workingtime_form.35ede5e99363d584ddc0.min.js",
-  "account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.css": "/assets/account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.b704390d69faf4034209.css",
+  "account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.css": "/assets/account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.d516daf3fba1d9eca3d8.css",
   "account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.js": "/assets/account_form~app_form~app_statistics~overtime_form~sick_note_form~sick_notes~workingtime_form.a9f550768e0f25904643.min.js",
   "app_detail.js": "/assets/app_detail.7a8db7d60e1cfc805207.min.js",
   "app_detail~app_form~person_overview.js": "/assets/app_detail~app_form~person_overview.10d14df6cbe7f19cdda6.min.js",

--- a/src/main/webapp/WEB-INF/jsp/application/app_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/application/app_form.jsp
@@ -367,7 +367,7 @@
                                                 </uv:select>
                                                 <button
                                                     type="submit"
-                                                    class="tw-text-gray-700 tw-border tw-border-l-0 tw-border-gray-300 tw-font-medium tw-rounded-r tw-px-4 hover:tw-bg-gray-200 tw-text-sm"
+                                                    class="btn btn-default tw-border-l-0 tw-rounded-r tw-m-0 tw-px-4 tw-font-medium"
                                                     name="add-holiday-replacement"
                                                     formmethod="post"
                                                     formaction="${ADD_REPLACEMENT_ACTION}"


### PR DESCRIPTION
Eingabefelder jetzt mit gleicher Rahmenfarbe. Vorher waren Stunden/Minuten bei den Überstunden dunkler als die anderen.

![uv-border-colors](https://user-images.githubusercontent.com/1732200/115998703-d20d1300-a5e8-11eb-849b-30d10c6f65e7.png)

Der Button zum hinzufügen von Vertretungen war im Safari dunkler als in anderen Browsern.

![uv-button-colors](https://user-images.githubusercontent.com/1732200/115998706-d2a5a980-a5e8-11eb-9e5c-58837638695b.png)
