### PR TITLE
Anzeigename bei E-Mail-Empfang ist "Urlaubsverwaltung"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ uv.development.demodata.additional-inactive-user=0
 uv.mail.administrator
 uv.mail.application-url
 uv.mail.sender
+uv.mail.senderDisplayName=Urlaubsverwaltung
 
 # security
 uv.security.auth=default
@@ -233,6 +234,7 @@ Um den E-Mail-Server zu konfigurieren müssen folgende Konfigurationen vorgenomm
 
 ```properties
 uv.mail.sender=absender@example.org         # Absender der E-Mails
+uv.mail.senderDisplayName=Urlaubsverwaltung # Schönere Darstellung im Postfach
 uv.mail.administrator=admin@example.org     # E-Mail-Adresse des Administrators
 uv.mail.application-url=https://example.org # Diese URL wird in den E-Mails zur Link-Generierung verwendet
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/mail/MailProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/mail/MailProperties.java
@@ -15,6 +15,9 @@ public class MailProperties {
     @NotEmpty
     private String sender;
 
+    @NotEmpty
+    private String senderDisplayName;
+
     @Email
     @NotEmpty
     private String administrator;
@@ -28,6 +31,14 @@ public class MailProperties {
 
     public void setSender(String sender) {
         this.sender = sender;
+    }
+
+    public String getSenderDisplayName() {
+        return senderDisplayName;
+    }
+
+    public void setSenderDisplayName(String senderDisplayName) {
+        this.senderDisplayName = senderDisplayName;
     }
 
     public String getAdministrator() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/mail/MailServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/mail/MailServiceImpl.java
@@ -45,7 +45,7 @@ class MailServiceImpl implements MailService {
         model.put("baseLinkURL", getApplicationUrl());
 
         final String subject = getTranslation(mail.getSubjectMessageKey(), mail.getSubjectMessageArguments());
-        final String sender = mailProperties.getSender();
+        final String sender = generateMailAddressAndDisplayName(mailProperties.getSender(), mailProperties.getSenderDisplayName());
 
         getRecipients(mail).forEach(recipient -> {
             model.put("recipient", recipient);
@@ -78,5 +78,9 @@ class MailServiceImpl implements MailService {
     private String getApplicationUrl() {
         final String applicationUrl = mailProperties.getApplicationUrl();
         return applicationUrl.endsWith("/") ? applicationUrl : applicationUrl + "/";
+    }
+
+    private String generateMailAddressAndDisplayName(String address, String displayName) {
+        return String.format("%s <%s>", displayName, address);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -91,6 +91,9 @@ uv.security.oidc.client-id=
 uv.security.oidc.client-secret=
 uv.security.oidc.logout-uri=
 
+# email settings -------------------------------------------------------------------------------------------------------
+uv.mail.senderDisplayName=Urlaubsverwaltung
+
 # JSP template engine---------------------------------------------------------------------------------------------------
 uv.template-engine.jsp.use-precompiled=false
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceIT.java
@@ -865,7 +865,7 @@ class ApplicationMailServiceIT extends TestContainersBase {
         Address[] from = msg.getFrom();
         assertThat(from).isNotNull();
         assertThat(from.length).isOne();
-        assertThat(from[0]).hasToString(mailProperties.getSender());
+        assertThat(from[0]).hasToString(String.format("%s <%s>", mailProperties.getSenderDisplayName(), mailProperties.getSender()));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/mail/MailServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/mail/MailServiceImplTest.java
@@ -46,6 +46,7 @@ class MailServiceImplTest {
         when(messageSource.getMessage(any(), any(), any())).thenReturn("subject");
         when(mailContentBuilder.buildMailBody(any(), any(), any())).thenReturn("emailBody");
         when(mailProperties.getSender()).thenReturn("no-reply@example.org");
+        when(mailProperties.getSenderDisplayName()).thenReturn("Urlaubsverwaltung");
         when(mailProperties.getApplicationUrl()).thenReturn("http://localhost:8080");
 
         sut = new MailServiceImpl(messageSource, mailContentBuilder, mailSenderService, mailProperties, personService);
@@ -74,7 +75,7 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("mail@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("mail@example.org"), "subject", "emailBody");
     }
 
     @Test
@@ -96,7 +97,7 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("hans@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("hans@example.org"), "subject", "emailBody");
     }
 
     @Test
@@ -122,8 +123,8 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("hans@example.org"), "subject", "emailBody");
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("franz@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("hans@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("franz@example.org"), "subject", "emailBody");
     }
 
     @Test
@@ -152,8 +153,8 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("franz@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("hans@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("franz@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("hans@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
     }
 
     @Test
@@ -182,8 +183,8 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("hans@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("franz@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("hans@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("franz@example.org"), "subject", "emailBody", List.of(new MailAttachment("fileName", iCal)));
     }
 
     @Test
@@ -203,7 +204,7 @@ class MailServiceImplTest {
             .build();
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of(to), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of(to), "subject", "emailBody");
     }
 
     @Test
@@ -233,9 +234,9 @@ class MailServiceImplTest {
 
         sut.send(mail);
 
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("hans@example.org"), "subject", "emailBody");
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("franz@example.org"), "subject", "emailBody");
-        verify(mailSenderService).sendEmail("no-reply@example.org", List.of("admin@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("hans@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("franz@example.org"), "subject", "emailBody");
+        verify(mailSenderService).sendEmail("Urlaubsverwaltung <no-reply@example.org>", List.of("admin@example.org"), "subject", "emailBody");
     }
 
     private void setupMockServletRequest() {

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,6 +13,7 @@ spring.mail.host=localhost
 spring.freemarker.template-loader-path=classpath:/org/synyx/urlaubsverwaltung/core/mail/
 uv.mail.application-url=https://localhost:8080
 uv.mail.sender=sender@example.org
+uv.mail.senderDisplayName=Urlaubsverwaltung
 uv.mail.administrator=administrators@example.org
 
 # CALENDAR


### PR DESCRIPTION
was before like "no-reply" and is now "Urlaubsverwaltung" as default

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
