### PR TITLE
Add mail reminder for upcoming holiday replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ uv.account.update.cron=0 0 5 1 1 *
 
 # application
 uv.application.reminder-notification.cron=0 0 7 * * *
+uv.application.upcoming-holiday-replacement-notification.cron=0 0 7 * * *
+uv.application.upcoming-notification.cron=0 0 7 * * *
 
 # ical calendar
 uv.calendar.organizer

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationProperties.java
@@ -13,7 +13,13 @@ import javax.validation.Valid;
 public class ApplicationProperties {
 
     /*
-     * Checks every day at 07:00 am if remind mails for upcoming applications can be send
+     * Checks every day at 07:00 am if remind mails for upcoming holiday replacement applications can be sent
+     */
+    @Valid
+    private ReminderNotification upcomingHolidayReplacementNotification = new ReminderNotification();
+
+    /*
+     * Checks every day at 07:00 am if remind mails for upcoming applications can be sent
      */
     @Valid
     private ReminderNotification upcomingNotification = new ReminderNotification();
@@ -23,6 +29,14 @@ public class ApplicationProperties {
      */
     @Valid
     private ReminderNotification reminderNotification = new ReminderNotification();
+
+    public ReminderNotification getUpcomingHolidayReplacementNotification() {
+        return upcomingHolidayReplacementNotification;
+    }
+
+    public void setUpcomingHolidayReplacementNotification(ReminderNotification upcomingHolidayReplacementNotification) {
+        this.upcomingHolidayReplacementNotification = upcomingHolidayReplacementNotification;
+    }
 
     public ReminderNotification getUpcomingNotification() {
         return upcomingNotification;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationSettings.java
@@ -35,9 +35,19 @@ public class ApplicationSettings {
     private boolean remindForUpcomingApplications = false;
 
     /**
-     * Specifies when a reminder for upcoming application should be send
+     * Specifies when a reminder for upcoming application should be sent
      */
     private Integer daysBeforeRemindForUpcomingApplications = 3;
+
+    /**
+     * Activates a notification after {daysBeforeRemindForUpcomingHolidayReplacement} days for upcoming holiday replacement
+     */
+    private boolean remindForUpcomingHolidayReplacement = false;
+
+    /**
+     * Specifies when a reminder for upcoming holiday replacement should be sent
+     */
+    private Integer daysBeforeRemindForUpcomingHolidayReplacement = 3;
 
     public Integer getMaximumMonthsToApplyForLeaveInAdvance() {
         return maximumMonthsToApplyForLeaveInAdvance;
@@ -85,5 +95,21 @@ public class ApplicationSettings {
 
     public void setDaysBeforeRemindForUpcomingApplications(Integer daysBeforeRemindForUpcomingApplications) {
         this.daysBeforeRemindForUpcomingApplications = daysBeforeRemindForUpcomingApplications;
+    }
+
+    public boolean isRemindForUpcomingHolidayReplacement() {
+        return remindForUpcomingHolidayReplacement;
+    }
+
+    public void setRemindForUpcomingHolidayReplacement(boolean remindForHolidayReplacementApplications) {
+        this.remindForUpcomingHolidayReplacement = remindForHolidayReplacementApplications;
+    }
+
+    public Integer getDaysBeforeRemindForUpcomingHolidayReplacement() {
+        return daysBeforeRemindForUpcomingHolidayReplacement;
+    }
+
+    public void setDaysBeforeRemindForUpcomingHolidayReplacement(Integer daysBeforeRemindForUpcomingHolidayReplacement) {
+        this.daysBeforeRemindForUpcomingHolidayReplacement = daysBeforeRemindForUpcomingHolidayReplacement;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationSettingsValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/ApplicationSettingsValidator.java
@@ -27,6 +27,13 @@ public class ApplicationSettingsValidator {
             errors.rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", ERROR_INVALID_ENTRY);
         }
 
+        final Integer daysBeforeRemindForUpcomingHolidayReplacement = applicationSettings.getDaysBeforeRemindForUpcomingHolidayReplacement();
+        if (daysBeforeRemindForUpcomingHolidayReplacement == null) {
+            errors.rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", ERROR_MANDATORY_FIELD);
+        } else if (daysBeforeRemindForUpcomingHolidayReplacement <= 0) {
+            errors.rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", ERROR_INVALID_ENTRY);
+        }
+
         final Integer daysBeforeRemindForUpcomingApplications = applicationSettings.getDaysBeforeRemindForUpcomingApplications();
         if (daysBeforeRemindForUpcomingApplications == null) {
             errors.rejectValue("applicationSettings.daysBeforeRemindForUpcomingApplications", ERROR_MANDATORY_FIELD);

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepository.java
@@ -21,7 +21,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Integ
 
     List<Application> findByStatusInAndStartDate(List<ApplicationStatus> statuses, LocalDate startDate);
 
-    List<Application> findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(List<ApplicationStatus> statuses, LocalDate startDate);
+    List<Application> findByStatusInAndStartDateBetweenAndHolidayReplacementsIsNotEmptyAndUpcomingHolidayReplacementNotificationSendIsNull(List<ApplicationStatus> statuses, LocalDate from, LocalDate to);
 
     List<Application> findByStatusInAndEndDateGreaterThanEqual(List<ApplicationStatus> statuses, LocalDate since);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepository.java
@@ -21,6 +21,8 @@ public interface ApplicationRepository extends CrudRepository<Application, Integ
 
     List<Application> findByStatusInAndStartDate(List<ApplicationStatus> statuses, LocalDate startDate);
 
+    List<Application> findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(List<ApplicationStatus> statuses, LocalDate startDate);
+
     List<Application> findByStatusInAndEndDateGreaterThanEqual(List<ApplicationStatus> statuses, LocalDate since);
 
     List<Application> findByStatusInAndPersonIn(List<ApplicationStatus> statuses, List<Person> persons);

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/domain/Application.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/domain/Application.java
@@ -160,6 +160,8 @@ public class Application {
     @Convert(converter = DurationConverter.class)
     private Duration hours;
 
+    private LocalDate upcomingHolidayReplacementNotificationSend;
+
     public Integer getId() {
         return id;
     }
@@ -330,6 +332,14 @@ public class Application {
 
     public void setHours(Duration hours) {
         this.hours = hours;
+    }
+
+    public LocalDate getUpcomingHolidayReplacementNotificationSend() {
+        return upcomingHolidayReplacementNotificationSend;
+    }
+
+    public void setUpcomingHolidayReplacementNotificationSend(LocalDate upcomingHolidayReplacementNotificationSend) {
+        this.upcomingHolidayReplacementNotificationSend = upcomingHolidayReplacementNotificationSend;
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailService.java
@@ -590,6 +590,25 @@ class ApplicationMailService {
         }
     }
 
+    void sendRemindForUpcomingHolidayReplacement(List<Application> applications, Integer daysBeforeUpcomingHolidayReplacement){
+        for (Application application : applications) {
+            for (HolidayReplacementEntity holidayReplacement : application.getHolidayReplacements()) {
+
+                final Map<String, Object> model = new HashMap<>();
+                model.put(APPLICATION, application);
+                model.put("daysBeforeUpcomingHolidayReplacement", daysBeforeUpcomingHolidayReplacement);
+                model.put("replacementNote", holidayReplacement.getNote());
+
+                final Mail mailToUpcomingHolidayReplacement = Mail.builder()
+                    .withRecipient(holidayReplacement.getPerson())
+                    .withSubject("subject.application.remind.upcoming.holiday_replacement", application.getPerson().getNiceName())
+                    .withTemplate("remind_holiday_replacement_upcoming", model)
+                    .build();
+                mailService.send(mailToUpcomingHolidayReplacement);
+            }
+        }
+    }
+
     void sendRemindForWaitingApplicationsReminderNotification(List<Application> waitingApplications) {
 
         /*

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailConfiguration.java
@@ -22,5 +22,6 @@ class ApplicationReminderMailConfiguration implements SchedulingConfigurer {
     public void configureTasks(ScheduledTaskRegistrar scheduledTaskRegistrar) {
         scheduledTaskRegistrar.addCronTask(applicationReminderMailService::sendWaitingApplicationsReminderNotification, applicationProperties.getReminderNotification().getCron());
         scheduledTaskRegistrar.addCronTask(applicationReminderMailService::sendUpcomingApplicationsReminderNotification, applicationProperties.getUpcomingNotification().getCron());
+        scheduledTaskRegistrar.addCronTask(applicationReminderMailService::sendUpcomingHolidayReplacementReminderNotification, applicationProperties.getUpcomingHolidayReplacementNotification().getCron());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailService.java
@@ -78,6 +78,18 @@ class ApplicationReminderMailService {
         }
     }
 
+    void sendUpcomingHolidayReplacementReminderNotification() {
+
+        final ApplicationSettings applicationSettings = settingsService.getSettings().getApplicationSettings();
+        if (applicationSettings.isRemindForUpcomingHolidayReplacement()) {
+            final LocalDate dateForUpcomingHolidayReplacement = LocalDate.now(clock).plusDays(applicationSettings.getDaysBeforeRemindForUpcomingHolidayReplacement());
+            final List<ApplicationStatus> allowedStatuses = List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED);
+            final List<Application> upcomingApplicationsForHolidayReplacement = applicationService.getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(dateForUpcomingHolidayReplacement, allowedStatuses);
+
+            applicationMailService.sendRemindForUpcomingHolidayReplacement(upcomingApplicationsForHolidayReplacement, applicationSettings.getDaysBeforeRemindForUpcomingHolidayReplacement());
+        }
+    }
+
     private Predicate<Application> isLongWaitingApplications() {
         return application -> {
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationService.java
@@ -65,13 +65,14 @@ public interface ApplicationService {
     List<Application> getApplicationsWithStartDateAndState(LocalDate startDate, List<ApplicationStatus> statuses);
 
     /**
-     * Gets all {@link Application}s that have the given start date and the given state and at least one holiday replacement
+     * Gets all {@link Application}s where the holiday replacement should be notified.
      *
-     * @param startDate {@link LocalDate}
-     * @param statuses  {@link ApplicationStatus}
-     * @return all {@link Application}s with the given states and startDate and at least one holiday replacement
+     * @param from defines the start as {@link LocalDate} of a period that should be considered
+     * @param to defines the end as {@link LocalDate} of a period that should be considered
+     * @param statuses  {@link ApplicationStatus} that should be filtered for
+     * @return all {@link Application}s where the given params match and
      */
-    List<Application> getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(LocalDate startDate, List<ApplicationStatus> statuses);
+    List<Application> getApplicationsWhereHolidayReplacementShouldBeNotified(LocalDate from, LocalDate to, List<ApplicationStatus> statuses);
 
     /**
      * Gets all {@link Application}s with vacation time between startDate x and endDate y for the given person and

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationService.java
@@ -65,6 +65,15 @@ public interface ApplicationService {
     List<Application> getApplicationsWithStartDateAndState(LocalDate startDate, List<ApplicationStatus> statuses);
 
     /**
+     * Gets all {@link Application}s that have the given start date and the given state and at least one holiday replacement
+     *
+     * @param startDate {@link LocalDate}
+     * @param statuses  {@link ApplicationStatus}
+     * @return all {@link Application}s with the given states and startDate and at least one holiday replacement
+     */
+    List<Application> getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(LocalDate startDate, List<ApplicationStatus> statuses);
+
+    /**
      * Gets all {@link Application}s with vacation time between startDate x and endDate y for the given person and
      * state.
      *

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
@@ -58,8 +58,8 @@ class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    public List<Application> getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(LocalDate startDate, List<ApplicationStatus> statuses) {
-        return applicationRepository.findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(statuses, startDate);
+    public List<Application> getApplicationsWhereHolidayReplacementShouldBeNotified(LocalDate from, LocalDate to, List<ApplicationStatus> statuses) {
+        return applicationRepository.findByStatusInAndStartDateBetweenAndHolidayReplacementsIsNotEmptyAndUpcomingHolidayReplacementNotificationSendIsNull(statuses, from, to);
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImpl.java
@@ -58,6 +58,11 @@ class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
+    public List<Application> getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(LocalDate startDate, List<ApplicationStatus> statuses) {
+        return applicationRepository.findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(statuses, startDate);
+    }
+
+    @Override
     public List<Application> getApplicationsForACertainPeriodAndPersonAndState(LocalDate startDate, LocalDate endDate, Person person, ApplicationStatus status) {
         return applicationRepository.getApplicationsForACertainTimeAndPersonAndState(startDate, endDate, person, status);
     }

--- a/src/main/resources/dbchangelogs/changelog-4.24.0-add-upcoming-holiday-replacement-reminder.xml
+++ b/src/main/resources/dbchangelogs/changelog-4.24.0-add-upcoming-holiday-replacement-reminder.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
 
   <changeSet author="schneider" id="upcoming-holiday-replacement-reminder">
-
     <preConditions>
       <tableExists tableName="settings"/>
       <not>
@@ -24,6 +23,18 @@
         <constraints nullable="false"/>
       </column>
     </addColumn>
+  </changeSet>
 
+  <changeSet author="schneider" id="add_upcoming_holiday_replacement_notification_send">
+    <preConditions>
+      <tableExists tableName="application"/>
+      <not>
+        <columnExists tableName="application" columnName="upcoming_holiday_replacement_notification_send"/>
+      </not>
+    </preConditions>
+
+    <addColumn tableName="application">
+      <column name="upcoming_holiday_replacement_notification_send" type="date"/>
+    </addColumn>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelog-4.24.0-add-upcoming-holiday-replacement-reminder.xml
+++ b/src/main/resources/dbchangelogs/changelog-4.24.0-add-upcoming-holiday-replacement-reminder.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+
+  <changeSet author="schneider" id="upcoming-holiday-replacement-reminder">
+
+    <preConditions>
+      <tableExists tableName="settings"/>
+      <not>
+        <columnExists tableName="settings" columnName="remind_for_upcoming_holiday_replacement"/>
+        <columnExists tableName="settings" columnName="days_before_remind_for_upcoming_holiday_replacement"/>
+      </not>
+    </preConditions>
+
+    <addColumn tableName="settings">
+      <column name="remind_for_upcoming_holiday_replacement" type="BIT(1)" defaultValue="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+
+    <addColumn tableName="settings">
+      <column name="days_before_remind_for_upcoming_holiday_replacement" type="INT(10)" defaultValue="3">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -86,4 +86,5 @@
   <include file="dbchangelogs/changelog-4.21.0-add-minimum-overtime-reduction-value.xml"/>
   <include file="dbchangelogs/changelog-4.21.0-add-overtime-reduction-without-application-active-flag.xml"/>
   <include file="dbchangelogs/changelog-4.21.0-add-setting-overtime-write-privileged-only.xml"/>
+  <include file="dbchangelogs/changelog-4.24.0-add-upcoming-holiday-replacement-reminder.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -630,6 +630,7 @@ subject.application.refer=Hilfe bei der Entscheidung über einen Urlaubsantrag
 subject.application.edited=Urlaubsantrag von {0} wurde erfolgreich editiert
 subject.application.remind=Erinnerung wartender Urlaubsantrag
 subject.application.remind.upcoming=Erinnerung an deine Abwesenheit
+subject.application.remind.upcoming.holiday_replacement=Erinnerung an deine bevorstehende Urlaubsvertretung für {0}
 subject.application.cronRemind=Erinnerung für wartende Urlaubsanträge
 subject.application.holidayReplacement.allow=Deine Urlaubsvertretung für {0} wurde eingeplant
 subject.application.holidayReplacement.apply=Deine vorläufig geplante Urlaubsvertretung für {0}
@@ -686,6 +687,13 @@ settings.vacation.remindForUpcomingApplications.true=aktivieren
 settings.vacation.remindForUpcomingApplications.false=deaktivieren
 settings.vacation.daysBeforeRemindForUpcomingApplications=Erinnerungsmail x Tage vor dem Urlaubsbeginn
 settings.vacation.remindForUpcomingApplications.description=Diese Einstellung ermöglicht es eine E-Mail an den Antragsteller:in x Tage vor seinem Urlaub zu schicken, die diese Person an die Übergabe vor seinem Urlaub erinnert. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+# Vacation Starts Soon Reminder Notification
+settings.vacation.remindForUpcomingHolidayReplacement.title=Automatische Erinnerung für bevorstehende Urlaubsvertretungen
+settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatische Erinnerungsfunktion
+settings.vacation.remindForUpcomingHolidayReplacement.activation.true=aktivieren
+settings.vacation.remindForUpcomingHolidayReplacement.activation.false=deaktivieren
+settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Erinnerungsmail x Tage vor dem Beginn einer Urlaubsvertretung
+settings.vacation.remindForUpcomingHolidayReplacement.description=Diese Einstellung ermöglicht es eine E-Mail an die Urlaubsvertretung x Tage vor dem Beginn des Antrages zu verschicken. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=Muss kleiner oder gleich der maximalen Anzahl der Urlaubstage pro Jahr sein
 # Sick Days

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -678,22 +678,22 @@ settings.vacation.remindForWaitingApplications.title=Automatische Erinnerung fü
 settings.vacation.remindForWaitingApplications=Automatische Erinnerungsfunktion
 settings.vacation.remindForWaitingApplications.true=aktivieren
 settings.vacation.remindForWaitingApplications.false=deaktivieren
-settings.vacation.daysBeforeRemindForWaitingApplications=Erinnerungsmail alle x Tage
-settings.vacation.daysBeforeRemindForWaitingApplications.descripton=Diese Einstellung ermöglicht es die Chefs bzw. Abteilungsleiter auf wartende Urlaubsanträge per E-Mail aufmerksam zu machen.
+settings.vacation.daysBeforeRemindForWaitingApplications=Wie viele Tage im Voraus sollen Chefs bzw. Abteilungsleiter benachrichtigt werden
+settings.vacation.daysBeforeRemindForWaitingApplications.descripton=Diese Einstellung ermöglicht es Chefs bzw. Abteilungsleiter auf wartende Urlaubsanträge per E-Mail aufmerksam zu machen.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingApplications.title=Automatische Erinnerung für bevorstehende Urlaube
 settings.vacation.remindForUpcomingApplications=Automatische Erinnerungsfunktion
 settings.vacation.remindForUpcomingApplications.true=aktivieren
 settings.vacation.remindForUpcomingApplications.false=deaktivieren
-settings.vacation.daysBeforeRemindForUpcomingApplications=Erinnerungsmail x Tage vor dem Urlaubsbeginn
-settings.vacation.remindForUpcomingApplications.description=Diese Einstellung ermöglicht es eine E-Mail an den Antragsteller:in x Tage vor seinem Urlaub zu schicken, die diese Person an die Übergabe vor seinem Urlaub erinnert.
+settings.vacation.daysBeforeRemindForUpcomingApplications=Wie viele Tage im Voraus soll die Antragsteller:in benachrichtigt werden
+settings.vacation.remindForUpcomingApplications.description=Diese Einstellung ermöglicht es eine E-Mail an den Antragsteller:in vor seinem Urlaub zu schicken, die diese Person an die Übergabe vor seinem Urlaub erinnert.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingHolidayReplacement.title=Automatische Erinnerung für bevorstehende Urlaubsvertretungen
 settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatische Erinnerungsfunktion
 settings.vacation.remindForUpcomingHolidayReplacement.activation.true=aktivieren
 settings.vacation.remindForUpcomingHolidayReplacement.activation.false=deaktivieren
-settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Erinnerungsmail x Tage vor dem Beginn einer Urlaubsvertretung
-settings.vacation.remindForUpcomingHolidayReplacement.description=Diese Einstellung ermöglicht es eine E-Mail an die Urlaubsvertretung x Tage vor dem Beginn des Antrages zu verschicken.
+settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Wie viele Tage im Voraus soll die Urlaubsvertretung über eine bevorstehende Vertretung benachrichtigt werden
+settings.vacation.remindForUpcomingHolidayReplacement.description=Diese Einstellung ermöglicht es eine E-Mail an die Urlaubsvertretung vor dem Beginn des Antrages zu verschicken.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=Muss kleiner oder gleich der maximalen Anzahl der Urlaubstage pro Jahr sein
 # Sick Days

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -679,21 +679,21 @@ settings.vacation.remindForWaitingApplications=Automatische Erinnerungsfunktion
 settings.vacation.remindForWaitingApplications.true=aktivieren
 settings.vacation.remindForWaitingApplications.false=deaktivieren
 settings.vacation.daysBeforeRemindForWaitingApplications=Erinnerungsmail alle x Tage
-settings.vacation.daysBeforeRemindForWaitingApplications.descripton=Diese Einstellung ermöglicht es die Chefs bzw. Abteilungsleiter auf wartende Urlaubsanträge per E-Mail aufmerksam zu machen. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+settings.vacation.daysBeforeRemindForWaitingApplications.descripton=Diese Einstellung ermöglicht es die Chefs bzw. Abteilungsleiter auf wartende Urlaubsanträge per E-Mail aufmerksam zu machen.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingApplications.title=Automatische Erinnerung für bevorstehende Urlaube
 settings.vacation.remindForUpcomingApplications=Automatische Erinnerungsfunktion
 settings.vacation.remindForUpcomingApplications.true=aktivieren
 settings.vacation.remindForUpcomingApplications.false=deaktivieren
 settings.vacation.daysBeforeRemindForUpcomingApplications=Erinnerungsmail x Tage vor dem Urlaubsbeginn
-settings.vacation.remindForUpcomingApplications.description=Diese Einstellung ermöglicht es eine E-Mail an den Antragsteller:in x Tage vor seinem Urlaub zu schicken, die diese Person an die Übergabe vor seinem Urlaub erinnert. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+settings.vacation.remindForUpcomingApplications.description=Diese Einstellung ermöglicht es eine E-Mail an den Antragsteller:in x Tage vor seinem Urlaub zu schicken, die diese Person an die Übergabe vor seinem Urlaub erinnert.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingHolidayReplacement.title=Automatische Erinnerung für bevorstehende Urlaubsvertretungen
 settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatische Erinnerungsfunktion
 settings.vacation.remindForUpcomingHolidayReplacement.activation.true=aktivieren
 settings.vacation.remindForUpcomingHolidayReplacement.activation.false=deaktivieren
 settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Erinnerungsmail x Tage vor dem Beginn einer Urlaubsvertretung
-settings.vacation.remindForUpcomingHolidayReplacement.description=Diese Einstellung ermöglicht es eine E-Mail an die Urlaubsvertretung x Tage vor dem Beginn des Antrages zu verschicken. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+settings.vacation.remindForUpcomingHolidayReplacement.description=Diese Einstellung ermöglicht es eine E-Mail an die Urlaubsvertretung x Tage vor dem Beginn des Antrages zu verschicken.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=Muss kleiner oder gleich der maximalen Anzahl der Urlaubstage pro Jahr sein
 # Sick Days
@@ -701,7 +701,7 @@ settings.sickDays.title=Einstellungen zu Krankmeldungen
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office Mitarbeiter per E-Mail über das Ende der Lohnfortzahlung informiert werden.
 settings.sickDays.maximumSickPayDays=Dauer der Lohnfortzahlung im Krankheitsfall (in Tagen)
 settings.sickDays.daysBeforeEndOfSickPayNotification=Wie viele Tage im Voraus soll der Arbeitnehmer über Lohnfortzahlungsende benachrichtigt werden
-settings.sickDays.daysBeforeEndOfSickPayNotification.error=Benachrichtigung über Lohnfortzahlungsende muss vor Ende der Lohnfortzahlung erfolgen. Diese Funktion ist nur nutzbar sofern der Mailversand aktiviert und konfiguriert ist.
+settings.sickDays.daysBeforeEndOfSickPayNotification.error=Benachrichtigung über Lohnfortzahlungsende muss vor Ende der Lohnfortzahlung erfolgen.
 # WorkingTime
 settings.workingTime.title=Einstellungen für Arbeitszeiten
 settings.workingTime.description=Standard Wochentage an denen gearbeitet wird. (Kann beim Mitarbeiter individuell überschrieben werden.)

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -670,22 +670,22 @@ settings.vacation.remindForWaitingApplications.title=Automatic reminder for wait
 settings.vacation.remindForWaitingApplications=Automatic reminder function
 settings.vacation.remindForWaitingApplications.true=Enable
 settings.vacation.remindForWaitingApplications.false=Disable
-settings.vacation.daysBeforeRemindForWaitingApplications=Reminder mail every x days
-settings.vacation.daysBeforeRemindForWaitingApplications.descripton=This setting allows the supervisors or department heads to alert them of waiting vacation requests by email.
+settings.vacation.daysBeforeRemindForWaitingApplications=How many days in advance should supervisors or department heads be notified
+settings.vacation.daysBeforeRemindForWaitingApplications.descripton=This setting allows the supervisors or department heads to be notified of waiting vacation requests by email.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingApplications.title=Automatic reminder for upcoming vacations
 settings.vacation.remindForUpcomingApplications=Automatic reminder function
 settings.vacation.remindForUpcomingApplications.true=Enable
 settings.vacation.remindForUpcomingApplications.false=Disable
-settings.vacation.daysBeforeRemindForUpcomingApplications=Reminder mail x days before vacation start
-settings.vacation.remindForUpcomingApplications.description=This setting enables an email to be sent to the applicant x days before the vacation, reminding this person about the handover before the vacation.
+settings.vacation.daysBeforeRemindForUpcomingApplications=How many days in advance should the applicant be notified
+settings.vacation.remindForUpcomingApplications.description=This setting makes it possible to send an email to the applicant before his vacation, reminding that person of the handover before his vacation.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingHolidayReplacement.title=Automatic reminder for holiday replacements
 settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatic reminder function
 settings.vacation.remindForUpcomingHolidayReplacement.activation.true=Enable
 settings.vacation.remindForUpcomingHolidayReplacement.activation.false=Disable
-settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Reminder mail x days before the start of a holiday replacement
-settings.vacation.remindForUpcomingHolidayReplacement.description=This setting enables an email to be sent to the holiday replacement x days before the start of the application.
+settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=How many days in advance should the holiday replacement be notified of an upcoming replacement
+settings.vacation.remindForUpcomingHolidayReplacement.description=This setting makes it possible to send an email to the holiday replacement before the start of the application.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=have to be equal or smaller than the maximum number of holidays per year
 # Sick Days

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -622,6 +622,7 @@ subject.application.refer=Help with the decision on a vacation request
 subject.application.edited=Application for leave of {0} was successfully edited
 subject.application.remind=Reminder for waiting vacation request
 subject.application.remind.upcoming=Reminder of your absence
+subject.application.remind.upcoming.holiday_replacement=Reminder of your upcoming holiday replacement for {0}
 subject.application.cronRemind=Reminder for waiting vacation requests
 subject.application.holidayReplacement.allow=Your vacation replacement for {0} has been scheduled
 subject.application.holidayReplacement.apply=Your provisionally planned vacation replacement for {0}
@@ -678,6 +679,13 @@ settings.vacation.remindForUpcomingApplications.true=Enable
 settings.vacation.remindForUpcomingApplications.false=Disable
 settings.vacation.daysBeforeRemindForUpcomingApplications=Reminder mail x days before vacation start
 settings.vacation.remindForUpcomingApplications.description=This setting enables an email to be sent to the applicant x days before the vacation, reminding this person about the handover before the vacation. This function is only available if the mail delivery is activated and configured.
+# Vacation Starts Soon Reminder Notification
+settings.vacation.remindForUpcomingHolidayReplacement.title=Automatic reminder for holiday replacements
+settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatic reminder function
+settings.vacation.remindForUpcomingHolidayReplacement.activation.true=Enable
+settings.vacation.remindForUpcomingHolidayReplacement.activation.false=Disable
+settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Reminder mail x days before the start of a holiday replacement
+settings.vacation.remindForUpcomingHolidayReplacement.description=This setting enables an email to be sent to the holiday replacement x days before the start of the application. This function is only available if the mail delivery is activated and configured.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=have to be equal or smaller than the maximum number of holidays per year
 # Sick Days

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -671,21 +671,21 @@ settings.vacation.remindForWaitingApplications=Automatic reminder function
 settings.vacation.remindForWaitingApplications.true=Enable
 settings.vacation.remindForWaitingApplications.false=Disable
 settings.vacation.daysBeforeRemindForWaitingApplications=Reminder mail every x days
-settings.vacation.daysBeforeRemindForWaitingApplications.descripton=This setting allows the supervisors or department heads to alert them of waiting vacation requests by email. This function is only available if the mail delivery is activated and configured.
+settings.vacation.daysBeforeRemindForWaitingApplications.descripton=This setting allows the supervisors or department heads to alert them of waiting vacation requests by email.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingApplications.title=Automatic reminder for upcoming vacations
 settings.vacation.remindForUpcomingApplications=Automatic reminder function
 settings.vacation.remindForUpcomingApplications.true=Enable
 settings.vacation.remindForUpcomingApplications.false=Disable
 settings.vacation.daysBeforeRemindForUpcomingApplications=Reminder mail x days before vacation start
-settings.vacation.remindForUpcomingApplications.description=This setting enables an email to be sent to the applicant x days before the vacation, reminding this person about the handover before the vacation. This function is only available if the mail delivery is activated and configured.
+settings.vacation.remindForUpcomingApplications.description=This setting enables an email to be sent to the applicant x days before the vacation, reminding this person about the handover before the vacation.
 # Vacation Starts Soon Reminder Notification
 settings.vacation.remindForUpcomingHolidayReplacement.title=Automatic reminder for holiday replacements
 settings.vacation.remindForUpcomingHolidayReplacement.activation=Automatic reminder function
 settings.vacation.remindForUpcomingHolidayReplacement.activation.true=Enable
 settings.vacation.remindForUpcomingHolidayReplacement.activation.false=Disable
 settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement=Reminder mail x days before the start of a holiday replacement
-settings.vacation.remindForUpcomingHolidayReplacement.description=This setting enables an email to be sent to the holiday replacement x days before the start of the application. This function is only available if the mail delivery is activated and configured.
+settings.vacation.remindForUpcomingHolidayReplacement.description=This setting enables an email to be sent to the holiday replacement x days before the start of the application.
 # Account
 settings.account.error.defaultMustBeSmallerOrEqualThanMax=have to be equal or smaller than the maximum number of holidays per year
 # Sick Days
@@ -693,7 +693,7 @@ settings.sickDays.title=Sick notes settings
 settings.sickDays.description=The sick pay settings determine when the sick employee and the office staff are informed by email about the end of the sick pay.
 settings.sickDays.maximumSickPayDays=Duration of sick pay (in days)
 settings.sickDays.daysBeforeEndOfSickPayNotification=How many days in advance should the employee be notified before the end of the sick pay.
-settings.sickDays.daysBeforeEndOfSickPayNotification.error=Notification of end of salary payment must be made before the end of the salary continuation. This function is only available if the mail delivery is activated and configured.
+settings.sickDays.daysBeforeEndOfSickPayNotification.error=Notification of end of salary payment must be made before the end of the salary continuation.
 # WorkingTime
 settings.workingTime.title=Working time settings
 settings.workingTime.description=Default workdays. (Can individually be overwritten for every employee.)

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind_holiday_replacement_upcoming.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind_holiday_replacement_upcoming.ftl
@@ -1,7 +1,10 @@
 Hallo ${recipient.niceName},
 
-<#if daysBeforeUpcomingHolidayReplacement == 1>morgen<#else>in ${daysBeforeUpcomingHolidayReplacement} Tagen</#if> beginnt deine Urlaubsvertretung für ${application.person.niceName}.
+deine Urlaubsvertretung für ${application.person.niceName} vom ${application.startDate.format("dd.MM.yyyy")} bis zum ${application.endDate.format("dd.MM.yyyy")} beginnt <#if daysBeforeUpcomingHolidayReplacement == 1>morgen<#else>in ${daysBeforeUpcomingHolidayReplacement} Tagen</#if>.
 
-<#if replacementNote?has_content>Notiz: "${replacementNote}"</#if>
+<#if replacementNote?has_content>
+Notiz:
+${replacementNote}${'\n'}
+</#if>
 
 Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter ${baseLinkURL}web/application#holiday-replacement

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind_holiday_replacement_upcoming.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/remind_holiday_replacement_upcoming.ftl
@@ -1,0 +1,7 @@
+Hallo ${recipient.niceName},
+
+<#if daysBeforeUpcomingHolidayReplacement == 1>morgen<#else>in ${daysBeforeUpcomingHolidayReplacement} Tagen</#if> beginnt deine Urlaubsvertretung für ${application.person.niceName}.
+
+<#if replacementNote?has_content>Notiz: "${replacementNote}"</#if>
+
+Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter ${baseLinkURL}web/application#holiday-replacement

--- a/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
@@ -272,6 +272,58 @@
                     <div class="form-section tw-mb-8">
                         <uv:section-heading>
                             <h2>
+                                <spring:message code="settings.vacation.remindForUpcomingHolidayReplacement.title"/>
+                            </h2>
+                        </uv:section-heading>
+                        <div class="row">
+                            <div class="col-md-4 col-md-push-8">
+                                <span class="help-block tw-text-sm">
+                                    <icon:information-circle className="tw-w-4 tw-h-4" solid="true" />
+                                    <spring:message code="settings.vacation.remindForUpcomingHolidayReplacement.description"/>
+                                </span>
+                            </div>
+                            <div class="col-md-8 col-md-pull-4">
+                                <div class="form-group is-required">
+                                    <label class="control-label col-md-4" for="applicationSettings.remindForUpcomingHolidayReplacement.activation.true">
+                                        <spring:message code='settings.vacation.remindForUpcomingHolidayReplacement.activation'/>:
+                                    </label>
+                                    <div class="col-md-8 radio">
+                                        <label class="halves">
+                                            <form:radiobutton id="applicationSettings.remindForUpcomingHolidayReplacement.activation.true"
+                                                              path="applicationSettings.remindForUpcomingHolidayReplacement"
+                                                              value="true"/>
+                                            <spring:message code="settings.vacation.remindForUpcomingHolidayReplacement.activation.true"/>
+                                        </label>
+                                        <label class="halves">
+                                            <form:radiobutton id="applicationSettings.remindForUpcomingHolidayReplacement.activation.false"
+                                                              path="applicationSettings.remindForUpcomingHolidayReplacement"
+                                                              value="false"/>
+                                            <spring:message code="settings.vacation.remindForUpcomingHolidayReplacement.activation.false"/>
+                                        </label>
+                                    </div>
+                                </div>
+
+                                <div class="form-group is-required">
+                                    <label class="control-label col-md-4" for="applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement">
+                                        <spring:message code='settings.vacation.daysBeforeRemindForUpcomingHolidayReplacement'/>:
+                                    </label>
+                                    <div class="col-md-8">
+                                        <form:input id="applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement"
+                                                    path="applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement"
+                                                    class="form-control" cssErrorClass="form-control error"
+                                                    type="number" step="1"/>
+                                        <uv:error-text>
+                                            <form:errors path="applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement" />
+                                        </uv:error-text>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-section tw-mb-8">
+                        <uv:section-heading>
+                            <h2>
                                 <spring:message code="settings.vacation.remindForUpcomingApplications.title"/>
                             </h2>
                         </uv:section-heading>

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/ApplicationSettingsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/ApplicationSettingsTest.java
@@ -13,5 +13,7 @@ class ApplicationSettingsTest {
         assertThat(settings.getMaximumMonthsToApplyForLeaveInAdvance()).isEqualTo(12);
         assertThat(settings.isRemindForUpcomingApplications()).isFalse();
         assertThat(settings.getDaysBeforeRemindForUpcomingApplications()).isEqualTo(3);
+        assertThat(settings.isRemindForUpcomingHolidayReplacement()).isFalse();
+        assertThat(settings.getDaysBeforeRemindForUpcomingHolidayReplacement()).isEqualTo(3);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/dao/ApplicationRepositoryIT.java
@@ -500,6 +500,7 @@ class ApplicationRepositoryIT extends TestContainersBase {
         // yesterday
         final LocalDate yesterdayDates = LocalDate.of(2020, 5, 3);
         final Application yesterdayApplication = createApplication(savedPerson, getVacationType(HOLIDAY), yesterdayDates, yesterdayDates, FULL);
+        yesterdayApplication.setHolidayReplacements(List.of(holidayReplacement));
         yesterdayApplication.setStatus(ALLOWED);
         sut.save(yesterdayApplication);
 
@@ -531,13 +532,28 @@ class ApplicationRepositoryIT extends TestContainersBase {
         tomorrowTemporaryAllowedDateApplication.setHolidayReplacements(List.of(holidayReplacement));
         sut.save(tomorrowTemporaryAllowedDateApplication);
 
+        final Application tomorrowDateApplicationAlreadySend = createApplication(savedPerson, getVacationType(HOLIDAY), tomorrowAllowedDates, tomorrowAllowedDates, FULL);
+        tomorrowDateApplicationAlreadySend.setStatus(TEMPORARY_ALLOWED);
+        tomorrowDateApplicationAlreadySend.setHolidayReplacements(List.of(holidayReplacement));
+        tomorrowDateApplicationAlreadySend.setUpcomingHolidayReplacementNotificationSend(tomorrowAllowedDates);
+        sut.save(tomorrowDateApplicationAlreadySend);
+
         final Application tomorrowWaitingDateApplication = createApplication(savedPerson, getVacationType(HOLIDAY), tomorrowAllowedDates, tomorrowAllowedDates, FULL);
         tomorrowWaitingDateApplication.setStatus(WAITING);
         sut.save(tomorrowWaitingDateApplication);
 
-        final LocalDate requestedStartDate = LocalDate.of(2020, 5, 5);
+        // day after tomorrow
+        final LocalDate dayAfterTomorrowAllowedDates = LocalDate.of(2020, 5, 6);
+
+        final Application dayAfterTomorrowDateApplication = createApplication(savedPerson, getVacationType(HOLIDAY), dayAfterTomorrowAllowedDates, dayAfterTomorrowAllowedDates, FULL);
+        dayAfterTomorrowDateApplication.setHolidayReplacements(List.of(holidayReplacement));
+        dayAfterTomorrowDateApplication.setStatus(ALLOWED);
+        sut.save(dayAfterTomorrowDateApplication);
+
+        final LocalDate requestedStartDateFrom = LocalDate.of(2020, 5, 4);
+        final LocalDate requestedStartDateTo = LocalDate.of(2020, 5, 5);
         final List<ApplicationStatus> requestStatuses = List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED);
-        final List<Application> applications = sut.findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(requestStatuses, requestedStartDate);
+        final List<Application> applications = sut.findByStatusInAndStartDateBetweenAndHolidayReplacementsIsNotEmptyAndUpcomingHolidayReplacementNotificationSendIsNull(requestStatuses, requestedStartDateFrom, requestedStartDateTo);
         assertThat(applications)
             .containsOnly(tomorrowDateApplication, tomorrowCancellationRequestDateApplication, tomorrowTemporaryAllowedDateApplication);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceIT.java
@@ -1951,6 +1951,100 @@ class ApplicationMailServiceIT extends TestContainersBase {
         assertThat(content).contains("/web/application/1234");
     }
 
+    @Test
+    void ensurePersonGetsANotificationForUpcomingHolidayReplacement() throws MessagingException, IOException {
+
+        final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
+        final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
+
+        final Application application = createApplication(person);
+
+        final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
+        holidayReplacementEntity.setPerson(holidayReplacement);
+        holidayReplacementEntity.setNote("Some notes");
+        application.setHolidayReplacements(List.of(holidayReplacementEntity));
+
+        sut.sendRemindForUpcomingHolidayReplacement(List.of(application), 1);
+
+        // was email sent?
+        MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(holidayReplacement.getEmail());
+        assertThat(inbox.length).isOne();
+
+        Message msg = inbox[0];
+        assertThat(msg.getSubject()).contains("Erinnerung an deine bevorstehende Urlaubsvertretung für Lieschen Müller");
+        assertThat(new InternetAddress(holidayReplacement.getEmail())).isEqualTo(msg.getAllRecipients()[0]);
+
+        // check content of email
+        String content = (String) msg.getContent();
+        assertThat(content).contains("Hallo replacement holiday");
+        assertThat(content).contains("morgen beginnt deine Urlaubsvertretung für Lieschen Müller");
+        assertThat(content).contains("Notiz: \"Some notes\"");
+        assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
+        assertThat(content).contains("/web/application#holiday-replacement");
+    }
+
+    @Test
+    void ensurePersonGetsANotificationForUpcomingHolidayReplacementMoreThanOneDay() throws MessagingException, IOException {
+
+        final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
+        final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
+
+        final Application application = createApplication(person);
+        final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
+        holidayReplacementEntity.setPerson(holidayReplacement);
+        holidayReplacementEntity.setNote("Some notes");
+        application.setHolidayReplacements(List.of(holidayReplacementEntity));
+
+        sut.sendRemindForUpcomingHolidayReplacement(List.of(application), 3);
+
+        // was email sent?
+        MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(holidayReplacement.getEmail());
+        assertThat(inbox.length).isOne();
+
+        Message msg = inbox[0];
+        assertThat(msg.getSubject()).contains("Erinnerung an deine bevorstehende Urlaubsvertretung für Lieschen Müller");
+        assertThat(new InternetAddress(holidayReplacement.getEmail())).isEqualTo(msg.getAllRecipients()[0]);
+
+        // check content of email
+        String content = (String) msg.getContent();
+        assertThat(content).contains("Hallo replacement holiday");
+        assertThat(content).contains("in 3 Tagen beginnt deine Urlaubsvertretung für Lieschen Müller");
+        assertThat(content).contains("Notiz: \"Some notes\"");
+        assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
+        assertThat(content).contains("/web/application#holiday-replacement");
+    }
+
+    @Test
+    void ensurePersonGetsANotificationForUpcomingHolidayReplacementWithoutNote() throws MessagingException, IOException {
+
+        final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
+        final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
+
+        final Application application = createApplication(person);
+
+        final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
+        holidayReplacementEntity.setPerson(holidayReplacement);
+        application.setHolidayReplacements(List.of(holidayReplacementEntity));
+
+        sut.sendRemindForUpcomingHolidayReplacement(List.of(application), 1);
+
+        // was email sent?
+        MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(holidayReplacement.getEmail());
+        assertThat(inbox.length).isOne();
+
+        Message msg = inbox[0];
+        assertThat(msg.getSubject()).contains("Erinnerung an deine bevorstehende Urlaubsvertretung für Lieschen Müller");
+        assertThat(new InternetAddress(holidayReplacement.getEmail())).isEqualTo(msg.getAllRecipients()[0]);
+
+        // check content of email
+        String content = (String) msg.getContent();
+        assertThat(content).contains("Hallo replacement holiday");
+        assertThat(content).contains("morgen beginnt deine Urlaubsvertretung für Lieschen Müller");
+        assertThat(content).doesNotContain("Notiz:");
+        assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
+        assertThat(content).contains("/web/application#holiday-replacement");
+    }
+
     private void verifyInbox(Person inboxOwner, List<Application> applications) throws MessagingException, IOException {
 
         MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(inboxOwner.getEmail());

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationMailServiceIT.java
@@ -1958,6 +1958,8 @@ class ApplicationMailServiceIT extends TestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
+        application.setStartDate(LocalDate.of(2021, Month.APRIL, 16));
+        application.setEndDate(LocalDate.of(2021, Month.APRIL, 16));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -1977,8 +1979,9 @@ class ApplicationMailServiceIT extends TestContainersBase {
         // check content of email
         String content = (String) msg.getContent();
         assertThat(content).contains("Hallo replacement holiday");
-        assertThat(content).contains("morgen beginnt deine Urlaubsvertretung für Lieschen Müller");
-        assertThat(content).contains("Notiz: \"Some notes\"");
+        assertThat(content).contains("deine Urlaubsvertretung für Lieschen Müller vom 16.04.2021 bis zum 16.04.2021 beginnt morgen.");
+        assertThat(content).contains("Notiz:");
+        assertThat(content).contains("Some notes");
         assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
         assertThat(content).contains("/web/application#holiday-replacement");
     }
@@ -1990,6 +1993,9 @@ class ApplicationMailServiceIT extends TestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
+        application.setStartDate(LocalDate.of(2021, Month.APRIL, 16));
+        application.setEndDate(LocalDate.of(2021, Month.APRIL, 16));
+
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
         holidayReplacementEntity.setNote("Some notes");
@@ -2008,8 +2014,9 @@ class ApplicationMailServiceIT extends TestContainersBase {
         // check content of email
         String content = (String) msg.getContent();
         assertThat(content).contains("Hallo replacement holiday");
-        assertThat(content).contains("in 3 Tagen beginnt deine Urlaubsvertretung für Lieschen Müller");
-        assertThat(content).contains("Notiz: \"Some notes\"");
+        assertThat(content).contains("deine Urlaubsvertretung für Lieschen Müller vom 16.04.2021 bis zum 16.04.2021 beginnt in 3 Tagen.");
+        assertThat(content).contains("Notiz:");
+        assertThat(content).contains("Some notes");
         assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
         assertThat(content).contains("/web/application#holiday-replacement");
     }
@@ -2021,6 +2028,8 @@ class ApplicationMailServiceIT extends TestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
+        application.setStartDate(LocalDate.of(2021, Month.APRIL, 16));
+        application.setEndDate(LocalDate.of(2021, Month.APRIL, 16));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -2039,7 +2048,7 @@ class ApplicationMailServiceIT extends TestContainersBase {
         // check content of email
         String content = (String) msg.getContent();
         assertThat(content).contains("Hallo replacement holiday");
-        assertThat(content).contains("morgen beginnt deine Urlaubsvertretung für Lieschen Müller");
+        assertThat(content).contains("deine Urlaubsvertretung für Lieschen Müller vom 16.04.2021 bis zum 16.04.2021 beginnt morgen.");
         assertThat(content).doesNotContain("Notiz:");
         assertThat(content).contains("Einen Überblick deiner aktuellen und zukünftigen Vertretungen findest du unter");
         assertThat(content).contains("/web/application#holiday-replacement");

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailConfigurationTest.java
@@ -25,20 +25,29 @@ class ApplicationReminderMailConfigurationTest {
         sut.configureTasks(taskRegistrar);
 
         final List<CronTask> cronTaskList = taskRegistrar.getCronTaskList();
-        assertThat(cronTaskList).hasSize(2);
-
-        final CronTask cronTask = cronTaskList.get(0);
-        assertThat(cronTask.getExpression()).isEqualTo("0 0 7 * * *");
+        assertThat(cronTaskList).hasSize(3);
 
         verifyNoInteractions(service);
+
+        // Waiting Application Reminder
+        final CronTask cronTask = cronTaskList.get(0);
+        assertThat(cronTask.getExpression()).isEqualTo("0 0 7 * * *");
 
         cronTask.getRunnable().run();
         verify(service).sendWaitingApplicationsReminderNotification();
 
+        // Upcoming Application Reminder
         final CronTask cronTaskStartsSoon = cronTaskList.get(1);
         assertThat(cronTaskStartsSoon.getExpression()).isEqualTo("0 0 7 * * *");
 
         cronTaskStartsSoon.getRunnable().run();
         verify(service).sendUpcomingApplicationsReminderNotification();
+
+        // Upcoming holiday replacement Reminder
+        final CronTask cronTaskHolidayReplacementStartsSoon = cronTaskList.get(2);
+        assertThat(cronTaskHolidayReplacementStartsSoon.getExpression()).isEqualTo("0 0 7 * * *");
+
+        cronTaskHolidayReplacementStartsSoon.getRunnable().run();
+        verify(service).sendUpcomingHolidayReplacementReminderNotification();
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationReminderMailServiceTest.java
@@ -4,6 +4,7 @@ package org.synyx.urlaubsverwaltung.application.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.application.ApplicationSettings;
@@ -129,15 +130,20 @@ class ApplicationReminderMailServiceTest {
         final ApplicationSettings applicationSettings = prepareSettingsWithRemindForUpcomingHolidayReplacements(true);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate localDate = LocalDate.now(clock).plusDays(applicationSettings.getDaysBeforeRemindForUpcomingHolidayReplacement());
+        final LocalDate now = LocalDate.now(clock);
+        final LocalDate to = now.plusDays(applicationSettings.getDaysBeforeRemindForUpcomingHolidayReplacement());
 
         final Application tomorrowApplication = createApplication(person, createVacationType(HOLIDAY));
-        tomorrowApplication.setApplicationDate(localDate);
+        tomorrowApplication.setApplicationDate(to);
 
-        when(applicationService.getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(localDate, List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED))).thenReturn(List.of(tomorrowApplication));
+        when(applicationService.getApplicationsWhereHolidayReplacementShouldBeNotified(now, to, List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED))).thenReturn(List.of(tomorrowApplication));
 
         sut.sendUpcomingHolidayReplacementReminderNotification();
         verify(applicationMailService).sendRemindForUpcomingHolidayReplacement(List.of(tomorrowApplication), applicationSettings.getDaysBeforeRemindForUpcomingApplications());
+
+        final ArgumentCaptor<Application> applicationArgumentCaptor = ArgumentCaptor.forClass(Application.class);
+        verify(applicationService).save(applicationArgumentCaptor.capture());
+        assertThat(applicationArgumentCaptor.getAllValues().get(0).getUpcomingHolidayReplacementNotificationSend()).isEqualTo(now);
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
@@ -148,14 +148,15 @@ class ApplicationServiceImplTest {
     }
 
     @Test
-    void getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty() {
-        final LocalDate startDate = LocalDate.of(2020, 10, 1);
+    void getApplicationsWhereHolidayReplacementShouldBeNotified() {
+        final LocalDate from = LocalDate.of(2020, 10, 1);
+        final LocalDate to = LocalDate.of(2020, 10, 3);
 
         final Application application = new Application();
         final List<ApplicationStatus> statuses = List.of(TEMPORARY_ALLOWED, ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
-        when(applicationRepository.findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(statuses, startDate)).thenReturn(List.of(application));
+        when(applicationRepository.findByStatusInAndStartDateBetweenAndHolidayReplacementsIsNotEmptyAndUpcomingHolidayReplacementNotificationSendIsNull(statuses, from, to)).thenReturn(List.of(application));
 
-        final List<Application> holidayReplacementApplications = sut.getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(startDate, statuses);
+        final List<Application> holidayReplacementApplications = sut.getApplicationsWhereHolidayReplacementShouldBeNotified(from, to, statuses);
         assertThat(holidayReplacementApplications).hasSize(1).contains(application);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/service/ApplicationServiceImplTest.java
@@ -146,4 +146,16 @@ class ApplicationServiceImplTest {
         final List<Application> holidayReplacementApplications = sut.getApplicationsWithStartDateAndState(startDate, statuses);
         assertThat(holidayReplacementApplications).hasSize(1).contains(application);
     }
+
+    @Test
+    void getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty() {
+        final LocalDate startDate = LocalDate.of(2020, 10, 1);
+
+        final Application application = new Application();
+        final List<ApplicationStatus> statuses = List.of(TEMPORARY_ALLOWED, ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
+        when(applicationRepository.findByStatusInAndStartDateAndHolidayReplacementsIsNotEmpty(statuses, startDate)).thenReturn(List.of(application));
+
+        final List<Application> holidayReplacementApplications = sut.getApplicationsWithStartDateAndStateAndHolidayReplacementIsNotEmpty(startDate, statuses);
+        assertThat(holidayReplacementApplications).hasSize(1).contains(application);
+    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
@@ -145,12 +145,14 @@ class SettingsValidatorTest {
 
         applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(null);
         applicationSettings.setDaysBeforeRemindForWaitingApplications(null);
+        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(null);
         applicationSettings.setDaysBeforeRemindForUpcomingApplications(null);
 
         Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
         verify(mockError).rejectValue("applicationSettings.maximumMonthsToApplyForLeaveInAdvance", "error.entry.mandatory");
         verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.mandatory");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.mandatory");
         verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingApplications", "error.entry.mandatory");
     }
 
@@ -161,6 +163,7 @@ class SettingsValidatorTest {
         ApplicationSettings applicationSettings = settings.getApplicationSettings();
 
         applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(invalidValue);
+        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(-1);
 
         Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
@@ -180,6 +183,7 @@ class SettingsValidatorTest {
         settingsValidator.validate(settings, mockError);
 
         verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.invalid");
     }
 
     @ParameterizedTest

--- a/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsValidatorTest.java
@@ -20,6 +20,7 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
 import java.util.stream.Stream;
 
+import static java.lang.Integer.MAX_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
@@ -136,19 +137,18 @@ class SettingsValidatorTest {
         verify(mockError).rejectValue("overtimeSettings.minimumOvertime", "error.entry.invalid");
     }
 
-    // Absence settings ------------------------------------------------------------------------------------------------
+    // Application settings ------------------------------------------------------------------------------------------------
     @Test
-    void ensureAbsenceSettingsCanNotBeNull() {
-
-        Settings settings = new Settings();
-        ApplicationSettings applicationSettings = settings.getApplicationSettings();
+    void ensureApplicationSettingsCanNotBeNull() {
+        final Settings settings = new Settings();
+        final ApplicationSettings applicationSettings = settings.getApplicationSettings();
 
         applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(null);
         applicationSettings.setDaysBeforeRemindForWaitingApplications(null);
         applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(null);
         applicationSettings.setDaysBeforeRemindForUpcomingApplications(null);
 
-        Errors mockError = mock(Errors.class);
+        final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
         verify(mockError).rejectValue("applicationSettings.maximumMonthsToApplyForLeaveInAdvance", "error.entry.mandatory");
         verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.mandatory");
@@ -158,57 +158,58 @@ class SettingsValidatorTest {
 
     @ParameterizedTest
     @ValueSource(ints = {0, -1})
-    void ensureApplicationSettingsMaximumMonthsToApplyForLeaveInAdvanceIsInvalid(int invalidValue) {
-        Settings settings = new Settings();
-        ApplicationSettings applicationSettings = settings.getApplicationSettings();
+    void ensureApplicationSettingsIsInvalid(int invalidValue) {
+        final Settings settings = new Settings();
+        final ApplicationSettings applicationSettings = settings.getApplicationSettings();
 
         applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(invalidValue);
-        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(-1);
+        applicationSettings.setDaysBeforeRemindForWaitingApplications(invalidValue);
+        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(invalidValue);
+        applicationSettings.setDaysBeforeRemindForUpcomingApplications(invalidValue);
 
-        Errors mockError = mock(Errors.class);
+        final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
-
         verify(mockError).rejectValue("applicationSettings.maximumMonthsToApplyForLeaveInAdvance", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingApplications", "error.entry.invalid");
     }
 
     @ParameterizedTest
     @ValueSource(ints = {0, -1})
     void ensureApplicationSettingsDaysBeforeRemindForWaitingApplicationsIsInvalid(int invalidValue) {
-        Settings settings = new Settings();
-        ApplicationSettings applicationSettings = settings.getApplicationSettings();
+        final Settings settings = new Settings();
+        final ApplicationSettings applicationSettings = settings.getApplicationSettings();
 
+        applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(invalidValue);
         applicationSettings.setDaysBeforeRemindForWaitingApplications(invalidValue);
-
-        Errors mockError = mock(Errors.class);
-        settingsValidator.validate(settings, mockError);
-
-        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.invalid");
-        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.invalid");
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {0, -1})
-    void ensureApplicationSettingsDaysBeforeRemindForUpcomingApplicationsIsInvalid(int invalidValue) {
-        Settings settings = new Settings();
-        ApplicationSettings applicationSettings = settings.getApplicationSettings();
+        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(invalidValue);
         applicationSettings.setDaysBeforeRemindForUpcomingApplications(invalidValue);
 
-        Errors mockError = mock(Errors.class);
+        final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
-
+        verify(mockError).rejectValue("applicationSettings.maximumMonthsToApplyForLeaveInAdvance", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.invalid");
         verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingApplications", "error.entry.invalid");
     }
 
     @Test
     void ensureThatAbsenceSettingsAreSmallerOrEqualsThanMaxInt() {
-
         final Settings settings = new Settings();
         final ApplicationSettings applicationSettings = settings.getApplicationSettings();
-        applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(Integer.MAX_VALUE + 1);
+
+        applicationSettings.setMaximumMonthsToApplyForLeaveInAdvance(MAX_VALUE + 1);
+        applicationSettings.setDaysBeforeRemindForWaitingApplications(MAX_VALUE + 1);
+        applicationSettings.setDaysBeforeRemindForUpcomingHolidayReplacement(MAX_VALUE + 1);
+        applicationSettings.setDaysBeforeRemindForUpcomingApplications(MAX_VALUE + 1);
 
         final Errors mockError = mock(Errors.class);
         settingsValidator.validate(settings, mockError);
         verify(mockError).rejectValue("applicationSettings.maximumMonthsToApplyForLeaveInAdvance", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForWaitingApplications", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingHolidayReplacement", "error.entry.invalid");
+        verify(mockError).rejectValue("applicationSettings.daysBeforeRemindForUpcomingApplications", "error.entry.invalid");
     }
 
     // Account settings ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
closes #2044 

How to test:
* `uv.application.upcoming-holiday-replacement-notification.cron=0 * * * * *`
* Create a approved vacation that starts in 3 days
* Activate holiday replacement mails in Settings
* Take a look at http://localhost:8025