### PR TITLE
add opentelemetry agent to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV JAVA_APP_JAR="${project.artifactId}.war"
 
 VOLUME /tmp
 
-RUN mkdir /app
+RUN mkdir /app && mkdir /opt/opentelemetry
+ADD target/docker-extra/opentelemetry-agent/opentelemetry-javaagent-${opentelemetry-agent.version}.jar /opt/opentelemetry/opentelemetry-javaagent.jar
 COPY maven/${project.build.finalName}.war /app/app.war
 
 WORKDIR /app

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <java.version>11</java.version>
     <testcontainers.version>1.16.2</testcontainers.version>
     <opentelemetry-agent.version>1.9.1</opentelemetry-agent.version>
+    <docker.name>synyx/urlaubsverwaltung</docker.name>
   </properties>
 
   <scm>
@@ -449,7 +450,7 @@
         <configuration>
           <images>
             <image>
-              <name>synyx/urlaubsverwaltung</name>
+              <name>${docker.name}</name>
               <build>
                 <dockerFileDir>${project.basedir}</dockerFileDir>
                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <java.version>11</java.version>
     <testcontainers.version>1.16.2</testcontainers.version>
+    <opentelemetry-agent.version>1.9.1</opentelemetry-agent.version>
   </properties>
 
   <scm>
@@ -513,6 +514,31 @@
                   <version>${java.version}</version>
                 </requireJavaVersion>
               </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-agent</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.opentelemetry.javaagent</groupId>
+                  <artifactId>opentelemetry-javaagent</artifactId>
+                  <version>${opentelemetry-agent.version}</version>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/docker-extra/opentelemetry-agent</outputDirectory>
+                </artifactItem>
+              </artifactItems>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This change introduces the possibility to integrate urlaubsverwaltung
into your distributed tracing system.

The opentelemetry java agent can be activated via `JAVA_TOOL_OPTIONS`
environment variable

docker run example: `docker run -e
JAVA_TOOL_OPTIONS='-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar'
synyx/urlaubsverwaltung`

See [Automatic Instrumentation](
https://opentelemetry.io/docs/instrumentation/java/automatic_instrumentation/)
and for detailed configuration options [OpenTelemetry SDK
Autoconfigure](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md)