### PR TITLE
Wrong calculation of vacation statistics on period spanning

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatistics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatistics.java
@@ -75,12 +75,12 @@ public class ApplicationForLeaveStatistics {
     }
 
     public void addWaitingVacationDays(VacationType vacationType, BigDecimal waitingVacationDays) {
-        BigDecimal currentWaitingVacationDays = getWaitingVacationDays().get(vacationType);
+        final BigDecimal currentWaitingVacationDays = getWaitingVacationDays().get(vacationType);
         getWaitingVacationDays().put(vacationType, currentWaitingVacationDays.add(waitingVacationDays));
     }
 
     public void addAllowedVacationDays(VacationType vacationType, BigDecimal allowedVacationDays) {
-        BigDecimal currentAllowedVacationDays = getAllowedVacationDays().get(vacationType);
+        final BigDecimal currentAllowedVacationDays = getAllowedVacationDays().get(vacationType);
         getAllowedVacationDays().put(vacationType, currentAllowedVacationDays.add(allowedVacationDays));
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsService.java
@@ -8,8 +8,8 @@ import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.web.FilterPeriod;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
 
 @Service
@@ -30,7 +30,7 @@ class ApplicationForLeaveStatisticsService {
     List<ApplicationForLeaveStatistics> getStatistics(FilterPeriod period) {
         return getRelevantPersons().stream()
             .map(person -> applicationForLeaveStatisticsBuilder.build(person, period.getStartDate(), period.getEndDate()))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     private List<Person> getRelevantPersons() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
@@ -100,12 +100,6 @@ public final class TestDataCreator {
         return application;
     }
 
-    public static Application anyFullDayApplication(Person person) {
-        Application application = anyApplication();
-        application.setPerson(person);
-        return application;
-    }
-
     public static Application anyApplication() {
         Application application = new Application();
         application.setPerson(new Person("muster", "Muster", "Marlene", "muster@example.org"));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -20,28 +20,26 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
+import static java.time.LocalDate.of;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.synyx.urlaubsverwaltung.TestDataCreator.anyFullDayApplication;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createVacationTypes;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.ALLOWED;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.ALLOWED_CANCELLATION_REQUESTED;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.REJECTED;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.TEMPORARY_ALLOWED;
 import static org.synyx.urlaubsverwaltung.application.domain.ApplicationStatus.WAITING;
+import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 
 @ExtendWith(MockitoExtension.class)
 class ApplicationForLeaveStatisticsBuilderTest {
@@ -69,7 +67,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
 
     @Test
     void ensureThrowsIfTheGivenFromAndToDatesAreNotInTheSameYear() {
-        assertThatIllegalArgumentException().isThrownBy(() -> sut.build(mock(Person.class), LocalDate.of(2014, 1, 1), LocalDate.of(2015, 1, 1)));
+        assertThatIllegalArgumentException().isThrownBy(() -> sut.build(new Person(), of(2014, 1, 1), of(2015, 1, 1)));
     }
 
     @Test
@@ -78,70 +76,84 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final List<VacationType> vacationTypes = createVacationTypes();
         when(vacationTypeService.getVacationTypes()).thenReturn(vacationTypes);
 
-        final LocalDate from = LocalDate.of(2014, 1, 1);
-        final LocalDate to = LocalDate.of(2014, 12, 31);
-
         final Person person = new Person();
 
-        final LocalDate validFrom = LocalDate.of(2014, JANUARY, 1);
-        final LocalDate validTo = LocalDate.of(2014, DECEMBER, 31);
+        final LocalDate validFrom = of(2014, JANUARY, 1);
+        final LocalDate validTo = of(2014, DECEMBER, 31);
         final Account account = new Account(person, validFrom, validTo, TEN, TEN, TEN, "comment");
 
         when(accountService.getHolidaysAccount(2014, person)).thenReturn(Optional.of(account));
-        when(vacationDaysService.calculateTotalLeftVacationDays(eq(account))).thenReturn(TEN);
+        when(vacationDaysService.calculateTotalLeftVacationDays(account)).thenReturn(TEN);
         when(overtimeService.getLeftOvertimeForPerson(person)).thenReturn(Duration.ofHours(9));
 
-        final Application holidayWaiting = anyFullDayApplication(person);
+        final Application holidayWaiting = new Application();
+        holidayWaiting.setPerson(person);
+        holidayWaiting.setDayLength(FULL);
         holidayWaiting.setVacationType(vacationTypes.get(0));
-        holidayWaiting.setStartDate(LocalDate.of(2014, 10, 13));
-        holidayWaiting.setEndDate(LocalDate.of(2014, 10, 13));
+        holidayWaiting.setStartDate(of(2014, 10, 13));
+        holidayWaiting.setEndDate(of(2014, 10, 13));
         holidayWaiting.setStatus(WAITING);
 
-        final Application holidayTemporaryAllowed = anyFullDayApplication(person);
+        final Application holidayTemporaryAllowed = new Application();
+        holidayTemporaryAllowed.setPerson(person);
+        holidayTemporaryAllowed.setDayLength(FULL);
         holidayTemporaryAllowed.setVacationType(vacationTypes.get(0));
-        holidayTemporaryAllowed.setStartDate(LocalDate.of(2014, 10, 12));
-        holidayTemporaryAllowed.setEndDate(LocalDate.of(2014, 10, 12));
+        holidayTemporaryAllowed.setStartDate(of(2014, 10, 12));
+        holidayTemporaryAllowed.setEndDate(of(2014, 10, 12));
         holidayTemporaryAllowed.setStatus(TEMPORARY_ALLOWED);
 
-        final Application holidayAllowed = anyFullDayApplication(person);
+        final Application holidayAllowed = new Application();
+        holidayAllowed.setPerson(person);
+        holidayAllowed.setDayLength(FULL);
         holidayAllowed.setVacationType(vacationTypes.get(0));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowed.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowed.setStartDate(of(2014, 10, 14));
+        holidayAllowed.setEndDate(of(2014, 10, 14));
         holidayAllowed.setStatus(ALLOWED);
 
-        final Application holidayAllowedCancellationRequested = anyFullDayApplication(person);
+        final Application holidayAllowedCancellationRequested = new Application();
+        holidayAllowedCancellationRequested.setPerson(person);
+        holidayAllowedCancellationRequested.setDayLength(FULL);
         holidayAllowedCancellationRequested.setVacationType(vacationTypes.get(0));
-        holidayAllowedCancellationRequested.setStartDate(LocalDate.of(2014, 10, 15));
-        holidayAllowedCancellationRequested.setEndDate(LocalDate.of(2014, 10, 15));
+        holidayAllowedCancellationRequested.setStartDate(of(2014, 10, 15));
+        holidayAllowedCancellationRequested.setEndDate(of(2014, 10, 15));
         holidayAllowedCancellationRequested.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
-        final Application holidayRejected = anyFullDayApplication(person);
+        final Application holidayRejected = new Application();
+        holidayRejected.setPerson(person);
+        holidayRejected.setDayLength(FULL);
         holidayRejected.setVacationType(vacationTypes.get(0));
-        holidayRejected.setStartDate(LocalDate.of(2014, 11, 6));
-        holidayRejected.setEndDate(LocalDate.of(2014, 11, 6));
+        holidayRejected.setStartDate(of(2014, 11, 6));
+        holidayRejected.setEndDate(of(2014, 11, 6));
         holidayRejected.setStatus(REJECTED);
 
-        final Application specialLeaveWaiting = anyFullDayApplication(person);
+        final Application specialLeaveWaiting = new Application();
+        specialLeaveWaiting.setPerson(person);
+        specialLeaveWaiting.setDayLength(FULL);
         specialLeaveWaiting.setVacationType(vacationTypes.get(1));
-        specialLeaveWaiting.setStartDate(LocalDate.of(2014, 10, 15));
-        specialLeaveWaiting.setEndDate(LocalDate.of(2014, 10, 15));
+        specialLeaveWaiting.setStartDate(of(2014, 10, 15));
+        specialLeaveWaiting.setEndDate(of(2014, 10, 15));
         specialLeaveWaiting.setStatus(WAITING);
 
-        final Application unpaidLeaveAllowed = anyFullDayApplication(person);
+        final Application unpaidLeaveAllowed = new Application();
+        unpaidLeaveAllowed.setPerson(person);
+        unpaidLeaveAllowed.setDayLength(FULL);
         unpaidLeaveAllowed.setVacationType(vacationTypes.get(2));
-        unpaidLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 16));
-        unpaidLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 16));
+        unpaidLeaveAllowed.setStartDate(of(2014, 10, 16));
+        unpaidLeaveAllowed.setEndDate(of(2014, 10, 16));
         unpaidLeaveAllowed.setStatus(ALLOWED);
 
-        final Application overTimeWaiting = anyFullDayApplication(person);
+        final Application overTimeWaiting = new Application();
+        overTimeWaiting.setPerson(person);
+        overTimeWaiting.setDayLength(FULL);
         overTimeWaiting.setVacationType(vacationTypes.get(3));
-        overTimeWaiting.setStartDate(LocalDate.of(2014, 11, 3));
-        overTimeWaiting.setEndDate(LocalDate.of(2014, 11, 3));
+        overTimeWaiting.setStartDate(of(2014, 11, 3));
+        overTimeWaiting.setEndDate(of(2014, 11, 3));
         overTimeWaiting.setStatus(WAITING);
 
-        List<Application> applications = List.of(holidayWaiting, holidayTemporaryAllowed, holidayAllowed,
+        final List<Application> applications = List.of(holidayWaiting, holidayTemporaryAllowed, holidayAllowed,
             holidayAllowedCancellationRequested, holidayRejected, specialLeaveWaiting, unpaidLeaveAllowed, overTimeWaiting);
-
+        final LocalDate from = of(2014, 1, 1);
+        final LocalDate to = of(2014, 12, 31);
         when(applicationService.getApplicationsForACertainPeriodAndPerson(from, to, person)).thenReturn(applications);
 
         // just return 1 day for each application for leave
@@ -149,87 +161,84 @@ class ApplicationForLeaveStatisticsBuilderTest {
             .thenReturn(ONE);
 
         final ApplicationForLeaveStatistics statistics = sut.build(person, from, to);
-
-        // PERSON
         assertThat(statistics.getPerson()).isEqualTo(person);
-
-        // VACATION DAYS
         assertThat(statistics.getTotalWaitingVacationDays()).isEqualTo(new BigDecimal("4"));
         assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(new BigDecimal("3"));
         assertThat(statistics.getLeftVacationDays()).isEqualTo(TEN);
     }
 
     @Test
-    void ensureCallsCalendarServiceToCalculatePartialVacationDaysOfVacationsSpanningTwoYears() {
+    void ensureCallsCalendarServiceToCalculatePartialVacationDaysOfVacationsSpanningOverTheGivenPeriod() {
 
         final List<VacationType> vacationTypes = createVacationTypes();
         when(vacationTypeService.getVacationTypes()).thenReturn(vacationTypes);
 
-        LocalDate from = LocalDate.of(2015, 1, 1);
-        LocalDate to = LocalDate.of(2015, 12, 31);
-
-        Person person = new Person();
-        final LocalDate validFrom = LocalDate.of(2015, JANUARY, 1);
-        final LocalDate validTo = LocalDate.of(2015, DECEMBER, 31);
+        final Person person = new Person();
+        final LocalDate validFrom = of(2021, 1, 1);
+        final LocalDate validTo = of(2021, 12, 31);
         final Account account = new Account(person, validFrom, validTo, TEN, TEN, TEN, "comment");
+        when(accountService.getHolidaysAccount(2021, person)).thenReturn(Optional.of(account));
 
-        when(accountService.getHolidaysAccount(2015, person)).thenReturn(Optional.of(account));
-        when(vacationDaysService.calculateTotalLeftVacationDays(eq(account)))
-            .thenReturn(TEN);
+        when(vacationDaysService.calculateTotalLeftVacationDays(account)).thenReturn(TEN);
         when(overtimeService.getLeftOvertimeForPerson(person)).thenReturn(Duration.ofHours(9));
 
-        Application holidayAllowed = anyFullDayApplication(person);
-        holidayAllowed.setVacationType(vacationTypes.get(0));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 12, 29));
-        holidayAllowed.setEndDate(LocalDate.of(2015, 1, 9));
-        holidayAllowed.setStatus(ALLOWED);
+        final Application applicationSpanningIntoPeriod = new Application();
+        applicationSpanningIntoPeriod.setPerson(person);
+        applicationSpanningIntoPeriod.setStatus(ALLOWED);
+        applicationSpanningIntoPeriod.setDayLength(FULL);
+        applicationSpanningIntoPeriod.setVacationType(vacationTypes.get(0));
+        applicationSpanningIntoPeriod.setStartDate(of(2021, 4, 25));
+        applicationSpanningIntoPeriod.setEndDate(of(2021, 4, 30));
+        when(workDaysCountService.getWorkDaysCount(FULL, of(2021, 4, 28), of(2021, 4, 30), person))
+            .thenReturn(BigDecimal.valueOf(3));
 
-        Application holidayWaiting = anyFullDayApplication(person);
-        holidayWaiting.setVacationType(vacationTypes.get(0));
-        holidayWaiting.setStartDate(LocalDate.of(2015, 12, 21));
-        holidayWaiting.setEndDate(LocalDate.of(2016, 1, 4));
-        holidayWaiting.setStatus(WAITING);
+        final Application applicationSpanningOutOfPeriod = new Application();
+        applicationSpanningOutOfPeriod.setPerson(person);
+        applicationSpanningOutOfPeriod.setStatus(WAITING);
+        applicationSpanningOutOfPeriod.setDayLength(FULL);
+        applicationSpanningOutOfPeriod.setVacationType(vacationTypes.get(0));
+        applicationSpanningOutOfPeriod.setStartDate(of(2021, 5, 21));
+        applicationSpanningOutOfPeriod.setEndDate(of(2021, 6, 10));
+        when(workDaysCountService.getWorkDaysCount(FULL, of(2021, 5, 21), of(2021, 5, 28), person))
+            .thenReturn(BigDecimal.valueOf(8));
 
-        List<Application> applications = Arrays.asList(holidayWaiting, holidayAllowed);
+        final Application applicationInPeriod = new Application();
+        applicationInPeriod.setPerson(person);
+        applicationInPeriod.setStatus(WAITING);
+        applicationInPeriod.setDayLength(FULL);
+        applicationInPeriod.setVacationType(vacationTypes.get(0));
+        applicationInPeriod.setStartDate(of(2021, 4, 28));
+        applicationInPeriod.setEndDate(of(2021, 5, 5));
+        when(workDaysCountService.getWorkDaysCount(FULL, of(2021, 4, 28), of(2021, 5, 5), person))
+            .thenReturn(BigDecimal.valueOf(8));
 
-        when(applicationService.getApplicationsForACertainPeriodAndPerson(from, to, person))
-            .thenReturn(applications);
+        final LocalDate periodFrom = of(2021, 4, 28);
+        final LocalDate periodTo = of(2021, 5, 28);
+        when(applicationService.getApplicationsForACertainPeriodAndPerson(periodFrom, periodTo, person)).thenReturn(List.of(applicationSpanningIntoPeriod, applicationInPeriod, applicationSpanningOutOfPeriod));
 
-        when(workDaysCountService.getWorkDaysCount(DayLength.FULL, LocalDate.of(2015, 1, 1),
-            LocalDate.of(2015, 1, 9), person))
-            .thenReturn(new BigDecimal("5"));
-        when(workDaysCountService.getWorkDaysCount(DayLength.FULL, LocalDate.of(2015, 12, 21),
-            LocalDate.of(2015, 12, 31), person))
-            .thenReturn(new BigDecimal("7"));
-
-        ApplicationForLeaveStatistics statistics = sut.build(person, from, to);
-
-        // VACATION DAYS
-        assertThat(statistics.getTotalWaitingVacationDays()).isEqualTo(new BigDecimal("7"));
-        assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(new BigDecimal("5"));
+        final ApplicationForLeaveStatistics statistics = sut.build(person, periodFrom, periodTo);
+        assertThat(statistics.getTotalWaitingVacationDays()).isEqualTo(BigDecimal.valueOf(16));
+        assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(BigDecimal.valueOf(3));
         assertThat(statistics.getLeftVacationDays()).isEqualTo(TEN);
     }
 
     @Test
     void ensureCalculatesLeftVacationDaysAndLeftOvertimeCorrectly() {
 
-        LocalDate from = LocalDate.of(2015, 1, 1);
-        LocalDate to = LocalDate.of(2015, 12, 31);
+        final LocalDate periodFrom = of(2015, 1, 1);
+        final LocalDate periodTo = of(2015, 12, 31);
 
-        Person person = mock(Person.class);
-        Account account = mock(Account.class);
+        final Person person = new Person();
+        final LocalDate validFrom = of(2015, JANUARY, 1);
+        final LocalDate validTo = of(2015, DECEMBER, 31);
+        final Account account = new Account(person, validFrom, validTo, TEN, TEN, TEN, "comment");
 
         when(accountService.getHolidaysAccount(2015, person)).thenReturn(Optional.of(account));
         when(overtimeService.getLeftOvertimeForPerson(person)).thenReturn(Duration.ofMinutes(390));
         when(vacationDaysService.calculateTotalLeftVacationDays(account)).thenReturn(new BigDecimal("8.5"));
 
-        ApplicationForLeaveStatistics statistics = sut.build(person, from, to);
-
-        // VACATION DAYS
+        final ApplicationForLeaveStatistics statistics = sut.build(person, periodFrom, periodTo);
         assertThat(statistics.getLeftOvertime()).isEqualTo(Duration.ofMinutes(390));
         assertThat(statistics.getLeftVacationDays()).isEqualTo(new BigDecimal("8.5"));
-
-        verify(overtimeService).getLeftOvertimeForPerson(person);
-        verify(vacationDaysService).calculateTotalLeftVacationDays(account);
     }
 }


### PR DESCRIPTION
closes #1211

@Reviewer: Das Gleiche haben wir auch bei der https://demo.urlaubsverwaltung.cloud/web/sicknote - wenn da das Startdatum des Zeitraums drin ist, wird der komplette Urlaub berechnet. Ich denke das sollten wir auch anpassen oder?