### PR TITLE
Upgrade logback to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <java.version>11</java.version>
     <testcontainers.version>1.16.2</testcontainers.version>
+    <!-- Remove on next Spring Boot Upgrade 2.5.8 -->
+    <logback.version>1.2.8</logback.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Die Urlaubsverwaltung ist von LOGBACK-1591 nicht betroffen. Wir wollen aber auch diesen Vektor schließen und direkt eine neue Version bereitstellen in 4.27.3.

http://logback.qos.ch/news.html

```
14th of December, 2021, Release of version 1.2.8

We note that the vulnerability mentioned in LOGBACK-1591 requires write access to logback's configuration file as a prerequisite.

• In response to LOGBACK-1591, we have disabled all JNDI lookup code in logback until further notice. This impacts ContextJNDISelector and <insertFromJNDI> element in configuration files.

• Also in response to LOGBACK-1591, we have removed all database (JDBC) related code in the project with no replacement.

We note that the vulnerability mentioned in LOGBACK-1591 requires write access to logback's configuration file as a prerequisite. A successul RCE requires all of the following to be true:

    write access to logback.xml
    use of versions < 1.2.8
    reloading of poisoned configuration data, which implies application restart or scan="true" set prior to attack

As an additional extra precaution, in addition to upgrading to logback version 1.2.8, we also recommend users to set their logback configuration files as read-only.
```

Further Information:
* https://github.com/cn-panda/logbackRceDemo
* https://jira.qos.ch/browse/LOGBACK-1591