### PR TITLE
Add additional method for valid single appointment ics attachment

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailService.java
@@ -66,7 +66,7 @@ class ApplicationMailService {
 
     void sendAllowedNotification(Application application, ApplicationComment applicationComment) {
 
-        final File calendarFile = generateCalendar(application, application.getPerson().getNiceName(), DEFAULT);
+        final File calendarFile = generateCalendar(application, DEFAULT);
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -285,8 +285,7 @@ class ApplicationMailService {
      */
     void notifyHolidayReplacementAllow(HolidayReplacementEntity holidayReplacement, Application application) {
 
-        final String calendarName = getTranslation("calendar.mail.holiday-replacement.name", application.getPerson().getNiceName());
-        final File calendarFile = generateCalendar(application, calendarName, AbsenceType.HOLIDAY_REPLACEMENT);
+        final File calendarFile = generateCalendar(application, AbsenceType.HOLIDAY_REPLACEMENT);
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -313,7 +312,7 @@ class ApplicationMailService {
      */
     void notifyHolidayReplacementAboutCancellation(HolidayReplacementEntity holidayReplacement, Application application) {
 
-        final File calendarFile = generateCalendar(application, application.getPerson().getNiceName(), DEFAULT, CANCELLED);
+        final File calendarFile = generateCalendar(application, DEFAULT, CANCELLED);
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -453,7 +452,7 @@ class ApplicationMailService {
      */
     void sendCancelledByOfficeNotification(Application application, ApplicationComment comment) {
 
-        final File calendarFile = generateCalendar(application, application.getPerson().getNiceName(), DEFAULT, CANCELLED);
+        final File calendarFile = generateCalendar(application, DEFAULT, CANCELLED);
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -635,12 +634,12 @@ class ApplicationMailService {
         return messageSource.getMessage(key, args, GERMAN);
     }
 
-    private File generateCalendar(Application application, String calendarName, AbsenceType absenceType) {
-        return generateCalendar(application, calendarName, absenceType, PUBLISHED);
+    private File generateCalendar(Application application, AbsenceType absenceType) {
+        return generateCalendar(application, absenceType, PUBLISHED);
     }
-    private File generateCalendar(Application application, String calendarName, AbsenceType absenceType, ICalType iCalType) {
+    private File generateCalendar(Application application, AbsenceType absenceType, ICalType iCalType) {
         final Absence absence = new Absence(application.getPerson(), application.getPeriod(), getAbsenceTimeConfiguration(), absenceType);
-        return iCalService.getCalendar(calendarName, List.of(absence), iCalType);
+        return iCalService.getSingleAppointment(absence, iCalType);
     }
 
     private AbsenceTimeConfiguration getAbsenceTimeConfiguration() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -57,23 +57,39 @@ public class ICalService {
     }
 
     public File getCalendar(String title, List<Absence> absences) {
-        return getCalendar(title, absences, PUBLISHED);
-    }
-
-    public File getCalendar(String title, List<Absence> absences, ICalType method) {
 
         final File file = generateCalenderFile(title);
-        final Calendar calendar = generateCalendar(title, absences, method);
+        final Calendar calendar = generateCalendar(title, absences);
 
         return writeCalenderIntoFile(calendar, file);
     }
 
-    private Calendar generateCalendar(String title, List<Absence> absences, ICalType method) {
+    public File getSingleAppointment(Absence absence, ICalType method) {
+        final File file = generateCalenderFile("appointment");
+        final Calendar calendar = generateForSingleAppointment(absence, method);
+
+        return writeCalenderIntoFile(calendar, file);
+    }
+
+    private Calendar generateCalendar(String title, List<Absence> absences) {
+
+        final Calendar calendar = prepareCalendar(absences, PUBLISHED);
+
+        calendar.getProperties().add(new XProperty("X-WR-CALNAME", title));
+
+        return calendar;
+    }
+
+    private Calendar generateForSingleAppointment(Absence absence, ICalType method) {
+
+        return prepareCalendar(List.of(absence), method);
+    }
+
+    private Calendar prepareCalendar(List<Absence> absences, ICalType method) {
         final Calendar calendar = new Calendar();
         calendar.getProperties().add(VERSION_2_0);
         calendar.getProperties().add(new ProdId("-//Urlaubsverwaltung//iCal4j 1.0//DE"));
         calendar.getProperties().add(GREGORIAN);
-        calendar.getProperties().add(new XProperty("X-WR-CALNAME", title));
         calendar.getProperties().add(new XProperty("X-MICROSOFT-CALSCALE", GREGORIAN.getValue()));
         calendar.getProperties().add(new RefreshInterval(new ParameterList(), calendarProperties.getRefreshInterval()));
 
@@ -150,7 +166,7 @@ public class ICalService {
         return DigestUtils.md5Hex(data).toUpperCase();
     }
 
-    private File generateCalenderFile(String title) {
+    File generateCalenderFile(String title) {
         final File file;
         try {
             file = File.createTempFile("calendar-", ".ics");
@@ -160,7 +176,7 @@ public class ICalService {
         return file;
     }
 
-    private File writeCalenderIntoFile(Calendar calendar, File file) {
+    File writeCalenderIntoFile(Calendar calendar, File file) {
         try (final FileWriter calendarFileWriter = new FileWriter(file)) {
             final CalendarOutputter calendarOutputter = new CalendarOutputter();
             calendarOutputter.output(calendar, calendarFileWriter);

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -58,32 +58,25 @@ public class ICalService {
     }
 
     public File getCalendar(String title, List<Absence> absences) {
-
         final File file = generateCalenderFile(title);
         final Calendar calendar = generateCalendar(title, absences);
-
         return writeCalenderIntoFile(calendar, file);
     }
 
     public File getSingleAppointment(Absence absence, ICalType method) {
         final File file = generateCalenderFile("appointment");
         final Calendar calendar = generateForSingleAppointment(absence, method);
-
         return writeCalenderIntoFile(calendar, file);
     }
 
     private Calendar generateCalendar(String title, List<Absence> absences) {
-
         final Calendar calendar = prepareCalendar(absences, PUBLISHED);
-
         calendar.getProperties().add(new XProperty("X-WR-CALNAME", title));
         calendar.getProperties().add(new RefreshInterval(new ParameterList(), calendarProperties.getRefreshInterval()));
-
         return calendar;
     }
 
     private Calendar generateForSingleAppointment(Absence absence, ICalType method) {
-
         return prepareCalendar(List.of(absence), method);
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -39,6 +39,7 @@ import static net.fortuna.ical4j.model.property.CalScale.GREGORIAN;
 import static net.fortuna.ical4j.model.property.Method.CANCEL;
 import static net.fortuna.ical4j.model.property.Version.VERSION_2_0;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.synyx.urlaubsverwaltung.calendar.ICalType.CANCELLED;
 import static org.synyx.urlaubsverwaltung.calendar.ICalType.PUBLISHED;
 
 
@@ -93,7 +94,7 @@ public class ICalService {
         calendar.getProperties().add(GREGORIAN);
         calendar.getProperties().add(new XProperty("X-MICROSOFT-CALSCALE", GREGORIAN.getValue()));
 
-        if (method == ICalType.CANCELLED) {
+        if (method == CANCELLED) {
             calendar.getProperties().add(CANCEL);
         }
 
@@ -140,7 +141,7 @@ public class ICalService {
         event.getProperties().add(new Uid(generateUid(absence)));
         event.getProperties().add(generateAttendee(absence));
 
-        if (method == ICalType.CANCELLED) {
+        if (method == CANCELLED) {
             event.getProperties().add(new Sequence(1));
         }
 
@@ -166,7 +167,7 @@ public class ICalService {
         return DigestUtils.md5Hex(data).toUpperCase();
     }
 
-    File generateCalenderFile(String title) {
+    private File generateCalenderFile(String title) {
         final File file;
         try {
             file = File.createTempFile("calendar-", ".ics");
@@ -176,7 +177,7 @@ public class ICalService {
         return file;
     }
 
-    File writeCalenderIntoFile(Calendar calendar, File file) {
+    private File writeCalenderIntoFile(Calendar calendar, File file) {
         try (final FileWriter calendarFileWriter = new FileWriter(file)) {
             final CalendarOutputter calendarOutputter = new CalendarOutputter();
             calendarOutputter.output(calendar, calendarFileWriter);

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -76,6 +76,7 @@ public class ICalService {
         final Calendar calendar = prepareCalendar(absences, PUBLISHED);
 
         calendar.getProperties().add(new XProperty("X-WR-CALNAME", title));
+        calendar.getProperties().add(new RefreshInterval(new ParameterList(), calendarProperties.getRefreshInterval()));
 
         return calendar;
     }
@@ -91,7 +92,6 @@ public class ICalService {
         calendar.getProperties().add(new ProdId("-//Urlaubsverwaltung//iCal4j 1.0//DE"));
         calendar.getProperties().add(GREGORIAN);
         calendar.getProperties().add(new XProperty("X-MICROSOFT-CALSCALE", GREGORIAN.getValue()));
-        calendar.getProperties().add(new RefreshInterval(new ParameterList(), calendarProperties.getRefreshInterval()));
 
         if (method == ICalType.CANCELLED) {
             calendar.getProperties().add(CANCEL);

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Date.from;
-import static java.util.stream.Collectors.toList;
 import static net.fortuna.ical4j.model.parameter.Role.REQ_PARTICIPANT;
 import static net.fortuna.ical4j.model.property.CalScale.GREGORIAN;
 import static net.fortuna.ical4j.model.property.Method.CANCEL;
@@ -91,12 +90,11 @@ public class ICalService {
             calendar.getProperties().add(CANCEL);
         }
 
-        final List<VEvent> absencesVEvents = absences.stream()
+        absences.stream()
             .map(absence -> this.toVEvent(absence, method))
             .filter(Optional::isPresent)
             .map(Optional::get)
-            .collect(toList());
-        calendar.getComponents().addAll(absencesVEvents);
+            .forEach(event -> calendar.getComponents().add(event));
 
         return calendar;
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceTest.java
@@ -10,13 +10,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 import org.synyx.urlaubsverwaltung.absence.TimeSettings;
 import org.synyx.urlaubsverwaltung.application.ApplicationSettings;
+import org.synyx.urlaubsverwaltung.application.dao.HolidayReplacementEntity;
 import org.synyx.urlaubsverwaltung.application.domain.Application;
 import org.synyx.urlaubsverwaltung.application.domain.ApplicationComment;
 import org.synyx.urlaubsverwaltung.application.domain.VacationCategory;
 import org.synyx.urlaubsverwaltung.application.domain.VacationType;
 import org.synyx.urlaubsverwaltung.calendar.ICalService;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
-import org.synyx.urlaubsverwaltung.application.dao.HolidayReplacementEntity;
 import org.synyx.urlaubsverwaltung.mail.Mail;
 import org.synyx.urlaubsverwaltung.mail.MailService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
@@ -30,7 +30,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -79,7 +78,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final File file = new File("");
-        when(iCalService.getCalendar(any(), any(), any())).thenReturn(file);
+        when(iCalService.getSingleAppointment(any(), any())).thenReturn(file);
 
         when(messageSource.getMessage(any(), any(), any())).thenReturn("something");
 
@@ -351,11 +350,8 @@ class ApplicationMailServiceTest {
         model.put("holidayReplacementNote", "awesome replacement note");
         model.put("dayLength", "FULL");
 
-        final String calendarName = "Vertretung für ...";
-        when(messageSource.getMessage("calendar.mail.holiday-replacement.name", new Object[]{"Theo Fritz"}, Locale.GERMAN)).thenReturn(calendarName);
-
         final File file = new File("");
-        when(iCalService.getCalendar(eq(calendarName), any(), any())).thenReturn(file);
+        when(iCalService.getSingleAppointment(any(), any())).thenReturn(file);
 
         sut.notifyHolidayReplacementAllow(replacementEntity, application);
 
@@ -454,7 +450,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final File file = new File("");
-        when(iCalService.getCalendar(any(), any(), any())).thenReturn(file);
+        when(iCalService.getSingleAppointment(any(), any())).thenReturn(file);
 
         final DayLength dayLength = FULL;
         when(messageSource.getMessage(eq(dayLength.name()), any(), any())).thenReturn("FULL");
@@ -580,7 +576,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final File file = new File("");
-        when(iCalService.getCalendar(any(), any(), any())).thenReturn(file);
+        when(iCalService.getSingleAppointment(any(), any())).thenReturn(file);
 
         final Person person = new Person();
         final Person office = new Person();

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -20,6 +20,7 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.synyx.urlaubsverwaltung.calendar.ICalType.CANCELLED;
+import static org.synyx.urlaubsverwaltung.calendar.ICalType.PUBLISHED;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
 import static org.synyx.urlaubsverwaltung.period.DayLength.NOON;
@@ -162,7 +163,7 @@ class ICalServiceTest {
     }
 
     @Test
-    void getCalendarCancelledEvent() {
+    void cancelSingleAppointment() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
@@ -184,6 +185,33 @@ class ICalServiceTest {
             .contains("DTEND:20190526T160000Z")
             .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
             .contains("SEQUENCE:1")
+
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
+    }
+
+    @Test
+    void singleAppointment() {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
+
+        final CalendarProperties calendarProperties = new CalendarProperties();
+        calendarProperties.setOrganizer("no-reply@example.org");
+        final ICalService sut = new ICalService(calendarProperties);
+
+        final File calendar = sut.getSingleAppointment(noonAbsence, PUBLISHED);
+        assertThat(fileToString(calendar))
+            .contains("VERSION:2.0")
+            .contains("CALSCALE:GREGORIAN")
+            .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
+            .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
+
+            .contains("SUMMARY:Marlene Muster abwesend")
+            .contains("DTSTART:20190526T120000Z")
+            .contains("DTEND:20190526T160000Z")
+            .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
+            .contains("X-MICROSOFT-CDO-BUSYSTATUS:OOF")
 
             .contains("ORGANIZER:mailto:no-reply@example.org")
             .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -211,7 +211,6 @@ class ICalServiceTest {
             .contains("DTSTART:20190526T120000Z")
             .contains("DTEND:20190526T160000Z")
             .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
-            .contains("X-MICROSOFT-CDO-BUSYSTATUS:OOF")
 
             .contains("ORGANIZER:mailto:no-reply@example.org")
             .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -170,13 +170,13 @@ class ICalServiceTest {
         final CalendarProperties calendarProperties = new CalendarProperties();
         calendarProperties.setOrganizer("no-reply@example.org");
         final ICalService sut = new ICalService(calendarProperties);
-        final File calendar = sut.getCalendar("Abwesenheitskalender", List.of(noonAbsence), CANCELLED);
+
+        final File calendar = sut.getSingleAppointment(noonAbsence, CANCELLED);
         assertThat(fileToString(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
             .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
             .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
-            .contains("X-WR-CALNAME:Abwesenheitskalender")
             .contains("REFRESH-INTERVAL:P1D")
             .contains("METHOD:CANCEL")
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -177,7 +177,6 @@ class ICalServiceTest {
             .contains("CALSCALE:GREGORIAN")
             .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
             .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
-            .contains("REFRESH-INTERVAL:P1D")
             .contains("METHOD:CANCEL")
 
             .contains("SUMMARY:Marlene Muster abwesend")


### PR DESCRIPTION
closes #2197

* Removes `X-WR-CALNAME` for single appointments (see:
https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d)
* Removes Refresh Interval for single appointments (mail attachment)
* Reduces complexity in iCalType handling

Resulting ical single appointment:

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE
CALSCALE:GREGORIAN
X-MICROSOFT-CALSCALE:GREGORIAN
BEGIN:VEVENT
DTSTAMP:20210818T223147Z
DTSTART;VALUE=DATE:20210825
SUMMARY:Marlene Muster abwesend
X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
UID:D0CB5ADE9849C55B96D0B24F9D660046
ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:office@urlaubsverw
 altung.cloud
ORGANIZER:mailto:organizer@example.org
END:VEVENT
END:VCALENDAR
```