### PR TITLE
Avatar auf der Abwesenheitsübersicht

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewMonthPersonDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewMonthPersonDto.java
@@ -7,12 +7,14 @@ public class AbsenceOverviewMonthPersonDto {
     private final String firstName;
     private final String lastName;
     private final String email;
+    private final String gravatarUrl;
     private final List<AbsenceOverviewPersonDayDto> days;
 
-    AbsenceOverviewMonthPersonDto(String firstName, String lastName, String email, List<AbsenceOverviewPersonDayDto> days) {
+    AbsenceOverviewMonthPersonDto(String firstName, String lastName, String email, String gravatarUrl, List<AbsenceOverviewPersonDayDto> days) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
+        this.gravatarUrl = gravatarUrl;
         this.days = days;
     }
 
@@ -26,6 +28,10 @@ public class AbsenceOverviewMonthPersonDto {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getGravatarUrl() {
+        return gravatarUrl;
     }
 
     public List<AbsenceOverviewPersonDayDto> getDays() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -178,16 +178,17 @@ public class AbsenceOverviewViewController {
             final Map<String, SickNote> sickNotesOnThisDayByEmail = sickNotesForDate(date, sickNotes,
                 sickNote -> sickNote.getPerson().getEmail());
 
-            final Map<AbsenceOverviewMonthPersonDto, Person> personByView = personList.stream().collect(toMap(
-                person -> monthView.getPersons().stream()
-                    .filter(view ->
-                        view.getEmail().equals(person.getEmail()) &&
+            final Map<AbsenceOverviewMonthPersonDto, Person> personByView = personList.stream()
+                .collect(
+                    toMap(person -> monthView.getPersons().stream()
+                        .filter(view -> view.getEmail().equals(person.getEmail()) &&
                             view.getFirstName().equals(person.getFirstName()) &&
                             view.getLastName().equals(person.getLastName())
+                        )
+                        .findFirst()
+                        .orElse(null),Function.identity()
                     )
-                    .findFirst().orElse(null),
-                Function.identity()
-            ));
+                );
 
             // create an absence day dto for every person of the department
             for (AbsenceOverviewMonthPersonDto personView : monthView.getPersons()) {
@@ -197,8 +198,8 @@ public class AbsenceOverviewViewController {
                 final Person person = personByView.get(personView);
 
                 final FederalState personDateFederalStateOverride = workingTimes.stream()
-                    .filter(workingTime ->
-                        workingTime.getPerson().equals(person) && (workingTime.getValidFrom().isBefore(date) || workingTime.getValidFrom().equals(date)))
+                    .filter(workingTime -> workingTime.getPerson().equals(person) &&
+                        (workingTime.getValidFrom().isBefore(date) || workingTime.getValidFrom().equals(date)))
                     .min(comparing(WorkingTime::getValidFrom))
                     .flatMap(WorkingTime::getFederalStateOverride).orElse(defaultFederalState);
 
@@ -241,8 +242,9 @@ public class AbsenceOverviewViewController {
         final String firstName = person.getFirstName();
         final String lastName = person.getLastName();
         final String email = person.getEmail();
+        final String gravatarUrl = person.getGravatarURL();
 
-        return new AbsenceOverviewMonthPersonDto(firstName, lastName, email, new ArrayList<>());
+        return new AbsenceOverviewMonthPersonDto(firstName, lastName, email, gravatarUrl, new ArrayList<>());
     }
 
     private static Map<String, SickNote> sickNotesForDate(LocalDate date, List<SickNote> sickNotes, Function<SickNote, String> keySupplier) {

--- a/src/main/webapp/WEB-INF/jsp/absences/absences_overview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/absences/absences_overview.jsp
@@ -147,6 +147,7 @@
                                aria-describedby="absence-table-${month.nameOfMonth}">
                             <thead>
                             <tr>
+                                <th scope="col">&nbsp;</th>
                                 <th scope="col" class="sortable-field">&nbsp;</th>
                                 <th scope="col" class="sortable-field">&nbsp;</th>
                                 <c:forEach items="${month.days}" var="day">
@@ -164,6 +165,16 @@
                             <tbody class="vacationOverview-tbody">
                             <c:forEach var="person" items="${month.persons}">
                                 <tr role="row">
+                                    <th scope="row">
+                                        <img
+                                            src="<c:out value='${person.gravatarUrl}?d=mm&s=30'/>"
+                                            alt="<spring:message code="gravatar.alt" arguments="${person.firstName} ${person.lastName}"/>"
+                                            class="gravatar gravatar--medium tw-rounded-full print:tw-hidden"
+                                            width="20px"
+                                            height="20px"
+                                            onerror="this.src !== '/images/gravatar.jpg' && (this.src = '/images/gravatar.jpg')"
+                                        />
+                                    </th>
                                     <th scope="row"><c:out value="${person.firstName}"/></th>
                                     <th scope="row"><c:out value="${person.lastName}"/></th>
                                     <c:forEach var="absence" items="${person.days}">

--- a/src/main/webapp/WEB-INF/jsp/absences/absences_overview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/absences/absences_overview.jsp
@@ -165,13 +165,13 @@
                             <tbody class="vacationOverview-tbody">
                             <c:forEach var="person" items="${month.persons}">
                                 <tr role="row">
-                                    <th scope="row">
+                                    <th scope="row" class="tw-py-0">
                                         <img
                                             src="<c:out value='${person.gravatarUrl}?d=mm&s=30'/>"
                                             alt="<spring:message code="gravatar.alt" arguments="${person.firstName} ${person.lastName}"/>"
                                             class="gravatar gravatar--medium tw-rounded-full print:tw-hidden"
-                                            width="20px"
-                                            height="20px"
+                                            width="24px"
+                                            height="24px"
                                             onerror="this.src !== '/images/gravatar.jpg' && (this.src = '/images/gravatar.jpg')"
                                         />
                                     </th>


### PR DESCRIPTION
Als Benutzer möchte ich visuell schneller erkennen, welche Zeile zu welchem Benutzer:in gehört, dafür wäre das einblenden des Avatars von Vorteil.