### PR TITLE
Fix lookup of sick notes for overlapping query date ranges

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteRepository.java
@@ -48,5 +48,5 @@ interface SickNoteRepository extends CrudRepository<SickNote, Integer> {
     List<SickNote> findByStatusInAndPersonInAndEndDateIsGreaterThanEqual(List<SickNoteStatus> openSickNoteStatuses,
                                                                          List<Person> persons, LocalDate sinceStartDate);
 
-    List<SickNote> findByStatusInAndPersonInAndStartDateIsGreaterThanEqualAndEndDateIsLessThanEqual(List<SickNoteStatus> sickNoteStatus, List<Person> persons, LocalDate start, LocalDate end);
+    List<SickNote> findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(List<SickNoteStatus> sickNoteStatus, List<Person> persons, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/SickNoteServiceImpl.java
@@ -84,6 +84,6 @@ class SickNoteServiceImpl implements SickNoteService {
 
     @Override
     public List<SickNote> getForStatesAndPerson(List<SickNoteStatus> sickNoteStatus, List<Person> persons, LocalDate start, LocalDate end) {
-        return sickNoteRepository.findByStatusInAndPersonInAndStartDateIsGreaterThanEqualAndEndDateIsLessThanEqual(sickNoteStatus, persons, start, end);
+        return sickNoteRepository.findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(sickNoteStatus, persons, start, end);
     }
 }


### PR DESCRIPTION
Repliziert den Fix aus #2123 für die Abwesenheiten, damit er auch für die Krankmeldungen greift.

Closes #2140