### PR TITLE
Cleanup public holiday and provide a unified interface

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImpl.java
@@ -8,6 +8,7 @@ import org.synyx.urlaubsverwaltung.application.application.ApplicationStatus;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNote;
@@ -279,8 +280,8 @@ public class AbsenceServiceImpl implements AbsenceService {
 
         return new AbsencePeriod.Record(tuple.date, person, morning, noon);
     }
-    private DayLength publicHolidayAbsence(LocalDate date, List<WorkingTime> workingTimeList,
-                                           FederalState federalStateDefault) {
+
+    private DayLength publicHolidayAbsence(LocalDate date, List<WorkingTime> workingTimeList, FederalState federalStateDefault) {
 
         final FederalState federalState = workingTime(date, workingTimeList)
             .or(() -> workingTimeList.isEmpty()
@@ -290,7 +291,8 @@ public class AbsenceServiceImpl implements AbsenceService {
             .map(WorkingTime::getFederalState)
             .orElse(federalStateDefault);
 
-        return publicHolidaysService.getAbsenceTypeOfDate(date, federalState);
+        final Optional<PublicHoliday> maybePublicHoliday = publicHolidaysService.getPublicHoliday(date, federalState);
+        return maybePublicHoliday.isPresent() ? maybePublicHoliday.get().getDayLength() : DayLength.ZERO;
     }
 
     private static Optional<WorkingTime> workingTime(LocalDate validFrom, List<WorkingTime> workingTimeList) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -342,14 +342,15 @@ public class AbsenceOverviewViewController {
     }
 
     private AbsenceOverviewMonthDayDto tableHeadDay(LocalDate date, FederalState defaultFederalState, LocalDate today) {
-        final String tableHeadDayText = String.format("%02d", date.getDayOfMonth());
-        final DayLength publicHolidayDayLength = publicHolidaysService.getAbsenceTypeOfDate(date, defaultFederalState);
+        final Optional<PublicHoliday> maybePublicHoliday = publicHolidaysService.getPublicHoliday(date, defaultFederalState);
+        final DayLength publicHolidayDayLength = maybePublicHoliday.isPresent() ? maybePublicHoliday.get().getDayLength() : DayLength.ZERO;
 
         AbsenceOverviewDayType publicHolidayType = null;
         if (DayLength.ZERO.compareTo(publicHolidayDayLength) != 0) {
             publicHolidayType = getPublicHolidayType(publicHolidayDayLength).build();
         }
 
+        final String tableHeadDayText = String.format("%02d", date.getDayOfMonth());
         final boolean isToday = date.isEqual(today);
 
         return new AbsenceOverviewMonthDayDto(publicHolidayType, tableHeadDayText, isWeekend(date), isToday);

--- a/src/main/java/org/synyx/urlaubsverwaltung/period/DayLength.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/period/DayLength.java
@@ -38,7 +38,9 @@ public enum DayLength {
                 return FULL;
         }
 
-        return null;
+        // this is not relevant, because every case is defined in the switch case, this will be nicer to read and withour
+        // this last return case in java 17
+        return ZERO;
     }
 
     public boolean isHalfDay() { return isHalfDay; }

--- a/src/main/java/org/synyx/urlaubsverwaltung/period/DayLength.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/period/DayLength.java
@@ -38,8 +38,8 @@ public enum DayLength {
                 return FULL;
         }
 
-        // this is not relevant, because every case is defined in the switch case, this will be nicer to read and withour
-        // this last return case in java 17
+        // this is not relevant, because every case is defined in the switch case, this will be nicer to read and
+        // without this last return case in java 17
         return ZERO;
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
@@ -20,11 +20,7 @@ public final class PublicHoliday {
     private final DayLength dayLength;
     private final String description;
 
-    public PublicHoliday(LocalDate date, DayLength dayLength) {
-        this(date, dayLength, null);
-    }
-
-    PublicHoliday(LocalDate date, DayLength dayLength, String description) {
+    public PublicHoliday(LocalDate date, DayLength dayLength, String description) {
         this.date = date;
         this.dayLength = dayLength;
         this.description = description;

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
@@ -13,10 +13,16 @@ public final class PublicHoliday {
 
     private final LocalDate date;
     private final DayLength dayLength;
+    private final String description;
 
     public PublicHoliday(LocalDate date, DayLength dayLength) {
+        this(date, dayLength, null);
+    }
+
+    PublicHoliday(LocalDate date, DayLength dayLength, String description) {
         this.date = date;
         this.dayLength = dayLength;
+        this.description = description;
     }
 
     public LocalDate getDate() {
@@ -25,6 +31,10 @@ public final class PublicHoliday {
 
     public DayLength getDayLength() {
         return dayLength;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public boolean isMorning() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHoliday.java
@@ -2,8 +2,13 @@ package org.synyx.urlaubsverwaltung.publicholiday;
 
 import org.synyx.urlaubsverwaltung.period.DayLength;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
+
+import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
+import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
+import static org.synyx.urlaubsverwaltung.period.DayLength.NOON;
 
 /**
  * Describes a public holiday with the UV specific setting if it is a half public holiday or not.
@@ -38,15 +43,19 @@ public final class PublicHoliday {
     }
 
     public boolean isMorning() {
-        return dayLength.equals(DayLength.MORNING);
+        return dayLength.equals(MORNING);
     }
 
     public boolean isNoon() {
-        return dayLength.equals(DayLength.NOON);
+        return dayLength.equals(NOON);
     }
 
     public boolean isFull() {
-        return dayLength.equals(DayLength.FULL);
+        return dayLength.equals(FULL);
+    }
+
+    public BigDecimal getWorkingDuration() {
+        return dayLength.getInverse().getDuration();
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
@@ -14,14 +14,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.synyx.urlaubsverwaltung.api.RestControllerAdviceMarker;
-import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -115,7 +113,7 @@ public class PublicHolidayApiController {
 
     private List<PublicHolidayDto> getPublicHolidays(LocalDate startDate, LocalDate endDate, FederalState federalState) {
         return publicHolidaysService.getPublicHolidays(startDate, endDate, federalState).stream()
-            .map(publicHoliday -> this.mapPublicHolidayToDto(publicHoliday, federalState))
+            .map(this::mapPublicHolidayToDto)
             .collect(toList());
     }
 
@@ -125,9 +123,7 @@ public class PublicHolidayApiController {
         }
     }
 
-    private PublicHolidayDto mapPublicHolidayToDto(PublicHoliday publicHoliday, FederalState federalState) {
-        final BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(publicHoliday.getDate(), federalState);
-        final DayLength absenceType = publicHolidaysService.getAbsenceTypeOfDate(publicHoliday.getDate(), federalState);
-        return new PublicHolidayDto(publicHoliday, workingDuration, absenceType.name());
+    private PublicHolidayDto mapPublicHolidayToDto(PublicHoliday publicHoliday) {
+        return new PublicHolidayDto(publicHoliday, publicHoliday.getDayLength().getDuration(), publicHoliday.getDayLength().name());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
-import de.jollyday.Holiday;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -115,8 +114,8 @@ public class PublicHolidayApiController {
     }
 
     private List<PublicHolidayDto> getPublicHolidays(LocalDate startDate, LocalDate endDate, FederalState federalState) {
-        return publicHolidaysService.getHolidays(startDate, endDate, federalState).stream()
-            .map(holiday -> this.mapPublicHolidayToDto(holiday, federalState))
+        return publicHolidaysService.getPublicHolidays(startDate, endDate, federalState).stream()
+            .map(publicHoliday -> this.mapPublicHolidayToDto(publicHoliday, federalState))
             .collect(toList());
     }
 
@@ -126,9 +125,9 @@ public class PublicHolidayApiController {
         }
     }
 
-    private PublicHolidayDto mapPublicHolidayToDto(Holiday holiday, FederalState federalState) {
-        final BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(holiday.getDate(), federalState);
-        final DayLength absenceType = publicHolidaysService.getAbsenceTypeOfDate(holiday.getDate(), federalState);
-        return new PublicHolidayDto(holiday, workingDuration, absenceType.name());
+    private PublicHolidayDto mapPublicHolidayToDto(PublicHoliday publicHoliday, FederalState federalState) {
+        final BigDecimal workingDuration = publicHolidaysService.getWorkingDurationOfDate(publicHoliday.getDate(), federalState);
+        final DayLength absenceType = publicHolidaysService.getAbsenceTypeOfDate(publicHoliday.getDate(), federalState);
+        return new PublicHolidayDto(publicHoliday, workingDuration, absenceType.name());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
@@ -1,24 +1,22 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
 import de.jollyday.HolidayManager;
-import de.jollyday.ManagerParameter;
-import de.jollyday.ManagerParameters;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.net.URL;
 
+import static de.jollyday.ManagerParameters.create;
+
 @Configuration
-public class PublicHolidayConfiguration {
+class PublicHolidayConfiguration {
 
     private static final String HOLIDAY_DEFINITION_FILE = "Holidays_de.xml";
 
     @Bean
-    public HolidayManager getHolidayManager() {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        URL url = cl.getResource(HOLIDAY_DEFINITION_FILE);
-        ManagerParameter managerParameter = ManagerParameters.create(url);
-
-        return HolidayManager.getInstance(managerParameter);
+    HolidayManager getHolidayManager() {
+        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        final URL url = cl.getResource(HOLIDAY_DEFINITION_FILE);
+        return HolidayManager.getInstance(create(url));
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayDto.java
@@ -1,9 +1,6 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
-import de.jollyday.Holiday;
-
 import java.math.BigDecimal;
-import java.util.Locale;
 
 final class PublicHolidayDto {
 
@@ -12,9 +9,9 @@ final class PublicHolidayDto {
     private final BigDecimal dayLength;
     private final String absencePeriodName;
 
-    PublicHolidayDto(Holiday holiday, BigDecimal dayLength, String absencePeriodName) {
-        this.date = holiday.getDate().toString();
-        this.description = holiday.getDescription(Locale.GERMAN);
+    PublicHolidayDto(PublicHoliday publicHoliday, BigDecimal dayLength, String absencePeriodName) {
+        this.date = publicHoliday.getDate().toString();
+        this.description = publicHoliday.getDescription();
         this.dayLength = dayLength;
         this.absencePeriodName = absencePeriodName;
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
@@ -3,6 +3,7 @@ package org.synyx.urlaubsverwaltung.publicholiday;
 import de.jollyday.Holiday;
 import de.jollyday.HolidayManager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
@@ -12,6 +13,8 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
@@ -48,15 +51,12 @@ public class PublicHolidaysService {
         return getHolidayDayLength(getWorkingTimeSettings(), date, federalState);
     }
 
-    public List<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
-        return List.copyOf(manager.getHolidays(from, to, federalState.getCodes()));
-    }
-
     public List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState) {
         final WorkingTimeSettings workingTimeSettings = getWorkingTimeSettings();
+        final Locale locale = LocaleContextHolder.getLocale();
 
         return getHolidays(from, to, federalState).stream()
-            .map(holiday -> new PublicHoliday(holiday.getDate(), getHolidayDayLength(workingTimeSettings, holiday.getDate(), federalState)))
+            .map(holiday -> new PublicHoliday(holiday.getDate(), getHolidayDayLength(workingTimeSettings, holiday.getDate(), federalState), holiday.getDescription(locale)))
             .collect(toUnmodifiableList());
     }
 
@@ -73,6 +73,10 @@ public class PublicHolidaysService {
         }
 
         return workingTime.getInverse();
+    }
+
+    private Set<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
+        return manager.getHolidays(from, to, federalState.getCodes());
     }
 
     private boolean isPublicHoliday(LocalDate date, FederalState federalState) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
@@ -1,38 +1,12 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
-import de.jollyday.Holiday;
-import de.jollyday.HolidayManager;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.stereotype.Component;
-import org.synyx.urlaubsverwaltung.period.DayLength;
-import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
-import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
-import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
-import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
-import static org.synyx.urlaubsverwaltung.util.DateUtil.isChristmasEve;
-import static org.synyx.urlaubsverwaltung.util.DateUtil.isNewYearsEve;
-
-@Component
-public class PublicHolidaysService {
-
-    private final HolidayManager manager;
-    private final SettingsService settingsService;
-
-    @Autowired
-    public PublicHolidaysService(SettingsService settingsService, HolidayManager holidayManager) {
-        this.settingsService = settingsService;
-        this.manager = holidayManager;
-    }
+public interface PublicHolidaysService {
 
     /**
      * Returns the public holiday information for a date and the federal state.
@@ -43,9 +17,7 @@ public class PublicHolidaysService {
      * @param federalState the federal state to consider holiday settings for
      * @return the public holiday if there is one at the given date, otherwise empty optional
      */
-    public Optional<PublicHoliday> getPublicHoliday(LocalDate date, FederalState federalState) {
-        return getPublicHolidays(date, date, federalState).stream().findFirst();
-    }
+    Optional<PublicHoliday> getPublicHoliday(LocalDate date, FederalState federalState);
 
     /**
      * Returns a list of public holiday information for the given date range (inclusive from and to) and the federal state.
@@ -57,39 +29,5 @@ public class PublicHolidaysService {
      * @param federalState the federal state to consider holiday settings for
      * @return a list of public holiday if there are any for the given date range, otherwise empty list
      */
-    public List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState) {
-        final WorkingTimeSettings workingTimeSettings = getWorkingTimeSettings();
-        final Locale locale = LocaleContextHolder.getLocale();
-
-        return getHolidays(from, to, federalState).stream()
-            .map(holiday -> new PublicHoliday(holiday.getDate(), getHolidayDayLength(workingTimeSettings, holiday.getDate(), federalState), holiday.getDescription(locale)))
-            .collect(toUnmodifiableList());
-    }
-
-    private DayLength getHolidayDayLength(WorkingTimeSettings workingTimeSettings, LocalDate date, FederalState federalState) {
-        DayLength workingTime = FULL;
-        if (isPublicHoliday(date, federalState)) {
-            if (isChristmasEve(date)) {
-                workingTime = workingTimeSettings.getWorkingDurationForChristmasEve();
-            } else if (isNewYearsEve(date)) {
-                workingTime = workingTimeSettings.getWorkingDurationForNewYearsEve();
-            } else {
-                workingTime = ZERO;
-            }
-        }
-
-        return workingTime.getInverse();
-    }
-
-    private Set<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
-        return manager.getHolidays(from, to, federalState.getCodes());
-    }
-
-    private boolean isPublicHoliday(LocalDate date, FederalState federalState) {
-        return manager.isHoliday(date, federalState.getCodes());
-    }
-
-    private WorkingTimeSettings getWorkingTimeSettings() {
-        return settingsService.getSettings().getWorkingTimeSettings();
-    }
+    List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState);
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
@@ -10,10 +10,10 @@ import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -35,22 +35,28 @@ public class PublicHolidaysService {
     }
 
     /**
-     * Returns the working duration for a date: may be full day (1.0) for a non public holiday or zero (0.0) for a
-     * public holiday. The working duration for Christmas Eve and New Year's Eve are configured in the business
-     * properties; normally the working duration for these holidays is a half day (0.5)
+     * Returns the public holiday information for a date and the federal state.
+     * If there is no public holiday at the given date the return value is an empty optional, otherwise
+     * the public holiday will be returned.
      *
-     * @param date         to get working duration for
+     * @param date         to get public holiday for
      * @param federalState the federal state to consider holiday settings for
-     * @return working duration of the given date
+     * @return the public holiday if there is one at the given date, otherwise empty optional
      */
-    public BigDecimal getWorkingDurationOfDate(LocalDate date, FederalState federalState) {
-        return getAbsenceTypeOfDate(date, federalState).getInverse().getDuration();
+    public Optional<PublicHoliday> getPublicHoliday(LocalDate date, FederalState federalState) {
+        return getPublicHolidays(date, date, federalState).stream().findFirst();
     }
 
-    public DayLength getAbsenceTypeOfDate(LocalDate date, FederalState federalState) {
-        return getHolidayDayLength(getWorkingTimeSettings(), date, federalState);
-    }
-
+    /**
+     * Returns a list of public holiday information for the given date range (inclusive from and to) and the federal state.
+     * If there is no public holiday at the given date range the return value is an empty list, otherwise
+     * the public holidays will be returned.
+     *
+     * @param from         to get public holiday from
+     * @param to           to get public holiday to
+     * @param federalState the federal state to consider holiday settings for
+     * @return a list of public holiday if there are any for the given date range, otherwise empty list
+     */
     public List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState) {
         final WorkingTimeSettings workingTimeSettings = getWorkingTimeSettings();
         final Locale locale = LocaleContextHolder.getLocale();

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
@@ -5,7 +5,6 @@ import de.jollyday.HolidayManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.period.DayLength;
-import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
@@ -46,11 +45,7 @@ public class PublicHolidaysService {
     }
 
     public DayLength getAbsenceTypeOfDate(LocalDate date, FederalState federalState) {
-
-        final Settings settings = settingsService.getSettings();
-        final WorkingTimeSettings workingTimeSettings = settings.getWorkingTimeSettings();
-
-        return getHolidayDayLength(workingTimeSettings, date, federalState);
+        return getHolidayDayLength(getWorkingTimeSettings(), date, federalState);
     }
 
     public List<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
@@ -58,8 +53,7 @@ public class PublicHolidaysService {
     }
 
     public List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState) {
-        final Settings settings = settingsService.getSettings();
-        final WorkingTimeSettings workingTimeSettings = settings.getWorkingTimeSettings();
+        final WorkingTimeSettings workingTimeSettings = getWorkingTimeSettings();
 
         return getHolidays(from, to, federalState).stream()
             .map(holiday -> new PublicHoliday(holiday.getDate(), getHolidayDayLength(workingTimeSettings, holiday.getDate(), federalState)))
@@ -83,5 +77,9 @@ public class PublicHolidaysService {
 
     private boolean isPublicHoliday(LocalDate date, FederalState federalState) {
         return manager.isHoliday(date, federalState.getCodes());
+    }
+
+    private WorkingTimeSettings getWorkingTimeSettings() {
+        return settingsService.getSettings().getWorkingTimeSettings();
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
@@ -1,0 +1,78 @@
+package org.synyx.urlaubsverwaltung.publicholiday;
+
+import de.jollyday.Holiday;
+import de.jollyday.HolidayManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Service;
+import org.synyx.urlaubsverwaltung.period.DayLength;
+import org.synyx.urlaubsverwaltung.settings.SettingsService;
+import org.synyx.urlaubsverwaltung.workingtime.FederalState;
+import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
+import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
+import static org.synyx.urlaubsverwaltung.util.DateUtil.isChristmasEve;
+import static org.synyx.urlaubsverwaltung.util.DateUtil.isNewYearsEve;
+
+@Service
+public class PublicHolidaysServiceImpl implements PublicHolidaysService {
+
+    private final HolidayManager manager;
+    private final SettingsService settingsService;
+
+    @Autowired
+    public PublicHolidaysServiceImpl(SettingsService settingsService, HolidayManager holidayManager) {
+        this.settingsService = settingsService;
+        this.manager = holidayManager;
+    }
+
+    @Override
+    public Optional<PublicHoliday> getPublicHoliday(LocalDate date, FederalState federalState) {
+        return getPublicHolidays(date, date, federalState).stream().findFirst();
+    }
+
+    @Override
+    public List<PublicHoliday> getPublicHolidays(LocalDate from, LocalDate to, FederalState federalState) {
+        final WorkingTimeSettings workingTimeSettings = getWorkingTimeSettings();
+        final Locale locale = LocaleContextHolder.getLocale();
+
+        return getHolidays(from, to, federalState).stream()
+            .map(holiday -> new PublicHoliday(holiday.getDate(), getHolidayDayLength(workingTimeSettings, holiday.getDate(), federalState), holiday.getDescription(locale)))
+            .collect(toUnmodifiableList());
+    }
+
+    private DayLength getHolidayDayLength(WorkingTimeSettings workingTimeSettings, LocalDate date, FederalState federalState) {
+        DayLength workingTime = FULL;
+        if (isPublicHoliday(date, federalState)) {
+            if (isChristmasEve(date)) {
+                workingTime = workingTimeSettings.getWorkingDurationForChristmasEve();
+            } else if (isNewYearsEve(date)) {
+                workingTime = workingTimeSettings.getWorkingDurationForNewYearsEve();
+            } else {
+                workingTime = ZERO;
+            }
+        }
+
+        return workingTime.getInverse();
+    }
+
+    private Set<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
+        return manager.getHolidays(from, to, federalState.getCodes());
+    }
+
+    private boolean isPublicHoliday(LocalDate date, FederalState federalState) {
+        return manager.isHoliday(date, federalState.getCodes());
+    }
+
+    private WorkingTimeSettings getWorkingTimeSettings() {
+        return settingsService.getSettings().getWorkingTimeSettings();
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewService.java
@@ -7,6 +7,7 @@ import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.api.PersonMapper;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.util.DateUtil;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
@@ -17,9 +18,11 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.synyx.urlaubsverwaltung.statistics.vacationoverview.api.DayOfMonth.TypeOfDay.WEEKEND;
 import static org.synyx.urlaubsverwaltung.statistics.vacationoverview.api.DayOfMonth.TypeOfDay.WORKDAY;
+import static org.synyx.urlaubsverwaltung.util.DateUtil.isWorkDay;
 
 /**
  * @deprecated This service purpose was to provide information for the client side rendered vacation overview which is obsolete now.
@@ -83,10 +86,9 @@ public class VacationOverviewService {
     private DayOfMonth.TypeOfDay getTypeOfDay(Person person, LocalDate currentDay) {
         DayOfMonth.TypeOfDay typeOfDay;
 
-        FederalState state = workingTimeService.getFederalStateForPerson(person, currentDay);
-        if (DateUtil.isWorkDay(currentDay)
-            && (publicHolidayService.getWorkingDurationOfDate(currentDay, state).longValue() > 0)) {
-
+        final FederalState state = workingTimeService.getFederalStateForPerson(person, currentDay);
+        final Optional<PublicHoliday> maybePublicHoliday = publicHolidayService.getPublicHoliday(currentDay, state);
+        if (isWorkDay(currentDay) && (maybePublicHoliday.isPresent() && maybePublicHoliday.get().getWorkingDuration().longValue() > 0)) {
             typeOfDay = WORKDAY;
         } else {
             typeOfDay = WEEKEND;

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.util.DateUtil;
 
@@ -94,11 +95,12 @@ public class WorkDaysCountService {
         LocalDate day = startDate;
         while (!day.isAfter(endDate)) {
             // value may be 1 for public holiday, 0 for not public holiday or 0.5 for Christmas Eve or New Year's Eve
-            BigDecimal duration = publicHolidaysService.getWorkingDurationOfDate(day, federalState);
+            final Optional<PublicHoliday> maybePublicHoliday = publicHolidaysService.getPublicHoliday(day, federalState);
+            final BigDecimal duration = maybePublicHoliday.isPresent() ? maybePublicHoliday.get().getWorkingDuration() : BigDecimal.ONE;
 
-            BigDecimal workingDuration = workingTime.getDayLengthForWeekDay(day.getDayOfWeek()).getDuration();
+            final BigDecimal workingDuration = workingTime.getDayLengthForWeekDay(day.getDayOfWeek()).getDuration();
 
-            BigDecimal result = duration.multiply(workingDuration);
+            final BigDecimal result = duration.multiply(workingDuration);
 
             vacationDays = vacationDays.add(result);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerTest.java
@@ -339,7 +339,7 @@ class AbsenceApiControllerTest {
         when(absenceService.getOpenAbsences(person, startDate, endDate)).thenReturn(List.of(absencePeriod));
 
         final LocalDate date = LocalDate.of(2016, Month.DECEMBER, 24);
-        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON);
+        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON, "");
 
         when(publicHolidaysService.getPublicHolidays(startDate, endDate, FederalState.BADEN_WUERTTEMBERG))
             .thenReturn(List.of(christmasEve));
@@ -376,7 +376,7 @@ class AbsenceApiControllerTest {
         when(absenceService.getOpenAbsences(person, startDate, endDate)).thenReturn(List.of(absencePeriod));
 
         final LocalDate date = LocalDate.of(2016, Month.DECEMBER, 24);
-        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON);
+        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON, "");
 
         when(publicHolidaysService.getPublicHolidays(startDate, endDate, FederalState.BADEN_WUERTTEMBERG))
             .thenReturn(List.of(christmasEve));
@@ -415,7 +415,7 @@ class AbsenceApiControllerTest {
         when(absenceService.getOpenAbsences(person, startDate, endDate)).thenReturn(List.of(absencePeriod));
 
         final LocalDate date = LocalDate.of(2016, Month.DECEMBER, 24);
-        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON);
+        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON, "");
 
         when(publicHolidaysService.getPublicHolidays(startDate, endDate, FederalState.BADEN_WUERTTEMBERG))
             .thenReturn(List.of(christmasEve));
@@ -452,7 +452,7 @@ class AbsenceApiControllerTest {
         when(absenceService.getOpenAbsences(person, startDate, endDate)).thenReturn(List.of(absencePeriod));
 
         final LocalDate date = LocalDate.of(2016, Month.DECEMBER, 24);
-        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON);
+        final PublicHoliday christmasEve = new PublicHoliday(date, DayLength.NOON, "");
 
         when(publicHolidaysService.getPublicHolidays(startDate, endDate, FederalState.BADEN_WUERTTEMBERG))
             .thenReturn(List.of(christmasEve));

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
@@ -209,7 +209,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         sut.getOpenAbsences(List.of(person), start, end);
 
@@ -243,7 +243,7 @@ class AbsenceServiceImplTest {
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
 
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -278,7 +278,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -311,7 +311,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -342,7 +342,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), eq(BADEN_WUERTTEMBERG))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BADEN_WUERTTEMBERG))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -373,7 +373,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(DayLength.MORNING);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -406,7 +406,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(DayLength.NOON);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -430,7 +430,7 @@ class AbsenceServiceImplTest {
 
         when(workingTimeService.getByPersons(any())).thenReturn(emptyList());
         when(workingTimeService.getSystemDefaultFederalState()).thenReturn(BERLIN);
-        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final SickNote sickNote = new SickNote();
         sickNote.setId(42);
@@ -476,7 +476,7 @@ class AbsenceServiceImplTest {
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
 
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(2);
@@ -519,7 +519,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -552,7 +552,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(FULL);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -587,8 +587,8 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
-        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, MAY, 20)), any())).thenReturn(Optional.of(new PublicHoliday(start, FULL)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, MAY, 20)), any())).thenReturn(Optional.of(new PublicHoliday(start, FULL, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -639,8 +639,8 @@ class AbsenceServiceImplTest {
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
 
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
-        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.NOON)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.NOON, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -694,8 +694,8 @@ class AbsenceServiceImplTest {
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
 
-        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
-        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.MORNING)));
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO, "")));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.MORNING, "")));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
@@ -9,6 +9,7 @@ import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
@@ -20,6 +21,7 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static java.time.DayOfWeek.FRIDAY;
@@ -207,13 +209,14 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         sut.getOpenAbsences(List.of(person), start, end);
 
-        verify(publicHolidaysService).getAbsenceTypeOfDate(LocalDate.of(2021, MAY, 10), BADEN_WUERTTEMBERG);
-        verify(publicHolidaysService).getAbsenceTypeOfDate(LocalDate.of(2021, MAY, 11), BADEN_WUERTTEMBERG);
-        verify(publicHolidaysService).getAbsenceTypeOfDate(LocalDate.of(2021, MAY, 12), BADEN_WUERTTEMBERG);
+        verify(publicHolidaysService).getPublicHoliday(LocalDate.of(2021, MAY, 10), BADEN_WUERTTEMBERG);
+        verify(publicHolidaysService).getPublicHoliday(LocalDate.of(2021, MAY, 11), BADEN_WUERTTEMBERG);
+        verify(publicHolidaysService).getPublicHoliday(LocalDate.of(2021, MAY, 12), BADEN_WUERTTEMBERG);
+
         verifyNoMoreInteractions(publicHolidaysService);
     }
 
@@ -239,7 +242,8 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -274,7 +278,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -307,7 +311,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), eq(BERLIN))).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -338,7 +342,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), eq(BADEN_WUERTTEMBERG))).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BADEN_WUERTTEMBERG))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -369,7 +373,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(DayLength.MORNING);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -402,7 +406,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(DayLength.NOON);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(1);
@@ -426,7 +430,7 @@ class AbsenceServiceImplTest {
 
         when(workingTimeService.getByPersons(any())).thenReturn(emptyList());
         when(workingTimeService.getSystemDefaultFederalState()).thenReturn(BERLIN);
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), eq(BERLIN))).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), eq(BERLIN))).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final SickNote sickNote = new SickNote();
         sickNote.setId(42);
@@ -472,7 +476,7 @@ class AbsenceServiceImplTest {
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
 
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
         assertThat(actualAbsences).hasSize(2);
@@ -515,7 +519,7 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -548,7 +552,7 @@ class AbsenceServiceImplTest {
         sickNote.setDayLength(FULL);
 
         when(sickNoteService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(sickNote));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -583,8 +587,8 @@ class AbsenceServiceImplTest {
         application.setStatus(ALLOWED);
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-        when(publicHolidaysService.getAbsenceTypeOfDate(eq(LocalDate.of(2021, MAY, 20)), any())).thenReturn(FULL);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, MAY, 20)), any())).thenReturn(Optional.of(new PublicHoliday(start, FULL)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -635,8 +639,8 @@ class AbsenceServiceImplTest {
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
 
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-        when(publicHolidaysService.getAbsenceTypeOfDate(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(DayLength.NOON);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.NOON)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 
@@ -690,8 +694,8 @@ class AbsenceServiceImplTest {
 
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(application));
 
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-        when(publicHolidaysService.getAbsenceTypeOfDate(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(DayLength.MORNING);
+        when(publicHolidaysService.getPublicHoliday(any(), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(eq(LocalDate.of(2021, DECEMBER, 24)), any())).thenReturn(Optional.of(new PublicHoliday(start, DayLength.MORNING)));
 
         final List<AbsencePeriod> actualAbsences = sut.getOpenAbsences(List.of(batman), start, end);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
@@ -1,7 +1,4 @@
-package org.synyx.urlaubsverwaltung.absence.web;
-
-
-import org.junit.jupiter.api.BeforeEach;
+package org.synyx.urlaubsverwaltung.absence.web;import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,7 +17,6 @@ import org.synyx.urlaubsverwaltung.absence.AbsenceService;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
-import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.person.Role;
@@ -28,14 +24,12 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
-import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.Month;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
@@ -49,7 +43,6 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
@@ -107,9 +100,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setFirstName("sam");
@@ -140,9 +130,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setPermissions(List.of(role));
         person.setFirstName("boss");
@@ -171,9 +158,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER, role));
@@ -208,9 +192,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final Person person = new Person();
         person.setFirstName("firstname");
         person.setLastName("lastname");
@@ -239,9 +220,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -268,9 +246,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -297,9 +272,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -329,9 +301,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var expectedCurrentYear = LocalDate.now().getYear();
 
         final var person = new Person();
@@ -355,9 +324,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var expectedCurrentYear = LocalDate.now().getYear();
         final var expectedSelectedYear = expectedCurrentYear - 1;
 
@@ -386,9 +352,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var now = LocalDate.now();
 
         final var person = new Person();
@@ -412,9 +375,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -437,18 +397,12 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
         person.setEmail("boss@example.org");
         person.setPermissions(List.of(OFFICE));
-        when(personService.getSignedInUser()).thenReturn(person);
-
-
-        when(departmentService.getNumberOfDepartments()).thenReturn(0L);
+        when(personService.getSignedInUser()).thenReturn(person);        when(departmentService.getNumberOfDepartments()).thenReturn(0L);
 
         perform(get("/web/absences")
             .param("month", "1"))
@@ -463,9 +417,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -501,9 +452,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final Clock fixedClock = Clock.fixed(Instant.parse("2018-10-17T00:00:00.00Z"), ZoneId.systemDefault());
 
         sut = new AbsenceOverviewViewController(personService, departmentService, messageSource, fixedClock,
@@ -535,9 +483,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         when(messageSource.getMessage(anyString(), any(), any())).thenReturn("awesome month text");
 
         final var person = new Person();
@@ -576,9 +521,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         when(messageSource.getMessage(anyString(), any(), any())).thenReturn("awesome month text");
 
         final var person = new Person();
@@ -617,8 +559,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
 
         sut = new AbsenceOverviewViewController(personService, departmentService, messageSource, clock,
             publicHolidaysService, settingsService, absenceService, workingTimeService);
@@ -662,9 +602,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("bruce");
         person.setLastName("wayne");
@@ -700,9 +637,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("bruce");
         person.setLastName("wayne");
@@ -739,9 +673,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final Clock fixedClock = Clock.fixed(Instant.parse("2020-10-17T00:00:00.00Z"), ZoneId.systemDefault());
 
         sut = new AbsenceOverviewViewController(personService, departmentService, messageSource, fixedClock,
@@ -783,9 +714,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setFirstName("boss");
         person.setLastName("the hoss");
@@ -839,9 +767,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -898,9 +823,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -957,9 +879,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1019,9 +938,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1078,9 +994,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1137,9 +1050,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1200,9 +1110,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1259,9 +1166,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1318,9 +1222,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1379,9 +1280,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1437,9 +1335,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1495,9 +1390,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1558,9 +1450,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1617,9 +1506,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1676,9 +1562,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1737,9 +1620,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1795,9 +1675,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1853,9 +1730,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -1916,9 +1790,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -1981,9 +1852,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(role));
@@ -2047,9 +1915,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -2111,9 +1976,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final var person = new Person();
         person.setId(1);
         person.setPermissions(List.of(USER));
@@ -2166,19 +2028,13 @@ class AbsenceOverviewViewControllerTest {
                     ))
                 ))
             ));
-    }
-
-
-    @Test
+    }    @Test
     void ensureWeekendsAndHolidays() throws Exception {
 
         final Settings settings = new Settings();
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final Clock fixedClock = Clock.fixed(Instant.parse("2020-12-01T00:00:00.00Z"), ZoneId.systemDefault());
 
         sut = new AbsenceOverviewViewController(personService, departmentService, messageSource, fixedClock,
@@ -2241,9 +2097,6 @@ class AbsenceOverviewViewControllerTest {
         final WorkingTimeSettings workingTimeSettings = new WorkingTimeSettings();
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         final Clock fixedClock = Clock.fixed(Instant.parse("2020-12-10T00:00:00.00Z"), ZoneId.systemDefault());
 
         sut = new AbsenceOverviewViewController(personService, departmentService, messageSource, fixedClock,
@@ -2323,9 +2176,6 @@ class AbsenceOverviewViewControllerTest {
         workingTimeSettings.setFederalState(RHEINLAND_PFALZ);
         settings.setWorkingTimeSettings(workingTimeSettings);
         when(settingsService.getSettings()).thenReturn(settings);
-
-        when(publicHolidaysService.getAbsenceTypeOfDate(any(), any())).thenReturn(DayLength.ZERO);
-
         perform(get("/web/absences")
             .param("year", "2022")
             .param("month", "1")

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
@@ -2168,7 +2168,7 @@ class AbsenceOverviewViewControllerTest {
         when(workingTimeService.getFederalStatesByPersonAndDateRange(personWithCustomPublicHolidays, dateRange)).thenReturn(Map.of(dateRange, BADEN_WUERTTEMBERG));
         when(workingTimeService.getFederalStatesByPersonAndDateRange(personDefaultPublicHolidays, dateRange)).thenReturn(Map.of(dateRange, RHEINLAND_PFALZ));
 
-        when(publicHolidaysService.getPublicHolidays(start, end, BADEN_WUERTTEMBERG)).thenReturn(List.of(new PublicHoliday(LocalDate.of(2022, JANUARY, 6), FULL)));
+        when(publicHolidaysService.getPublicHolidays(start, end, BADEN_WUERTTEMBERG)).thenReturn(List.of(new PublicHoliday(LocalDate.of(2022, JANUARY, 6), FULL, "")));
         when(publicHolidaysService.getPublicHolidays(start, end, RHEINLAND_PFALZ)).thenReturn(emptyList());
 
         final Settings settings = new Settings();

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
@@ -12,7 +12,7 @@ import org.synyx.urlaubsverwaltung.TestDataCreator;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationService;
 import org.synyx.urlaubsverwaltung.person.Person;
-import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysServiceImpl;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
@@ -78,7 +78,7 @@ class VacationDaysServiceTest {
     @BeforeEach
     void setUp() {
 
-        workDaysCountService = new WorkDaysCountService(new PublicHolidaysService(settingsService, getHolidayManager()), workingTimeService);
+        workDaysCountService = new WorkDaysCountService(new PublicHolidaysServiceImpl(settingsService, getHolidayManager()), workingTimeService);
 
         sut = new VacationDaysService(workDaysCountService, applicationService, Clock.systemUTC());
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
@@ -16,6 +16,7 @@ import org.synyx.urlaubsverwaltung.account.VacationDaysService;
 import org.synyx.urlaubsverwaltung.overlap.OverlapService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysServiceImpl;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
@@ -73,7 +74,7 @@ class CalculationServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final HolidayManager holidayManager = getHolidayManager();
-        final PublicHolidaysService publicHolidaysService = new PublicHolidaysService(settingsService, holidayManager);
+        final PublicHolidaysService publicHolidaysService = new PublicHolidaysServiceImpl(settingsService, holidayManager);
         final WorkDaysCountService workDaysCountService = new WorkDaysCountService(publicHolidaysService, workingTimeService);
 
         // create working time object (MON-FRI)

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
@@ -13,6 +15,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -43,7 +46,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensurePersonIsNotAvailableOnHolidays() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getWorkingDurationOfDate(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(new BigDecimal(0));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL)));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -61,7 +64,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensurePersonIsHalfAvailableOnHolidays() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getWorkingDurationOfDate(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(BigDecimal.valueOf(0.5));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, NOON)));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -79,7 +82,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensureDoesNotCallNextProviderIfAlreadyAbsentForWholeDay() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getWorkingDurationOfDate(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(new BigDecimal(0));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL)));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -94,7 +97,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensureCallsNextSickDayAbsenceProviderIfNotAbsentForHoliday() {
 
         final LocalDate standardWorkingDay = LocalDate.of(2016, 1, 4);
-        when(publicHolidaysService.getWorkingDurationOfDate(standardWorkingDay, BADEN_WUERTTEMBERG)).thenReturn(new BigDecimal(1));
+        when(publicHolidaysService.getPublicHoliday(standardWorkingDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(standardWorkingDay, DayLength.ZERO)));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, standardWorkingDay)).thenReturn(BADEN_WUERTTEMBERG);

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/PublicHolidayAbsenceProviderTest.java
@@ -46,7 +46,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensurePersonIsNotAvailableOnHolidays() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL)));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL, "")));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -64,7 +64,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensurePersonIsHalfAvailableOnHolidays() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, NOON)));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, NOON, "")));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -82,7 +82,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensureDoesNotCallNextProviderIfAlreadyAbsentForWholeDay() {
 
         final LocalDate newYearsDay = LocalDate.of(2016, 1, 1);
-        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL)));
+        when(publicHolidaysService.getPublicHoliday(newYearsDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(newYearsDay, FULL, "")));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, newYearsDay)).thenReturn(BADEN_WUERTTEMBERG);
@@ -97,7 +97,7 @@ class PublicHolidayAbsenceProviderTest {
     void ensureCallsNextSickDayAbsenceProviderIfNotAbsentForHoliday() {
 
         final LocalDate standardWorkingDay = LocalDate.of(2016, 1, 4);
-        when(publicHolidaysService.getPublicHoliday(standardWorkingDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(standardWorkingDay, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(standardWorkingDay, BADEN_WUERTTEMBERG)).thenReturn(Optional.of(new PublicHoliday(standardWorkingDay, DayLength.ZERO, "")));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         when(workingTimeService.getFederalStateForPerson(person, standardWorkingDay)).thenReturn(BADEN_WUERTTEMBERG);

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
@@ -1,6 +1,5 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
-import de.jollyday.Holiday;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +19,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static de.jollyday.HolidayType.OFFICIAL_HOLIDAY;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static org.hamcrest.Matchers.hasSize;
@@ -61,9 +59,9 @@ class PublicHolidayApiControllerTest {
 
         final LocalDate from = LocalDate.of(2016, 5, 19);
         final LocalDate to = LocalDate.of(2016, 5, 20);
-        final Holiday fromHoliday = new Holiday(from, "", OFFICIAL_HOLIDAY);
-        final Holiday toHoliday = new Holiday(to, "", OFFICIAL_HOLIDAY);
-        when(publicHolidayService.getHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
+        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.FULL, "");
+        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.FULL, "");
+        when(publicHolidayService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
 
         when(publicHolidayService.getWorkingDurationOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(ONE);
         when(publicHolidayService.getAbsenceTypeOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(DayLength.MORNING);
@@ -134,9 +132,9 @@ class PublicHolidayApiControllerTest {
         when(workingTimeService.getFederalStateForPerson(person, from)).thenReturn(BADEN_WUERTTEMBERG);
 
         final LocalDate to = LocalDate.of(2016, 5, 20);
-        final Holiday fromHoliday = new Holiday(from, "", OFFICIAL_HOLIDAY);
-        final Holiday toHoliday = new Holiday(to, "", OFFICIAL_HOLIDAY);
-        when(publicHolidayService.getHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
+        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.FULL, "");
+        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.FULL, "");
+        when(publicHolidayService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
 
         when(publicHolidayService.getWorkingDurationOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(ONE);
         when(publicHolidayService.getAbsenceTypeOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(DayLength.MORNING);

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
@@ -19,8 +19,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static java.math.BigDecimal.ONE;
-import static java.math.BigDecimal.TEN;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
@@ -37,7 +35,7 @@ class PublicHolidayApiControllerTest {
     private PublicHolidayApiController sut;
 
     @Mock
-    private PublicHolidaysService publicHolidayService;
+    private PublicHolidaysService publicHolidaysService;
     @Mock
     private PersonService personService;
     @Mock
@@ -47,7 +45,7 @@ class PublicHolidayApiControllerTest {
 
     @BeforeEach
     void setUp() {
-        sut = new PublicHolidayApiController(publicHolidayService, personService, workingTimeService, settingsService);
+        sut = new PublicHolidayApiController(publicHolidaysService, personService, workingTimeService, settingsService);
     }
 
     @Test
@@ -59,14 +57,9 @@ class PublicHolidayApiControllerTest {
 
         final LocalDate from = LocalDate.of(2016, 5, 19);
         final LocalDate to = LocalDate.of(2016, 5, 20);
-        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.FULL, "");
-        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.FULL, "");
-        when(publicHolidayService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
-
-        when(publicHolidayService.getWorkingDurationOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(ONE);
-        when(publicHolidayService.getAbsenceTypeOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(DayLength.MORNING);
-        when(publicHolidayService.getWorkingDurationOfDate(to, BADEN_WUERTTEMBERG)).thenReturn(TEN);
-        when(publicHolidayService.getAbsenceTypeOfDate(to, BADEN_WUERTTEMBERG)).thenReturn(DayLength.NOON);
+        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.MORNING, "");
+        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.NOON, "");
+        when(publicHolidaysService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
 
         perform(get("/api/public-holidays")
             .param("from", "2016-05-19")
@@ -76,10 +69,10 @@ class PublicHolidayApiControllerTest {
             .andExpect(jsonPath("$.publicHolidays").exists())
             .andExpect(jsonPath("$.publicHolidays", hasSize(2)))
             .andExpect(jsonPath("$.publicHolidays[0].date", is("2016-05-19")))
-            .andExpect(jsonPath("$.publicHolidays[0].dayLength", is(1)))
+            .andExpect(jsonPath("$.publicHolidays[0].dayLength", is(0.5)))
             .andExpect(jsonPath("$.publicHolidays[0].absencePeriodName", is("MORNING")))
             .andExpect(jsonPath("$.publicHolidays[1].date", is("2016-05-20")))
-            .andExpect(jsonPath("$.publicHolidays[1].dayLength", is(10)))
+            .andExpect(jsonPath("$.publicHolidays[1].dayLength", is(0.5)))
             .andExpect(jsonPath("$.publicHolidays[1].absencePeriodName", is("NOON")));
     }
 
@@ -132,14 +125,9 @@ class PublicHolidayApiControllerTest {
         when(workingTimeService.getFederalStateForPerson(person, from)).thenReturn(BADEN_WUERTTEMBERG);
 
         final LocalDate to = LocalDate.of(2016, 5, 20);
-        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.FULL, "");
-        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.FULL, "");
-        when(publicHolidayService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
-
-        when(publicHolidayService.getWorkingDurationOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(ONE);
-        when(publicHolidayService.getAbsenceTypeOfDate(from, BADEN_WUERTTEMBERG)).thenReturn(DayLength.MORNING);
-        when(publicHolidayService.getWorkingDurationOfDate(to, BADEN_WUERTTEMBERG)).thenReturn(TEN);
-        when(publicHolidayService.getAbsenceTypeOfDate(to, BADEN_WUERTTEMBERG)).thenReturn(DayLength.NOON);
+        final PublicHoliday fromHoliday = new PublicHoliday(from, DayLength.MORNING, "");
+        final PublicHoliday toHoliday = new PublicHoliday(to, DayLength.NOON, "");
+        when(publicHolidaysService.getPublicHolidays(from, to, BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
 
         perform(get("/api/persons/1/public-holidays")
             .param("from", "2016-05-19")
@@ -149,10 +137,10 @@ class PublicHolidayApiControllerTest {
             .andExpect(jsonPath("$.publicHolidays").exists())
             .andExpect(jsonPath("$.publicHolidays", hasSize(2)))
             .andExpect(jsonPath("$.publicHolidays[0].date", is("2016-05-19")))
-            .andExpect(jsonPath("$.publicHolidays[0].dayLength", is(1)))
+            .andExpect(jsonPath("$.publicHolidays[0].dayLength", is(0.5)))
             .andExpect(jsonPath("$.publicHolidays[0].absencePeriodName", is("MORNING")))
             .andExpect(jsonPath("$.publicHolidays[1].date", is("2016-05-20")))
-            .andExpect(jsonPath("$.publicHolidays[1].dayLength", is(10)))
+            .andExpect(jsonPath("$.publicHolidays[1].dayLength", is(0.5)))
             .andExpect(jsonPath("$.publicHolidays[1].absencePeriodName", is("NOON")));
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayTest.java
@@ -1,0 +1,40 @@
+package org.synyx.urlaubsverwaltung.publicholiday;
+
+import org.junit.jupiter.api.Test;
+import org.synyx.urlaubsverwaltung.period.DayLength;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicHolidayTest {
+
+    @Test
+    void getWorkingDurationFull() {
+
+        final PublicHoliday publicHoliday = new PublicHoliday(LocalDate.MIN, DayLength.FULL, "description");
+        assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void getWorkingDurationMorning() {
+
+        final PublicHoliday publicHoliday = new PublicHoliday(LocalDate.MIN, DayLength.MORNING, "description");
+        assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.valueOf(0.5));
+    }
+
+    @Test
+    void getWorkingDurationNoon() {
+
+        final PublicHoliday publicHoliday = new PublicHoliday(LocalDate.MIN, DayLength.NOON, "description");
+        assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.valueOf(0.5));
+    }
+
+    @Test
+    void getWorkingDurationZero() {
+
+        final PublicHoliday publicHoliday = new PublicHoliday(LocalDate.MIN, DayLength.ZERO, "description");
+        assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.ONE);
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.List;
 import java.util.Optional;
 
 import static de.jollyday.ManagerParameters.create;
@@ -205,6 +206,17 @@ class PublicHolidaysServiceImplTest {
 
         final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, DECEMBER, 31), BADEN_WUERTTEMBERG);
         assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getDayLength()).isEqualTo(DayLength.NOON));
+    }
+
+    @Test
+    void ensureGetPublicHolidaysReturnsForNewYearsEve() {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final List<PublicHoliday> publicHolidays = sut.getPublicHolidays(of(2019, DECEMBER, 30), of(2019, DECEMBER, 31), BADEN_WUERTTEMBERG);
+        assertThat(publicHolidays)
+            .hasSize(1)
+            .extracting(p -> p.getDayLength()).containsExactly(DayLength.NOON);
     }
 
     private HolidayManager getHolidayManager() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
@@ -30,7 +30,7 @@ import static org.synyx.urlaubsverwaltung.workingtime.FederalState.BAYERN_MUENCH
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.BERLIN;
 
 @ExtendWith(MockitoExtension.class)
-class PublicHolidaysServiceTest {
+class PublicHolidaysServiceImplTest {
 
     private PublicHolidaysService sut;
 
@@ -39,7 +39,7 @@ class PublicHolidaysServiceTest {
 
     @BeforeEach
     void setUp() {
-        sut = new PublicHolidaysService(settingsService, getHolidayManager());
+        sut = new PublicHolidaysServiceImpl(settingsService, getHolidayManager());
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceTest.java
@@ -1,8 +1,6 @@
 package org.synyx.urlaubsverwaltung.publicholiday;
 
 import de.jollyday.HolidayManager;
-import de.jollyday.ManagerParameter;
-import de.jollyday.ManagerParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,14 +9,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
-import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 
 import java.math.BigDecimal;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Optional;
 
+import static de.jollyday.ManagerParameters.create;
+import static java.math.BigDecimal.ONE;
+import static java.math.BigDecimal.ZERO;
+import static java.time.LocalDate.of;
 import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.BADEN_WUERTTEMBERG;
@@ -27,8 +31,6 @@ import static org.synyx.urlaubsverwaltung.workingtime.FederalState.BERLIN;
 
 @ExtendWith(MockitoExtension.class)
 class PublicHolidaysServiceTest {
-
-    private static final FederalState state = BADEN_WUERTTEMBERG;
 
     private PublicHolidaysService sut;
 
@@ -44,20 +46,19 @@ class PublicHolidaysServiceTest {
     void ensureCorrectWorkingDurationForWorkDay() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
-        LocalDate testDate = LocalDate.of(2013, Month.NOVEMBER, 27);
+        final LocalDate localDate = of(2013, Month.NOVEMBER, 27);
 
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ONE);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(localDate, BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
     void ensureCorrectWorkingDurationForPublicHoliday() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
-        final LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 25);
 
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 25), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(ZERO));
     }
 
     @Test
@@ -67,12 +68,9 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForChristmasEve(DayLength.FULL);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 24);
-
-        BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ONE);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 24), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(ONE));
     }
-
 
     @Test
     void ensureWorkingDurationForNewYearsEveCanBeConfiguredToAWorkingDurationOfFullDay() {
@@ -81,10 +79,8 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForNewYearsEve(DayLength.FULL);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 31);
-
-        BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ONE);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 31), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(ONE));
     }
 
     @Test
@@ -94,10 +90,8 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForChristmasEve(DayLength.MORNING);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 24);
-
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.valueOf(0.5));
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 24), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.valueOf(0.5)));
     }
 
     @Test
@@ -107,10 +101,8 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForNewYearsEve(DayLength.NOON);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 31);
-
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.valueOf(0.5));
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 31), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(BigDecimal.valueOf(0.5)));
     }
 
     @Test
@@ -120,10 +112,8 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForChristmasEve(DayLength.ZERO);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 24);
-
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 24), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(ZERO));
     }
 
     @Test
@@ -133,10 +123,8 @@ class PublicHolidaysServiceTest {
         settings.getWorkingTimeSettings().setWorkingDurationForNewYearsEve(DayLength.ZERO);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final LocalDate testDate = LocalDate.of(2013, Month.DECEMBER, 31);
-
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(testDate, state);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2013, DECEMBER, 31), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getWorkingDuration()).isEqualByComparingTo(ZERO));
     }
 
     @Test
@@ -144,8 +132,8 @@ class PublicHolidaysServiceTest {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(LocalDate.of(2015, AUGUST, 15), BERLIN);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ONE);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2015, AUGUST, 15), BERLIN);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
@@ -153,99 +141,75 @@ class PublicHolidaysServiceTest {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(LocalDate.of(2015, AUGUST, 15), BADEN_WUERTTEMBERG);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ONE);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2015, AUGUST, 15), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
     void ensureCorrectWorkingDurationForAssumptionDayForBayernMuenchen() {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final BigDecimal workingDuration = sut.getWorkingDurationOfDate(LocalDate.of(2015, AUGUST, 15), BAYERN_MUENCHEN);
-        assertThat(workingDuration).isEqualByComparingTo(BigDecimal.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2015, DECEMBER, 15), BAYERN_MUENCHEN);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsZeroWhenDateIsNoPublicHoliday() {
+    void ensureGetDayLengthReturnsFullForCorpusChristi() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final LocalDate date = LocalDate.of(2019, 1, 2);
-
-        final DayLength actual = sut.getAbsenceTypeOfDate(date, BADEN_WUERTTEMBERG);
-        assertThat(actual).isEqualTo(DayLength.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, MAY, 30), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getDayLength()).isEqualTo(DayLength.FULL));
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsFullForCorpusChristi() {
+    void ensureGetDayLengthReturnsFullForAssumptionDayInBayernMunich() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
-        final LocalDate corpusChristi = LocalDate.of(2019, Month.MAY, 30);
 
-        final DayLength actual = sut.getAbsenceTypeOfDate(corpusChristi, BADEN_WUERTTEMBERG);
-        assertThat(actual).isEqualTo(DayLength.FULL);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, AUGUST, 15), BAYERN_MUENCHEN);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getDayLength()).isEqualTo(DayLength.FULL));
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsFullForAssumptionDayInBayernMunich() {
+    void ensureGetDayLengthReturnsZeroForAssumptionDayInBerlin() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
-        final LocalDate assumptionDay = LocalDate.of(2019, AUGUST, 15);
 
-        final DayLength actual = sut.getAbsenceTypeOfDate(assumptionDay, BAYERN_MUENCHEN);
-        assertThat(actual).isEqualTo(DayLength.FULL);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, AUGUST, 15), BERLIN);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsZeroForAssumptionDayInBerlin() {
+    void ensureGetDayLengthReturnsZeroForAssumptionDayInBadenWuerttemberg() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final LocalDate assumptionDay = LocalDate.of(2019, AUGUST, 15);
-
-        final DayLength actual = sut.getAbsenceTypeOfDate(assumptionDay, BERLIN);
-        assertThat(actual).isEqualTo(DayLength.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, AUGUST, 15), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).isEmpty();
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsZeroForAssumptionDayInBadenWuerttemberg() {
+    void ensureGetDayLengthReturnsForChristmasEve() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final LocalDate assumptionDay = LocalDate.of(2019, AUGUST, 15);
-
-        final DayLength actual = sut.getAbsenceTypeOfDate(assumptionDay, BADEN_WUERTTEMBERG);
-        assertThat(actual).isEqualTo(DayLength.ZERO);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, DECEMBER, 24), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getDayLength()).isEqualTo(DayLength.NOON));
     }
 
     @Test
-    void ensureGetAbsenceTypeOfDateReturnsForChristmasEve() {
+    void ensureGetDayLengthReturnsForNewYearsEve() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final LocalDate date = LocalDate.of(2019, 12, 24);
-
-        final DayLength actual = sut.getAbsenceTypeOfDate(date, BADEN_WUERTTEMBERG);
-        assertThat(actual).isEqualTo(DayLength.NOON);
-    }
-
-    @Test
-    void ensureGetAbsenceTypeOfDateReturnsForNewYearsEve() {
-
-        when(settingsService.getSettings()).thenReturn(new Settings());
-
-        final LocalDate date = LocalDate.of(2019, 12, 31);
-
-        final DayLength actual = sut.getAbsenceTypeOfDate(date, BADEN_WUERTTEMBERG);
-        assertThat(actual).isEqualTo(DayLength.NOON);
+        final Optional<PublicHoliday> maybePublicHoliday = sut.getPublicHoliday(of(2019, DECEMBER, 31), BADEN_WUERTTEMBERG);
+        assertThat(maybePublicHoliday).hasValueSatisfying(publicHoliday -> assertThat(publicHoliday.getDayLength()).isEqualTo(DayLength.NOON));
     }
 
     private HolidayManager getHolidayManager() {
-        final HolidayManager holidayManager;
         final ClassLoader cl = Thread.currentThread().getContextClassLoader();
         final URL url = cl.getResource("Holidays_de.xml");
-        final ManagerParameter managerParameter = ManagerParameters.create(url);
-        holidayManager = HolidayManager.getInstance(managerParameter);
-        return holidayManager;
+        return HolidayManager.getInstance(create(url));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewServiceTest.java
@@ -3,13 +3,13 @@ package org.synyx.urlaubsverwaltung.statistics.vacationoverview.api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
@@ -17,9 +17,12 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.statistics.vacationoverview.api.DayOfMonth.TypeOfDay.WORKDAY;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.BADEN_WUERTTEMBERG;
@@ -34,11 +37,11 @@ class VacationOverviewServiceTest {
     @Mock
     private WorkingTimeService workingTimeService;
     @Mock
-    private PublicHolidaysService publicHolidayService;
+    private PublicHolidaysService publicHolidaysService;
 
     @BeforeEach
     void setUp() {
-        this.sut = new VacationOverviewService(departmentService, workingTimeService, publicHolidayService, Clock.systemUTC());
+        this.sut = new VacationOverviewService(departmentService, workingTimeService, publicHolidaysService, Clock.systemUTC());
     }
 
     @Test
@@ -53,10 +56,11 @@ class VacationOverviewServiceTest {
         department.setMembers(List.of(person));
 
         when(departmentService.getAllDepartments()).thenReturn(singletonList(department));
-        when(workingTimeService.getFederalStateForPerson(ArgumentMatchers.eq(person), ArgumentMatchers.any(LocalDate.class))).thenReturn(BADEN_WUERTTEMBERG);
-        when(publicHolidayService.getWorkingDurationOfDate(ArgumentMatchers.any(LocalDate.class), ArgumentMatchers.any(FederalState.class))).thenReturn(DayLength.FULL.getDuration());
+        when(workingTimeService.getFederalStateForPerson(eq(person), any(LocalDate.class))).thenReturn(BADEN_WUERTTEMBERG);
 
         final LocalDate localDate = LocalDate.parse("2017-09-01");
+        when(publicHolidaysService.getPublicHoliday(any(LocalDate.class), any(FederalState.class))).thenReturn(Optional.of(new PublicHoliday(localDate, DayLength.ZERO)));
+
         final List<VacationOverviewDto> vacationOverviewDtos = sut.getVacationOverviews(departmentName, localDate.getYear(), localDate.getMonthValue());
         assertThat(vacationOverviewDtos).hasSize(1);
         assertThat(vacationOverviewDtos.get(0).getPerson().getEmail()).isEqualTo(email);

--- a/src/test/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/statistics/vacationoverview/api/VacationOverviewServiceTest.java
@@ -59,7 +59,7 @@ class VacationOverviewServiceTest {
         when(workingTimeService.getFederalStateForPerson(eq(person), any(LocalDate.class))).thenReturn(BADEN_WUERTTEMBERG);
 
         final LocalDate localDate = LocalDate.parse("2017-09-01");
-        when(publicHolidaysService.getPublicHoliday(any(LocalDate.class), any(FederalState.class))).thenReturn(Optional.of(new PublicHoliday(localDate, DayLength.ZERO)));
+        when(publicHolidaysService.getPublicHoliday(any(LocalDate.class), any(FederalState.class))).thenReturn(Optional.of(new PublicHoliday(localDate, DayLength.ZERO, "")));
 
         final List<VacationOverviewDto> vacationOverviewDtos = sut.getVacationOverviews(departmentName, localDate.getYear(), localDate.getMonthValue());
         assertThat(vacationOverviewDtos).hasSize(1);

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveCreateIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveCreateIT.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.synyx.urlaubsverwaltung.account.AccountInteractionService;
-import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.person.Role;
@@ -282,7 +281,7 @@ class ApplicationForLeaveCreateIT {
         final FederalState federalState = settingsService.getSettings().getWorkingTimeSettings().getFederalState();
 
         LocalDate nextWorkDay = now();
-        while (DayLength.ZERO.compareTo(publicHolidaysService.getAbsenceTypeOfDate(nextWorkDay, federalState)) != 0) {
+        while (publicHolidaysService.getPublicHoliday(nextWorkDay, federalState).isEmpty()) {
             nextWorkDay = nextWorkDay.plusDays(1);
         }
         return nextWorkDay;

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveCreateIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveCreateIT.java
@@ -281,7 +281,7 @@ class ApplicationForLeaveCreateIT {
         final FederalState federalState = settingsService.getSettings().getWorkingTimeSettings().getFederalState();
 
         LocalDate nextWorkDay = now();
-        while (publicHolidaysService.getPublicHoliday(nextWorkDay, federalState).isEmpty()) {
+        while (publicHolidaysService.getPublicHoliday(nextWorkDay, federalState).isPresent()) {
             nextWorkDay = nextWorkDay.plusDays(1);
         }
         return nextWorkDay;

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -1,8 +1,6 @@
 package org.synyx.urlaubsverwaltung.workingtime;
 
 import de.jollyday.HolidayManager;
-import de.jollyday.ManagerParameter;
-import de.jollyday.ManagerParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +21,7 @@ import java.time.Month;
 import java.util.List;
 import java.util.Optional;
 
+import static de.jollyday.ManagerParameters.create;
 import static java.math.BigDecimal.TEN;
 import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -481,7 +480,6 @@ class WorkDaysCountServiceTest {
     private HolidayManager getHolidayManager() {
         final ClassLoader cl = Thread.currentThread().getContextClassLoader();
         final URL url = cl.getResource("Holidays_de.xml");
-        final ManagerParameter managerParameter = ManagerParameters.create(url);
-        return HolidayManager.getInstance(managerParameter);
+        return HolidayManager.getInstance(create(url));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.TestDataCreator;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.person.Person;
-import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
+import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysServiceImpl;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 
@@ -47,7 +47,7 @@ class WorkDaysCountServiceTest {
 
     @BeforeEach
     void setUp() {
-        final var publicHolidaysService = new PublicHolidaysService(settingsService, getHolidayManager());
+        final var publicHolidaysService = new PublicHolidaysServiceImpl(settingsService, getHolidayManager());
         sut = new WorkDaysCountService(publicHolidaysService, workingTimeService);
     }
 


### PR DESCRIPTION
In diesem PR wird das "Package" publicholiday überarbeitet und die Schnittstellen glatt gezogen, sodass das Domänenobjekt gestärkt wird.

refs #2515 