### PR TITLE
improve error message for AccountForm

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -85,14 +85,12 @@ class AccountFormValidator implements Validator {
                 if (toYear != year) {
                     reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, msg("holidaysAccountValidTo.invalidYear"), String.valueOf(year));
                 }
-                return;
             }
 
             boolean periodIsOnlyOneDay = holidaysAccountValidFrom.equals(holidaysAccountValidTo);
             if (periodIsOnlyOneDay) {
                 reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_FROM, msg("holidaysAccountValidFrom.invalidRange"));
                 reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, msg("holidaysAccountValidTo.invalidRange"));
-                return;
             }
 
             boolean beginOfPeriodIsAfterEndOfPeriod = holidaysAccountValidFrom.isAfter(holidaysAccountValidTo);

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -20,7 +20,7 @@ class AccountFormValidator implements Validator {
     private static final String ERROR_ENTRY = "error.entry.invalid";
     private static final String ERROR_PERIOD = "error.entry.invalidPeriod";
     private static final String ERROR_COMMENT_TO_LONG = "error.entry.commentTooLong";
-    private static final String ERROR_FULL_OR_HALF_AN_HOUR_FIELD = "error.entry.fullOrHalfHour";
+    private static final String ERROR_FULL_OR_HALF_NUMBER = "error.entry.fullOrHalfNumber";
 
     private static final String ATTRIBUTE_ANNUAL_VACATION_DAYS = "annualVacationDays";
     private static final String ATTRIBUTE_ACTUAL_VACATION_DAYS = "actualVacationDays";
@@ -100,7 +100,7 @@ class AccountFormValidator implements Validator {
 
         if (actualVacationDays != null) {
 
-            validateFullOrHalfAnHour(actualVacationDays, ATTRIBUTE_ACTUAL_VACATION_DAYS, errors);
+            validateFullOrHalfDay(actualVacationDays, ATTRIBUTE_ACTUAL_VACATION_DAYS, errors);
 
             final BigDecimal annualVacationDays = form.getAnnualVacationDays();
             validateNumberOfDays(actualVacationDays, ATTRIBUTE_ACTUAL_VACATION_DAYS, annualVacationDays, errors);
@@ -117,23 +117,23 @@ class AccountFormValidator implements Validator {
 
         if (remainingVacationDays != null) {
             // field entitlement's remaining vacation days
-            validateFullOrHalfAnHour(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
+            validateFullOrHalfDay(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
             validateNumberOfDays(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, maxDays, errors);
 
             if (remainingVacationDaysNotExpiring != null) {
-                validateFullOrHalfAnHour(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, errors);
+                validateFullOrHalfDay(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, errors);
                 validateNumberOfDays(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, remainingVacationDays, errors);
             }
         }
     }
 
-    private void validateFullOrHalfAnHour(BigDecimal days, String field, Errors errors) {
+    private void validateFullOrHalfDay(BigDecimal days, String field, Errors errors) {
 
         final String decimal = days.subtract(new BigDecimal(days.intValue())).toPlainString();
         final boolean isFullOrHalfAnHour = decimal.equals("0") || decimal.startsWith("0.0") || decimal.startsWith("0.5");
 
         if (!isFullOrHalfAnHour && errors.getFieldErrors(field).isEmpty()) {
-            errors.rejectValue(field, ERROR_FULL_OR_HALF_AN_HOUR_FIELD);
+            errors.rejectValue(field, ERROR_FULL_OR_HALF_NUMBER);
         }
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -44,13 +44,13 @@ class AccountFormValidator implements Validator {
     @Override
     public void validate(Object target, Errors errors) {
 
-        final BigDecimal maximumAnnualVacationDays = getMaximumAnnualVacationDays();
+        final BigDecimal maxAnnualVacationDays = getMaximumAnnualVacationDays();
 
         final AccountForm form = (AccountForm) target;
         validatePeriod(form, errors);
-        validateAnnualVacation(form, errors, maximumAnnualVacationDays);
+        validateAnnualVacation(form, errors, maxAnnualVacationDays);
         validateActualVacation(form, errors);
-        validateRemainingVacationDays(form, errors, maximumAnnualVacationDays);
+        validateRemainingVacationDays(form, errors, maxAnnualVacationDays);
         validateRemainingVacationDaysNotExpiring(form, errors);
         validateComment(form, errors);
     }
@@ -102,7 +102,7 @@ class AccountFormValidator implements Validator {
         }
     }
 
-    void validateAnnualVacation(AccountForm form, Errors errors, BigDecimal maxAnnualVacation) {
+    void validateAnnualVacation(AccountForm form, Errors errors, BigDecimal maxAnnualVacationDays) {
 
         final BigDecimal annualVacationDays = form.getAnnualVacationDays();
         validateNumberNotNull(annualVacationDays, ATTRIBUTE_ANNUAL_VACATION_DAYS, errors);
@@ -114,8 +114,8 @@ class AccountFormValidator implements Validator {
             if (isNegative(annualVacationDays)) {
                 reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
             }
-            else if (isGreater(annualVacationDays, maxAnnualVacation)) {
-                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.max", asIntString(maxAnnualVacation));
+            else if (isGreater(annualVacationDays, maxAnnualVacationDays)) {
+                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.max", asIntString(maxAnnualVacationDays));
             }
         }
     }
@@ -139,7 +139,7 @@ class AccountFormValidator implements Validator {
         }
     }
 
-    void validateRemainingVacationDays(AccountForm form, Errors errors, BigDecimal maxDays) {
+    void validateRemainingVacationDays(AccountForm form, Errors errors, BigDecimal maxAnnualVacationDays) {
 
         final BigDecimal remainingVacationDays = form.getRemainingVacationDays();
 
@@ -149,8 +149,8 @@ class AccountFormValidator implements Validator {
             validateFullOrHalfDay(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
             if (isNegative(remainingVacationDays)) {
                 reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
-            } else if (isGreater(remainingVacationDays, maxDays)) {
-                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, msg("remainingVacationDays.tooBig"), asIntString(maxDays));
+            } else if (isGreater(remainingVacationDays, maxAnnualVacationDays)) {
+                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, msg("remainingVacationDays.tooBig"), asIntString(maxAnnualVacationDays));
             }
         }
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -27,7 +27,7 @@ class AccountFormValidator implements Validator {
     private static final String ATTRIBUTE_COMMENT = "comment";
     private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_FROM = "holidaysAccountValidFrom";
     private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_TO = "holidaysAccountValidTo";
-    public static final String ERROR_ENTRY_MIN = "error.entry.min";
+    private static final String ERROR_ENTRY_MIN = "error.entry.min";
 
     private final SettingsService settingsService;
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -17,8 +17,6 @@ class AccountFormValidator implements Validator {
 
     private static final String ERROR_MANDATORY_FIELD = "error.entry.mandatory";
     private static final String ERROR_INTEGER_FIELD = "error.entry.integer";
-    private static final String ERROR_ENTRY = "error.entry.invalid";
-    private static final String ERROR_PERIOD = "error.entry.invalidPeriod";
     private static final String ERROR_COMMENT_TO_LONG = "error.entry.commentTooLong";
     private static final String ERROR_FULL_OR_HALF_NUMBER = "error.entry.fullOrHalfNumber";
 
@@ -27,6 +25,8 @@ class AccountFormValidator implements Validator {
     private static final String ATTRIBUTE_REMAINING_VACATION_DAYS = "remainingVacationDays";
     private static final String ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING = "remainingVacationDaysNotExpiring";
     private static final String ATTRIBUTE_COMMENT = "comment";
+    private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_FROM = "holidaysAccountValidFrom";
+    private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_TO = "holidaysAccountValidTo";
 
     private final SettingsService settingsService;
 
@@ -50,6 +50,7 @@ class AccountFormValidator implements Validator {
         validateAnnualVacation(form, errors, maximumAnnualVacationDays);
         validateActualVacation(form, errors);
         validateRemainingVacationDays(form, errors, maximumAnnualVacationDays);
+        validateRemainingVacationDaysNotExpiring(form, errors);
         validateComment(form, errors);
     }
 
@@ -66,22 +67,41 @@ class AccountFormValidator implements Validator {
         final LocalDate holidaysAccountValidFrom = form.getHolidaysAccountValidFrom();
         final LocalDate holidaysAccountValidTo = form.getHolidaysAccountValidTo();
 
-        validateDateNotNull(holidaysAccountValidFrom, "holidaysAccountValidFrom", errors);
-        validateDateNotNull(holidaysAccountValidTo, "holidaysAccountValidTo", errors);
+        validateDateNotNull(holidaysAccountValidFrom, ATTR_HOLIDAYS_ACCOUNT_VALID_FROM, errors);
+        validateDateNotNull(holidaysAccountValidTo, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, errors);
 
         if (holidaysAccountValidFrom != null && holidaysAccountValidTo != null) {
-            boolean periodIsNotWithinOneYear = holidaysAccountValidFrom.getYear() != form.getHolidaysAccountYear()
-                || holidaysAccountValidTo.getYear() != form.getHolidaysAccountYear();
-            boolean periodIsOnlyOneDay = holidaysAccountValidFrom.equals(holidaysAccountValidTo);
-            boolean beginOfPeriodIsAfterEndOfPeriod = holidaysAccountValidFrom.isAfter(holidaysAccountValidTo);
+            final int year = form.getHolidaysAccountYear();
+            final int fromYear = holidaysAccountValidFrom.getYear();
+            final int toYear = holidaysAccountValidTo.getYear();
+            final boolean invalidYear = fromYear != year || toYear != year;
 
-            if (periodIsNotWithinOneYear || periodIsOnlyOneDay || beginOfPeriodIsAfterEndOfPeriod) {
-                errors.reject(ERROR_PERIOD);
+            if (invalidYear) {
+                if (fromYear != year) {
+                    reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_FROM, msg("holidaysAccountValidFrom.invalidYear"), String.valueOf(year));
+                }
+                if (toYear != year) {
+                    reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, msg("holidaysAccountValidTo.invalidYear"), String.valueOf(year));
+                }
+                return;
+            }
+
+            boolean periodIsOnlyOneDay = holidaysAccountValidFrom.equals(holidaysAccountValidTo);
+            if (periodIsOnlyOneDay) {
+                reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_FROM, msg("holidaysAccountValidFrom.invalidRange"));
+                reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, msg("holidaysAccountValidTo.invalidRange"));
+                return;
+            }
+
+            boolean beginOfPeriodIsAfterEndOfPeriod = holidaysAccountValidFrom.isAfter(holidaysAccountValidTo);
+            if (beginOfPeriodIsAfterEndOfPeriod) {
+                reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_FROM, msg("holidaysAccountValidFrom.invalidRangeReversed"));
+                reject(errors, ATTR_HOLIDAYS_ACCOUNT_VALID_TO, msg("holidaysAccountValidTo.invalidRangeReversed"));
             }
         }
     }
 
-    void validateAnnualVacation(AccountForm form, Errors errors, BigDecimal maxDays) {
+    void validateAnnualVacation(AccountForm form, Errors errors, BigDecimal maxAnnualVacation) {
 
         final BigDecimal annualVacationDays = form.getAnnualVacationDays();
         validateNumberNotNull(annualVacationDays, ATTRIBUTE_ANNUAL_VACATION_DAYS, errors);
@@ -89,7 +109,13 @@ class AccountFormValidator implements Validator {
         if (annualVacationDays != null) {
 
             validateIsInteger(annualVacationDays, ATTRIBUTE_ANNUAL_VACATION_DAYS, errors);
-            validateNumberOfDays(annualVacationDays, ATTRIBUTE_ANNUAL_VACATION_DAYS, maxDays, errors);
+
+            if (isNegative(annualVacationDays)) {
+                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.min", "0");
+            }
+            else if (isGreater(annualVacationDays, maxAnnualVacation)) {
+                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.max", asIntString(maxAnnualVacation));
+            }
         }
     }
 
@@ -103,26 +129,50 @@ class AccountFormValidator implements Validator {
             validateFullOrHalfDay(actualVacationDays, ATTRIBUTE_ACTUAL_VACATION_DAYS, errors);
 
             final BigDecimal annualVacationDays = form.getAnnualVacationDays();
-            validateNumberOfDays(actualVacationDays, ATTRIBUTE_ACTUAL_VACATION_DAYS, annualVacationDays, errors);
+
+            if (isNegative(actualVacationDays)) {
+                reject(errors, ATTRIBUTE_ACTUAL_VACATION_DAYS, "error.entry.min", "0");
+            } else if (isGreater(actualVacationDays, annualVacationDays)) {
+                reject(errors, ATTRIBUTE_ACTUAL_VACATION_DAYS, "error.entry.max", asIntString(annualVacationDays));
+            }
         }
     }
 
     void validateRemainingVacationDays(AccountForm form, Errors errors, BigDecimal maxDays) {
 
         final BigDecimal remainingVacationDays = form.getRemainingVacationDays();
-        final BigDecimal remainingVacationDaysNotExpiring = form.getRemainingVacationDaysNotExpiring();
 
         validateNumberNotNull(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
-        validateNumberNotNull(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, errors);
 
         if (remainingVacationDays != null) {
-            // field entitlement's remaining vacation days
             validateFullOrHalfDay(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
-            validateNumberOfDays(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, maxDays, errors);
+            if (isNegative(remainingVacationDays)) {
+                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, "error.entry.min", "0");
+            } else if (isGreater(remainingVacationDays, maxDays)) {
+                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, msg("remainingVacationDays.tooBig"), asIntString(maxDays));
+            }
+        }
+    }
 
-            if (remainingVacationDaysNotExpiring != null) {
+    void validateRemainingVacationDaysNotExpiring(AccountForm form, Errors errors) {
+
+        final BigDecimal remainingVacationDays = form.getRemainingVacationDays();
+        final BigDecimal remainingVacationDaysNotExpiring = form.getRemainingVacationDaysNotExpiring();
+
+        if (remainingVacationDays == null && remainingVacationDaysNotExpiring == null) {
+            reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, ERROR_MANDATORY_FIELD);
+        }
+
+        if (remainingVacationDays != null) {
+            if (remainingVacationDaysNotExpiring == null) {
+                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, ERROR_MANDATORY_FIELD);
+            } else {
                 validateFullOrHalfDay(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, errors);
-                validateNumberOfDays(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, remainingVacationDays, errors);
+                if (isNegative(remainingVacationDaysNotExpiring)) {
+                    reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, "error.entry.min", "0");
+                } else if (isGreater(remainingVacationDaysNotExpiring, remainingVacationDays)) {
+                    reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, msg("remainingVacationDaysNotExpiring.tooBig"), asIntString(remainingVacationDays));
+                }
             }
         }
     }
@@ -165,21 +215,32 @@ class AccountFormValidator implements Validator {
         }
     }
 
-    private void validateNumberOfDays(BigDecimal days, String field, BigDecimal maximumDays, Errors errors) {
-
-        // is number of days < 0 ?
-        if (days.compareTo(BigDecimal.ZERO) < 0) {
-            errors.rejectValue(field, ERROR_ENTRY);
-        }
-
-        // is number of days unrealistic?
-        if (days.compareTo(maximumDays) > 0) {
-            errors.rejectValue(field, ERROR_ENTRY);
-        }
-    }
-
     private BigDecimal getMaximumAnnualVacationDays() {
         final AccountSettings accountSettings = settingsService.getSettings().getAccountSettings();
         return BigDecimal.valueOf(accountSettings.getMaximumAnnualVacationDays());
+    }
+
+    private boolean isNegative(BigDecimal bigDecimal) {
+        return bigDecimal.compareTo(BigDecimal.ZERO) < 0;
+    }
+
+    private boolean isGreater(BigDecimal first, BigDecimal second) {
+        return first.compareTo(second) > 0;
+    }
+
+    private void reject(Errors errors, String field, String errorCode, Object... messageAttributes) {
+        if (messageAttributes.length == 0) {
+            errors.rejectValue(field, errorCode);
+        } else {
+            errors.rejectValue(field, errorCode, messageAttributes, "");
+        }
+    }
+
+    private static String asIntString(BigDecimal bigDecimal) {
+        return String.valueOf(bigDecimal.intValue());
+    }
+
+    private static String msg(String key) {
+        return "person.form.annualVacation.error." + key;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -27,6 +27,7 @@ class AccountFormValidator implements Validator {
     private static final String ATTRIBUTE_COMMENT = "comment";
     private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_FROM = "holidaysAccountValidFrom";
     private static final String ATTR_HOLIDAYS_ACCOUNT_VALID_TO = "holidaysAccountValidTo";
+    public static final String ERROR_ENTRY_MIN = "error.entry.min";
 
     private final SettingsService settingsService;
 
@@ -111,7 +112,7 @@ class AccountFormValidator implements Validator {
             validateIsInteger(annualVacationDays, ATTRIBUTE_ANNUAL_VACATION_DAYS, errors);
 
             if (isNegative(annualVacationDays)) {
-                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.min", "0");
+                reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
             }
             else if (isGreater(annualVacationDays, maxAnnualVacation)) {
                 reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.max", asIntString(maxAnnualVacation));
@@ -131,7 +132,7 @@ class AccountFormValidator implements Validator {
             final BigDecimal annualVacationDays = form.getAnnualVacationDays();
 
             if (isNegative(actualVacationDays)) {
-                reject(errors, ATTRIBUTE_ACTUAL_VACATION_DAYS, "error.entry.min", "0");
+                reject(errors, ATTRIBUTE_ACTUAL_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
             } else if (isGreater(actualVacationDays, annualVacationDays)) {
                 reject(errors, ATTRIBUTE_ACTUAL_VACATION_DAYS, "error.entry.max", asIntString(annualVacationDays));
             }
@@ -147,7 +148,7 @@ class AccountFormValidator implements Validator {
         if (remainingVacationDays != null) {
             validateFullOrHalfDay(remainingVacationDays, ATTRIBUTE_REMAINING_VACATION_DAYS, errors);
             if (isNegative(remainingVacationDays)) {
-                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, "error.entry.min", "0");
+                reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
             } else if (isGreater(remainingVacationDays, maxDays)) {
                 reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS, msg("remainingVacationDays.tooBig"), asIntString(maxDays));
             }
@@ -169,7 +170,7 @@ class AccountFormValidator implements Validator {
             } else {
                 validateFullOrHalfDay(remainingVacationDaysNotExpiring, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, errors);
                 if (isNegative(remainingVacationDaysNotExpiring)) {
-                    reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, "error.entry.min", "0");
+                    reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, ERROR_ENTRY_MIN, "0");
                 } else if (isGreater(remainingVacationDaysNotExpiring, remainingVacationDays)) {
                     reject(errors, ATTRIBUTE_REMAINING_VACATION_DAYS_NOT_EXPIRING, msg("remainingVacationDaysNotExpiring.tooBig"), asIntString(remainingVacationDays));
                 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.account;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -37,12 +38,12 @@ class AccountFormValidator implements Validator {
     }
 
     @Override
-    public boolean supports(Class<?> clazz) {
+    public boolean supports(@NonNull Class<?> clazz) {
         return AccountForm.class.equals(clazz);
     }
 
     @Override
-    public void validate(Object target, Errors errors) {
+    public void validate(@NonNull Object target, @NonNull Errors errors) {
 
         final BigDecimal maxAnnualVacationDays = getMaximumAnnualVacationDays();
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountFormValidator.java
@@ -113,8 +113,7 @@ class AccountFormValidator implements Validator {
 
             if (isNegative(annualVacationDays)) {
                 reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, ERROR_ENTRY_MIN, "0");
-            }
-            else if (isGreater(annualVacationDays, maxAnnualVacationDays)) {
+            } else if (isGreater(annualVacationDays, maxAnnualVacationDays)) {
                 reject(errors, ATTRIBUTE_ANNUAL_VACATION_DAYS, "error.entry.max", asIntString(maxAnnualVacationDays));
             }
         }

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -480,6 +480,7 @@ typeMismatch=Die Eingabe ist ungültig.
 error.entry.mandatory=Dies ist ein Pflichtfeld.
 error.entry.integer=Die Eingabe muss ganzzahlig sein.
 error.entry.fullOrHalfHour=Die Eingabe muss eine volle oder eine halbe Stunde sein.
+error.entry.fullOrHalfNumber=Die Eingabe muss eine ganze oder eine halbe Zahl sein.
 error.entry.tooManyChars=Die Eingabe enthält zu viele Zeichen.
 error.entry.invalid=Die Eingabe ist ungültig.
 error.entry.invalidPeriod=Der gewählte Zeitraum ist ungültig.

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -486,6 +486,9 @@ error.entry.invalid=Die Eingabe ist ungültig.
 error.entry.invalidPeriod=Der gewählte Zeitraum ist ungültig.
 error.entry.mail=Die angegebene E-Mail-Adresse muss ein gültiges Format haben. (z.B. max@mustermann.de)
 error.entry.commentTooLong=Der Kommentar darf nur 200 Zeichen lang sein.
+error.entry.max = muss kleiner gleich {0} sein.
+error.entry.min = muss größer gleich {0} sein.
+error.info.message=Die Änderungen konnten nicht übernommen werden. Bitte prüfe deine Eingaben.
 
 # PERSON LIST
 person.overview.header.title=Benutzerübersicht
@@ -564,6 +567,14 @@ person.form.annualVacation.remainingVacation=Resturlaub
 person.form.annualVacation.remainingVacation.notExpiring=Anteil des Resturlaubs, welcher nicht am 1. April verfällt
 person.form.annualVacation.comment=Kommentar zur Änderung des Urlaubsanspruchs
 person.form.annualVacation.comment.placeholder=Hier kann ein Kommentar eingegeben werden...
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidYear=muss im Jahr {0} liegen.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidYear=muss im Jahr {0} liegen.
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidRange=Der Zeitraum muss größer als ein Tag sein.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidRange=Der Zeitraum muss größer als ein Tag sein.
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidRangeReversed=muss vor dem "Bis" Datum sein.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed=muss nach dem "Von" Datum sein.
+person.form.annualVacation.error.remainingVacationDays.tooBig=muss kleiner gleich der maximalen Anzahl an Urlaubstagen von {0} Tagen sein.
+person.form.annualVacation.error.remainingVacationDaysNotExpiring.tooBig=muss kleiner gleich Resturlaub von {0} Tagen sein.
 
 # Working Times
 person.form.workingTime.header.title=Arbeitszeiten von {0}

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -574,7 +574,7 @@ person.form.annualVacation.error.holidaysAccountValidTo.invalidRange=Der Zeitrau
 person.form.annualVacation.error.holidaysAccountValidFrom.invalidRangeReversed=muss vor dem "Bis" Datum sein.
 person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed=muss nach dem "Von" Datum sein.
 person.form.annualVacation.error.remainingVacationDays.tooBig=muss kleiner gleich der maximalen Anzahl an Urlaubstagen von {0} Tagen sein.
-person.form.annualVacation.error.remainingVacationDaysNotExpiring.tooBig=muss kleiner gleich Resturlaub von {0} Tagen sein.
+person.form.annualVacation.error.remainingVacationDaysNotExpiring.tooBig=muss kleiner gleich des Resturlaubs von {0} Tagen sein.
 
 # Working Times
 person.form.workingTime.header.title=Arbeitszeiten von {0}

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -476,6 +476,7 @@ typeMismatch=Entry is invalid.
 error.entry.mandatory=Entry mandatory.
 error.entry.integer=Entry must be an integer.
 error.entry.fullOrHalfHour=Entry must be full or half an hour.
+error.entry.fullOrHalfNumber=Entry must be a full or a half number.
 error.entry.tooManyChars=The entry has too many characters.
 error.entry.invalid=Entry is invalid.
 error.entry.invalidPeriod=The selected period is invalid.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -482,6 +482,9 @@ error.entry.invalid=Entry is invalid.
 error.entry.invalidPeriod=The selected period is invalid.
 error.entry.mail=The specified email address must be in the correct format. (e.g. john@doe.de)
 error.entry.commentTooLong=The comment must not exceed 200 characters.
+error.entry.max = must be less than or equal to {0}
+error.entry.min = must be greater than or equal to {0}
+error.info.message=Changes could not be saved. Please check the errors below.
 
 # PERSON LIST
 person.overview.header.title=User overview
@@ -559,6 +562,16 @@ person.form.annualVacation.remainingVacation=Remaining vacation days
 person.form.annualVacation.remainingVacation.notExpiring=Share of remaining vacation days, not expiring on 1st of april
 person.form.annualVacation.comment=Comment on the change of vacation entitlement
 person.form.annualVacation.comment.placeholder=Here you can enter a comment...
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidYear=has to be in year {0}.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidYear=has to be in year {0}.
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidRange=Period must be greater than one day.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidRange=Period must be greater than one day.
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidRangeReversed=must be before Until.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed=must be after From.
+person.form.annualVacation.error.actualVacation.tooSmall=must be greater or equal to 0
+person.form.annualVacation.error.actualVacation.tooBig=must be lower or equal to 'Annual vacation entitlement'
+person.form.annualVacation.error.remainingVacationDays.tooBig=Must be lower or equal to the maximum number of holidays of {0} days.
+person.form.annualVacation.error.remainingVacationDaysNotExpiring.tooBig=Must be lower or equal to 'Remaining vacation days' of {0} days.
 
 # Working Times
 person.form.workingTime.header.title=Working hours of {0}

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -566,10 +566,10 @@ person.form.annualVacation.error.holidaysAccountValidFrom.invalidYear=has to be 
 person.form.annualVacation.error.holidaysAccountValidTo.invalidYear=has to be in year {0}.
 person.form.annualVacation.error.holidaysAccountValidFrom.invalidRange=Period must be greater than one day.
 person.form.annualVacation.error.holidaysAccountValidTo.invalidRange=Period must be greater than one day.
-person.form.annualVacation.error.holidaysAccountValidFrom.invalidRangeReversed=must be before Until.
-person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed=must be after From.
-person.form.annualVacation.error.actualVacation.tooSmall=must be greater or equal to 0
-person.form.annualVacation.error.actualVacation.tooBig=must be lower or equal to 'Annual vacation entitlement'
+person.form.annualVacation.error.holidaysAccountValidFrom.invalidRangeReversed=must be before 'Until'.
+person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed=must be after 'From'.
+person.form.annualVacation.error.actualVacation.tooSmall=must be greater or equal to 0.
+person.form.annualVacation.error.actualVacation.tooBig=must be lower or equal to 'Annual vacation entitlement'.
 person.form.annualVacation.error.remainingVacationDays.tooBig=Must be lower or equal to the maximum number of holidays of {0} days.
 person.form.annualVacation.error.remainingVacationDaysNotExpiring.tooBig=Must be lower or equal to 'Remaining vacation days' of {0} days.
 

--- a/src/main/webapp/WEB-INF/jsp/account/account_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/account/account_form.jsp
@@ -66,7 +66,7 @@
                     <div class="row tw-mb-8">
                         <div class="col-xs-12">
                             <div class="alert alert-danger tw-text-red-800">
-                                <form:errors />
+                                <spring:message code="error.info.message"/>
                             </div>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/jsp/account/account_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/account/account_form.jsp
@@ -65,7 +65,7 @@
                 <spring:hasBindErrors name="account">
                     <div class="row tw-mb-8">
                         <div class="col-xs-12">
-                            <div class="alert alert-danger tw-text-red-800">
+                            <div class="alert alert-danger tw-text-red-800 tw-text-sm">
                                 <spring:message code="error.info.message"/>
                             </div>
                         </div>

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
@@ -114,7 +114,7 @@ class AccountFormValidatorTest {
         form.setActualVacationDays(BigDecimal.valueOf(10.1));
 
         sut.validateActualVacation(form, errors);
-        verify(errors).rejectValue("actualVacationDays", "error.entry.fullOrHalfHour");
+        verify(errors).rejectValue("actualVacationDays", "error.entry.fullOrHalfNumber");
     }
 
     @Test
@@ -163,7 +163,7 @@ class AccountFormValidatorTest {
         form.setRemainingVacationDaysNotExpiring(new BigDecimal(11));
 
         sut.validateRemainingVacationDays(form, errors, BigDecimal.valueOf(40));
-        verify(errors).rejectValue("remainingVacationDays", "error.entry.fullOrHalfHour");
+        verify(errors).rejectValue("remainingVacationDays", "error.entry.fullOrHalfNumber");
     }
 
     @Test
@@ -173,7 +173,7 @@ class AccountFormValidatorTest {
         form.setRemainingVacationDaysNotExpiring(new BigDecimal(10.3));
 
         sut.validateRemainingVacationDays(form, errors, BigDecimal.valueOf(40));
-        verify(errors).rejectValue("remainingVacationDaysNotExpiring", "error.entry.fullOrHalfHour");
+        verify(errors).rejectValue("remainingVacationDaysNotExpiring", "error.entry.fullOrHalfNumber");
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
@@ -220,6 +220,16 @@ class AccountFormValidatorTest {
     }
 
     @Test
+    void ensureRemainingVacationDaysNotExpiringMustNotBeNullEvenIfVacationDaysAreNotNull() {
+        final AccountForm form = new AccountForm(2013);
+        form.setRemainingVacationDays(BigDecimal.valueOf(10));
+        form.setRemainingVacationDaysNotExpiring(null);
+
+        sut.validateRemainingVacationDaysNotExpiring(form, errors);
+        verify(errors).rejectValue("remainingVacationDaysNotExpiring", "error.entry.mandatory");
+    }
+
+    @Test
     void ensureRemainingVacationDaysNotExpiringMustBeFullOrHalf() {
         final AccountForm form = new AccountForm(2013);
         form.setRemainingVacationDays(new BigDecimal(10));
@@ -343,6 +353,15 @@ class AccountFormValidatorTest {
     void ensureCommentHasNoValidationError() {
         final AccountForm form = new AccountForm(2017);
         form.setComment("blabla");
+
+        sut.validateComment(form, errors);
+        verifyNoInteractions(errors);
+    }
+
+    @Test
+    void ensureCommentWithNullHasNoValidationError() {
+        final AccountForm form = new AccountForm(2017);
+        form.setComment(null);
 
         sut.validateComment(form, errors);
         verifyNoInteractions(errors);


### PR DESCRIPTION
Dieser Pull Request führt sprechendere Fehler Hinweise beim bearbeiten des Urlaubsanspruches hinzu.  
Statt "falsche Eingabe" wird jetzt gesagt, dass z. B. ein Wert kleiner gleich 42 sein muss.

closes #2293