### PR TITLE
Allow absences on public holidays

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiController.java
@@ -106,12 +106,13 @@ public class AbsenceApiController {
         final Predicate<DayAbsenceDto> isVacation = dto -> dto.getType().equals(VACATION.name());
         final Predicate<DayAbsenceDto> isSick = dto -> dto.getType().equals(SICK_NOTE.name());
 
+        // FIXME - default federal state cannot be used for a person to get their public holidays
+        // this is used for the calendar on the overview page e.g.
         final Map<LocalDate, PublicHoliday> holidaysByDate = holidaysByDate(start, end);
 
         return absenceService.getOpenAbsences(person, start, end)
             .stream()
             .flatMap(absencePeriod -> this.toDayAbsenceDto(absencePeriod, holidaysByDate))
-            // TODO do we have to generate the dtos even they are not asked? or is the performance impact insignificantly?
             .filter(vacationAsked.and(isVacation).or(sickAsked.and(isSick)))
             .collect(toList());
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -205,12 +205,7 @@ public class AbsenceOverviewViewController {
             .entrySet().stream()
             .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().getStartDate(), entry.getKey().getEndDate(), entry.getValue()))
             .flatMap(List::stream)
-            .collect(
-                toMap(
-                    PublicHoliday::getDate,
-                    Function.identity()
-                )
-            );
+            .collect(toMap(PublicHoliday::getDate, Function.identity()));
     }
 
     private AbsenceOverviewMonthDto initializeAbsenceOverviewMonthDto(LocalDate date, List<Person> personList, Locale locale) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -364,6 +364,7 @@ class ApplicationForLeaveDetailsViewController {
         model.addAttribute("application", new ApplicationForLeave(application, workDaysCountService));
 
         // WORKING TIME FOR VACATION PERIOD
+        // FIXME - wird in app_info verwenden und auch nur anhand des start datums. Hier sollte eine Liste her.
         final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
             application.getPerson(), application.getStartDate());
         optionalWorkingTime.ifPresent(workingTime -> model.addAttribute("workingTime", workingTime));

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -16,10 +16,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.synyx.urlaubsverwaltung.account.Account;
 import org.synyx.urlaubsverwaltung.account.AccountService;
 import org.synyx.urlaubsverwaltung.account.VacationDaysService;
-import org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentForm;
-import org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentValidator;
 import org.synyx.urlaubsverwaltung.application.comment.ApplicationComment;
+import org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentForm;
 import org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentService;
+import org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentValidator;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
@@ -365,8 +365,7 @@ class ApplicationForLeaveDetailsViewController {
 
         // WORKING TIME FOR VACATION PERIOD
         // FIXME - wird in app_info verwenden und auch nur anhand des start datums. Hier sollte eine Liste her.
-        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
-            application.getPerson(), application.getStartDate());
+        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getWorkingTime(application.getPerson(), application.getStartDate());
         optionalWorkingTime.ifPresent(workingTime -> model.addAttribute("workingTime", workingTime));
 
         // DEPARTMENT APPLICATIONS FOR LEAVE

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidator.java
@@ -28,10 +28,10 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.springframework.util.StringUtils.hasText;
+import static org.synyx.urlaubsverwaltung.application.application.ApplicationMapper.mapToApplication;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.HOLIDAY;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.OVERTIME;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.SPECIALLEAVE;
-import static org.synyx.urlaubsverwaltung.application.application.ApplicationMapper.mapToApplication;
 import static org.synyx.urlaubsverwaltung.overlap.OverlapCase.FULLY_OVERLAPPING;
 import static org.synyx.urlaubsverwaltung.overlap.OverlapCase.PARTLY_OVERLAPPING;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
@@ -90,8 +90,8 @@ class ApplicationForLeaveFormValidator implements Validator {
 
     @Autowired
     ApplicationForLeaveFormValidator(WorkingTimeService workingTimeService, WorkDaysCountService workDaysCountService,
-                                            OverlapService overlapService, CalculationService calculationService, SettingsService settingsService,
-                                            OvertimeService overtimeService, Clock clock) {
+                                     OverlapService overlapService, CalculationService calculationService, SettingsService settingsService,
+                                     OvertimeService overtimeService, Clock clock) {
 
         this.workingTimeService = workingTimeService;
         this.workDaysCountService = workDaysCountService;
@@ -393,9 +393,7 @@ class ApplicationForLeaveFormValidator implements Validator {
 
     private boolean personHasWorkingTime(ApplicationForLeaveForm applicationForLeaveForm) {
 
-        final Optional<WorkingTime> workingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
-            applicationForLeaveForm.getPerson(), applicationForLeaveForm.getStartDate());
-
+        final Optional<WorkingTime> workingTime = workingTimeService.getWorkingTime(applicationForLeaveForm.getPerson(), applicationForLeaveForm.getStartDate());
         return workingTime.isPresent();
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProvider.java
@@ -66,15 +66,12 @@ class FreeTimeAbsenceProvider extends AbstractTimedAbsenceProvider {
 
     private DayLength getExpectedWorkTimeFor(Person person, LocalDate currentDay) {
 
-        Optional<WorkingTime> workingTimeOrNot = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(person,
-            currentDay);
-
-        if (workingTimeOrNot.isEmpty()) {
+        final Optional<WorkingTime> maybeWorkingTime = workingTimeService.getWorkingTime(person, currentDay);
+        if (maybeWorkingTime.isEmpty()) {
             throw new FreeTimeAbsenceException("Person " + person + " does not have workingTime configured");
         }
 
-        WorkingTime workingTime = workingTimeOrNot.get();
-
+        final WorkingTime workingTime = maybeWorkingTime.get();
         return workingTime.getDayLengthForWeekDay(currentDay.getDayOfWeek());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonDetailsViewController.java
@@ -20,7 +20,6 @@ import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.person.UnknownPersonException;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
-import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
@@ -97,13 +96,10 @@ public class PersonDetailsViewController {
         model.addAttribute("departmentHeadOfDepartments", departmentService.getManagedDepartmentsOfDepartmentHead(person));
         model.addAttribute("secondStageAuthorityOfDepartments", departmentService.getManagedDepartmentsOfSecondStageAuthority(person));
 
-        final Optional<WorkingTime> workingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(person, LocalDate.now(clock));
-
-        final FederalState federalState = workingTime.map(WorkingTime::getFederalState)
-            .orElseGet(() -> settingsService.getSettings().getWorkingTimeSettings().getFederalState());
-
-        model.addAttribute("workingTime", workingTime.orElse(null));
-        model.addAttribute("federalState", federalState);
+        final Optional<WorkingTime> maybeWorkingTime = workingTimeService.getWorkingTime(person, LocalDate.now(clock));
+        model.addAttribute("workingTime", maybeWorkingTime.orElse(null));
+        model.addAttribute("federalState", maybeWorkingTime.map(WorkingTime::getFederalState)
+            .orElseGet(() -> settingsService.getSettings().getWorkingTimeSettings().getFederalState()));
 
         final Optional<Account> maybeAccount = accountService.getHolidaysAccount(year, person);
         maybeAccount.ifPresent(account -> model.addAttribute("account", account));

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
@@ -105,6 +105,7 @@ public class PublicHolidayApiController {
         }
 
         final Person person = optionalPerson.get();
+        // FIXME - federal state cannot be determined by only the start date
         final FederalState federalState = workingTimeService.getFederalStateForPerson(person, startDate);
 
         final List<PublicHolidayDto> publicHolidays = getPublicHolidays(startDate, endDate, federalState);

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiController.java
@@ -34,8 +34,6 @@ import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_OFFICE;
 @RequestMapping("/api")
 public class PublicHolidayApiController {
 
-    public static final String PUBLIC_HOLIDAYS = "public-holidays";
-
     private final PublicHolidaysService publicHolidaysService;
     private final PersonService personService;
     private final WorkingTimeService workingTimeService;
@@ -56,7 +54,7 @@ public class PublicHolidayApiController {
         description = "Get all public holidays for a certain period. "
             + "Information only reachable for users with role office."
     )
-    @GetMapping(PUBLIC_HOLIDAYS)
+    @GetMapping("public-holidays")
     @PreAuthorize(IS_OFFICE)
     public PublicHolidaysDto getPublicHolidays(
         @Parameter(description = "Start date with pattern yyyy-MM-dd")
@@ -80,7 +78,7 @@ public class PublicHolidayApiController {
         summary = "Get all public holidays for a certain period", description = "Get all public holidays for a certain period. "
         + "Information only reachable for users with role office and for own public holidays."
     )
-    @GetMapping("/persons/{personId}/" + PUBLIC_HOLIDAYS)
+    @GetMapping("/persons/{personId}/public-holidays")
     @PreAuthorize(IS_OFFICE +
         " or @userApiMethodSecurity.isSamePersonId(authentication, #personId)" +
         " or @userApiMethodSecurity.isInDepartmentOfDepartmentHead(authentication, #personId)")

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
@@ -66,11 +66,19 @@ public class PublicHolidaysServiceImpl implements PublicHolidaysService {
     }
 
     private Set<Holiday> getHolidays(final LocalDate from, final LocalDate to, FederalState federalState) {
-        return holidayManagers.get(federalState.getCountry()).getHolidays(from, to, federalState.getCodes());
+        return getHolidayManager(federalState)
+            .map(holidayManager -> holidayManager.getHolidays(from, to, federalState.getCodes()))
+            .orElseGet(Set::of);
     }
 
     private boolean isPublicHoliday(LocalDate date, FederalState federalState) {
-        return holidayManagers.get(federalState.getCountry()).isHoliday(date, federalState.getCodes());
+        return getHolidayManager(federalState)
+            .map(holidayManager -> holidayManager.isHoliday(date, federalState.getCodes()))
+            .orElse(false);
+    }
+
+    private Optional<HolidayManager> getHolidayManager(FederalState federalState) {
+        return Optional.ofNullable(holidayManagers.get(federalState.getCountry()));
     }
 
     private WorkingTimeSettings getWorkingTimeSettings() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteValidator.java
@@ -152,10 +152,8 @@ public class SickNoteValidator implements Validator {
     private void validateNoOverlapping(SickNote sickNote, Errors errors) {
 
         // Ensure the person has a working time for the period of the sick note
-        final Optional<WorkingTime> workingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
-            sickNote.getPerson(), sickNote.getStartDate());
-
-        if (workingTime.isEmpty()) {
+        final Optional<WorkingTime> maybeWorkingTime = workingTimeService.getWorkingTime(sickNote.getPerson(), sickNote.getStartDate());
+        if (maybeWorkingTime.isEmpty()) {
             errors.reject(ERROR_WORKING_TIME);
             return;
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
@@ -1,10 +1,10 @@
 package org.synyx.urlaubsverwaltung.workingtime;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
 
 /**
  * Enum representing the federal states of Germany. The information about the federal state is needed to check if a day
@@ -12,6 +12,8 @@ import java.util.Map;
  * different public holidays).
  */
 public enum FederalState {
+
+    NONE("none"),
 
     GERMANY_BADEN_WUERTTEMBERG("de", "bw"),
     GERMANY_BAYERN("de", "by"),
@@ -92,13 +94,15 @@ public enum FederalState {
         return codes[0];
     }
 
+    /**
+     * Returns a map of a country identifier and a list of federal states that this country has.
+     * Does not return "none" (No publix holiday regulation) and the default
+     *
+     * @return Map of countries with a list of their federal states
+     */
     public static Map<String, List<FederalState>> federalStatesTypesByCountry() {
-
-        final Map<String, List<FederalState>> federalStatesTypesByCountry = new HashMap<>();
-
-        Arrays.stream(values()).forEach(federalState ->
-            federalStatesTypesByCountry.computeIfAbsent(federalState.getCountry(), country -> new ArrayList<>()).add(federalState));
-
-        return federalStatesTypesByCountry;
+        return Arrays.stream(values())
+            .filter(federalState -> federalState != NONE)
+            .collect(groupingBy(FederalState::getCountry));
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
@@ -2,6 +2,7 @@ package org.synyx.urlaubsverwaltung.workingtime;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
@@ -10,16 +11,14 @@ import org.synyx.urlaubsverwaltung.util.DateUtil;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static org.synyx.urlaubsverwaltung.util.DateFormat.DD_MM_YYYY;
 
-
-/**
- * Service for calendar purpose.
- */
 @Service
 public class WorkDaysCountService {
 
@@ -65,7 +64,6 @@ public class WorkDaysCountService {
         return workDays;
     }
 
-
     /**
      * This method calculates how many workdays are used in the stated period (from start date to end date) considering
      * the personal working time of the given person, getNumberOfPublicHolidays calculates the number of official
@@ -80,22 +78,24 @@ public class WorkDaysCountService {
      */
     public BigDecimal getWorkDaysCount(DayLength dayLength, LocalDate startDate, LocalDate endDate, Person person) {
 
-        // FIXME - wenn eine Application sehr lang ist und dazwischen die WorkingTime geändert wird und an einem Tag
-        //  nicht mehr gearbeitet dann stimmt das hier nicht mehr!?
-        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getWorkingTime(person, startDate);
-        if (optionalWorkingTime.isEmpty()) {
-            throw new WorkDaysCountException("No working time found for User '" + person.getId()
+        final DateRange dateRange = new DateRange(startDate, endDate);
+
+        final Map<DateRange, WorkingTime> workingTimes = workingTimeService.getWorkingTimesByPersonAndDateRange(person, dateRange);
+        if (workingTimes.isEmpty()) {
+            throw new WorkDaysCountException("No working times found for user '" + person.getId()
                 + "' in period " + startDate.format(ofPattern(DD_MM_YYYY)) + " - " + endDate.format(ofPattern(DD_MM_YYYY)));
         }
 
-        final WorkingTime workingTime = optionalWorkingTime.get();
-        final FederalState federalState = workingTime.getFederalState();
+        final Map<LocalDate, WorkingTime> workingTimesByDate = toLocalDateWorkingTime(workingTimes);
 
         BigDecimal vacationDays = BigDecimal.ZERO;
         LocalDate day = startDate;
         while (!day.isAfter(endDate)) {
+
+            final WorkingTime workingTime = workingTimesByDate.get(day);
+
             // value may be 1 for public holiday, 0 for not public holiday or 0.5 for Christmas Eve or New Year's Eve
-            final Optional<PublicHoliday> maybePublicHoliday = publicHolidaysService.getPublicHoliday(day, federalState);
+            final Optional<PublicHoliday> maybePublicHoliday = publicHolidaysService.getPublicHoliday(day, workingTime.getFederalState());
             final BigDecimal duration = maybePublicHoliday.isPresent() ? maybePublicHoliday.get().getWorkingDuration() : BigDecimal.ONE;
 
             final BigDecimal workingDuration = workingTime.getDayLengthForWeekDay(day.getDayOfWeek()).getDuration();
@@ -113,5 +113,11 @@ public class WorkDaysCountService {
         }
 
         return vacationDays.multiply(dayLength.getDuration()).setScale(1, UNNECESSARY);
+    }
+
+    private Map<LocalDate, WorkingTime> toLocalDateWorkingTime(Map<DateRange, WorkingTime> workingTimes) {
+        final Map<LocalDate, WorkingTime> localDateWorkingTimeMap = new HashMap<>();
+        workingTimes.forEach((key, value) -> key.iterator().forEachRemaining(localDate -> localDateWorkingTimeMap.put(localDate, value)));
+        return localDateWorkingTimeMap;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
@@ -80,6 +80,8 @@ public class WorkDaysCountService {
      */
     public BigDecimal getWorkDaysCount(DayLength dayLength, LocalDate startDate, LocalDate endDate, Person person) {
 
+        // FIXME - wenn eine Application sehr lang ist und dazwischen die WorkingTime geändert wird und an einem Tag
+        //  nicht mehr gearbeitet dann stimmt das hier nicht mehr!?
         final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
             person, startDate);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
@@ -82,9 +82,7 @@ public class WorkDaysCountService {
 
         // FIXME - wenn eine Application sehr lang ist und dazwischen die WorkingTime geändert wird und an einem Tag
         //  nicht mehr gearbeitet dann stimmt das hier nicht mehr!?
-        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(
-            person, startDate);
-
+        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getWorkingTime(person, startDate);
         if (optionalWorkingTime.isEmpty()) {
             throw new WorkDaysCountException("No working time found for User '" + person.getId()
                 + "' in period " + startDate.format(ofPattern(DD_MM_YYYY)) + " - " + endDate.format(ofPattern(DD_MM_YYYY)));

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTime.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTime.java
@@ -28,6 +28,7 @@ public class WorkingTime {
     private final Person person;
     private final LocalDate validFrom;
     private final FederalState federalState;
+    private final boolean isDefaultFederalState;
     private DayLength monday = ZERO;
     private DayLength tuesday = ZERO;
     private DayLength wednesday = ZERO;
@@ -36,10 +37,11 @@ public class WorkingTime {
     private DayLength saturday = ZERO;
     private DayLength sunday = ZERO;
 
-    public WorkingTime(Person person, LocalDate validFrom, FederalState federalState) {
+    public WorkingTime(Person person, LocalDate validFrom, FederalState federalState, boolean isDefaultFederalState) {
         this.person = person;
         this.validFrom = validFrom;
         this.federalState = federalState;
+        this.isDefaultFederalState = isDefaultFederalState;
     }
 
     public Person getPerson() {
@@ -52,6 +54,10 @@ public class WorkingTime {
 
     public FederalState getFederalState() {
         return federalState;
+    }
+
+    public boolean isDefaultFederalState() {
+        return isDefaultFederalState;
     }
 
     public DayLength getMonday() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeForm.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeForm.java
@@ -4,16 +4,19 @@ import org.synyx.urlaubsverwaltung.period.DayLength;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE;
+import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
 
 public class WorkingTimeForm {
 
     private LocalDate validFrom;
     private List<Integer> workingDays = new ArrayList<>();
     private FederalState federalState;
+    private boolean isDefaultFederalState;
 
     WorkingTimeForm() {
         // OK
@@ -22,16 +25,15 @@ public class WorkingTimeForm {
     WorkingTimeForm(WorkingTime workingTime) {
 
         for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
-
-            DayLength dayLength = workingTime.getDayLengthForWeekDay(dayOfWeek);
-
-            if (dayLength != DayLength.ZERO) {
+            final DayLength dayLength = workingTime.getDayLengthForWeekDay(dayOfWeek);
+            if (dayLength != ZERO) {
                 workingDays.add(dayOfWeek.getValue());
             }
         }
 
         this.validFrom = workingTime.getValidFrom();
         this.federalState = workingTime.getFederalState();
+        this.isDefaultFederalState = workingTime.isDefaultFederalState();
     }
 
     public String getValidFromIsoValue() {
@@ -39,7 +41,7 @@ public class WorkingTimeForm {
             return "";
         }
 
-        return validFrom.format(DateTimeFormatter.ISO_DATE);
+        return validFrom.format(ISO_DATE);
     }
 
     public LocalDate getValidFrom() {
@@ -66,18 +68,27 @@ public class WorkingTimeForm {
         this.federalState = federalState;
     }
 
+    public boolean isDefaultFederalState() {
+        return isDefaultFederalState;
+    }
+
+    public void setDefaultFederalState(boolean defaultFederalState) {
+        isDefaultFederalState = defaultFederalState;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WorkingTimeForm that = (WorkingTimeForm) o;
-        return Objects.equals(validFrom, that.validFrom) &&
-            Objects.equals(workingDays, that.workingDays) &&
-            federalState == that.federalState;
+        return isDefaultFederalState == that.isDefaultFederalState
+            && Objects.equals(validFrom, that.validFrom)
+            && Objects.equals(workingDays, that.workingDays)
+            && federalState == that.federalState;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(validFrom, workingDays, federalState);
+        return Objects.hash(validFrom, workingDays, federalState, isDefaultFederalState);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -10,8 +10,29 @@ import java.util.Optional;
 
 public interface WorkingTimeService {
 
+    /**
+     * Returns a list of working times for the given person.
+     * <p>
+     * Note: The federal state of the working times are either
+     * the default federate state based on the settings
+     * or the user specific. But never empty.
+     *
+     * @param person to get all working times
+     * @return list of all working times of a person
+     */
     List<WorkingTime> getByPerson(Person person);
 
+    /**
+     * Returns a map of date ranges and the associated federal state.
+     * <p>
+     * Note: The federal state of the {@link DateRange} is either
+     * the default federate state based on the settings
+     * or the user specific. But never empty.
+     *
+     * @param person    to get the federal states
+     * @param dateRange to specify the
+     * @return map of date ranges and the associated federal state of a person
+     */
     Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange);
 
     List<WorkingTime> getByPersons(List<Person> persons);

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -11,6 +11,15 @@ import java.util.Optional;
 public interface WorkingTimeService {
 
     /**
+     * Returns the used working time of the given person and date.
+     *
+     * @param person to check for working time
+     * @param date   on this given date
+     * @return working time of person, otherwise empty optional
+     */
+    Optional<WorkingTime> getWorkingTime(Person person, LocalDate date);
+
+    /**
      * Returns a list of working times for the given person.
      * <p>
      * Note: The federal state of the working times are either
@@ -49,8 +58,6 @@ public interface WorkingTimeService {
     Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange);
 
     List<WorkingTime> getByPersons(List<Person> persons);
-
-    Optional<WorkingTime> getByPersonAndValidityDateEqualsOrMinorDate(Person person, LocalDate date);
 
     FederalState getFederalStateForPerson(Person person, LocalDate date);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -32,6 +32,18 @@ public interface WorkingTimeService {
     List<WorkingTime> getByPerson(Person person);
 
     /**
+     * Returns a list of working times for the given persons.
+     * <p>
+     * Note: The federal state of the working times are either
+     * the default federate state based on the settings
+     * or the user specific. But never empty.
+     *
+     * @param persons to get all working times of
+     * @return list of all working times of the persons
+     */
+    List<WorkingTime> getByPersons(List<Person> persons);
+
+    /**
      * Returns a map of date ranges and the associated working time.
      * <p>
      * Note: The federal state of the working time is either
@@ -56,8 +68,6 @@ public interface WorkingTimeService {
      * @return map of date ranges and the associated federal state of a person
      */
     Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange);
-
-    List<WorkingTime> getByPersons(List<Person> persons);
 
     /**
      * Returns the federal state of a person.

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -59,7 +59,23 @@ public interface WorkingTimeService {
 
     List<WorkingTime> getByPersons(List<Person> persons);
 
+    /**
+     * Returns the federal state of a person.
+     * <p>
+     * Note: That the federal state is either
+     * the default federate state based on the settings
+     * or the user specific.
+     *
+     * @param person to get the current federal state of
+     * @param date   of this given date
+     * @return the federal state of the given date and person
+     */
     FederalState getFederalStateForPerson(Person person, LocalDate date);
 
+    /**
+     * Returns the default federal state based on the settings
+     *
+     * @return default federal state
+     */
     FederalState getSystemDefaultFederalState();
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -23,6 +23,19 @@ public interface WorkingTimeService {
     List<WorkingTime> getByPerson(Person person);
 
     /**
+     * Returns a map of date ranges and the associated working time.
+     * <p>
+     * Note: The federal state of the working time is either
+     * the default federate state based on the settings
+     * or the user specific. But never empty.
+     *
+     * @param person    to get the working times
+     * @param dateRange to specify the
+     * @return map of date ranges and the associated working times of a person
+     */
+    Map<DateRange, WorkingTime> getWorkingTimesByPersonAndDateRange(Person person, DateRange dateRange);
+
+    /**
      * Returns a map of date ranges and the associated federal state.
      * <p>
      * Note: The federal state of the {@link DateRange} is either

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -121,7 +121,7 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     @Override
     public Optional<WorkingTime> getByPersonAndValidityDateEqualsOrMinorDate(Person person, LocalDate date) {
         return Optional.ofNullable(workingTimeRepository.findByPersonAndValidityDateEqualsOrMinorDate(person, date))
-            .map(entity -> toWorkingTimes(entity, this::getSystemDefaultFederalState));
+            .map(entity -> toWorkingTime(entity, this::getSystemDefaultFederalState));
     }
 
     @Override
@@ -155,10 +155,10 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
         this.touch(defaultWorkingDays, today, person);
     }
 
-    private List<WorkingTime> toWorkingTimes(List<WorkingTimeEntity> entities) {
+    private List<WorkingTime> toWorkingTimes(List<WorkingTimeEntity> workingTimeEntities) {
         final CachedSupplier<FederalState> federalStateCachedSupplier = new CachedSupplier<>(this::getSystemDefaultFederalState);
-        return entities.stream()
-            .map(entity -> toWorkingTimes(entity, federalStateCachedSupplier))
+        return workingTimeEntities.stream()
+            .map(workingTime -> toWorkingTime(workingTime, federalStateCachedSupplier))
             .collect(toList());
     }
 
@@ -198,7 +198,7 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
         }
     }
 
-    private static WorkingTime toWorkingTimes(WorkingTimeEntity workingTimeEntity, Supplier<FederalState> defaultFederalStateProvider) {
+    private static WorkingTime toWorkingTime(WorkingTimeEntity workingTimeEntity, Supplier<FederalState> defaultFederalStateProvider) {
 
         final FederalState federalState = workingTimeEntity.getFederalStateOverride() == null
             ? defaultFederalStateProvider.get()

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -206,11 +206,10 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
 
     private static WorkingTime toWorkingTime(WorkingTimeEntity workingTimeEntity, Supplier<FederalState> defaultFederalStateProvider) {
 
-        final FederalState federalState = workingTimeEntity.getFederalStateOverride() == null
-            ? defaultFederalStateProvider.get()
-            : workingTimeEntity.getFederalStateOverride();
+        final boolean isDefaultFederalState = workingTimeEntity.getFederalStateOverride() == null;
+        final FederalState federalState = isDefaultFederalState ? defaultFederalStateProvider.get() : workingTimeEntity.getFederalStateOverride();
 
-        final WorkingTime workingTime = new WorkingTime(workingTimeEntity.getPerson(), workingTimeEntity.getValidFrom(), federalState);
+        final WorkingTime workingTime = new WorkingTime(workingTimeEntity.getPerson(), workingTimeEntity.getValidFrom(), federalState, isDefaultFederalState);
 
         for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
             final DayLength dayLength = dayLengthForDayOfWeek(workingTimeEntity, dayOfWeek);

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -88,6 +88,11 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     }
 
     @Override
+    public List<WorkingTime> getByPersons(List<Person> persons) {
+        return toWorkingTimes(workingTimeRepository.findByPersonIn(persons));
+    }
+
+    @Override
     public Map<DateRange, WorkingTime> getWorkingTimesByPersonAndDateRange(Person person, DateRange dateRange) {
 
         final List<WorkingTime> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonOrderByValidFromDesc(person));
@@ -123,11 +128,6 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     public Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange) {
         return getWorkingTimesByPersonAndDateRange(person, dateRange).entrySet().stream()
             .collect(toMap(Map.Entry::getKey, dateRangeWorkingTimeEntry -> dateRangeWorkingTimeEntry.getValue().getFederalState()));
-    }
-
-    @Override
-    public List<WorkingTime> getByPersons(List<Person> persons) {
-        return toWorkingTimes(workingTimeRepository.findByPersonIn(persons));
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -76,6 +76,12 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     }
 
     @Override
+    public Optional<WorkingTime> getWorkingTime(Person person, LocalDate date) {
+        return Optional.ofNullable(workingTimeRepository.findByPersonAndValidityDateEqualsOrMinorDate(person, date))
+            .map(entity -> toWorkingTime(entity, this::getSystemDefaultFederalState));
+    }
+
+    @Override
     public List<WorkingTime> getByPerson(Person person) {
         return toWorkingTimes(workingTimeRepository.findByPersonOrderByValidFromDesc(person));
     }
@@ -151,14 +157,8 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     }
 
     @Override
-    public Optional<WorkingTime> getByPersonAndValidityDateEqualsOrMinorDate(Person person, LocalDate date) {
-        return Optional.ofNullable(workingTimeRepository.findByPersonAndValidityDateEqualsOrMinorDate(person, date))
-            .map(entity -> toWorkingTime(entity, this::getSystemDefaultFederalState));
-    }
-
-    @Override
     public FederalState getFederalStateForPerson(Person person, LocalDate date) {
-        return getByPersonAndValidityDateEqualsOrMinorDate(person, date)
+        return getWorkingTime(person, date)
             .map(WorkingTime::getFederalState)
             .orElseGet(() -> {
                 LOG.debug("No working time found for user '{}' equals or minor {}, using system federal state as fallback",

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewController.java
@@ -69,8 +69,7 @@ public class WorkingTimeViewController {
         throws UnknownPersonException {
 
         final Person person = personService.getPersonByID(personId).orElseThrow(() -> new UnknownPersonException(personId));
-        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(person, LocalDate.now(clock));
-
+        final Optional<WorkingTime> optionalWorkingTime = workingTimeService.getWorkingTime(person, LocalDate.now(clock));
         if (optionalWorkingTime.isPresent()) {
             model.addAttribute("workingTime", new WorkingTimeForm(optionalWorkingTime.get()));
         } else {
@@ -108,16 +107,16 @@ public class WorkingTimeViewController {
         model.addAttribute(PERSON_ATTRIBUTE, person);
 
         final List<WorkingTime> workingTimeHistories = workingTimeService.getByPerson(person);
-        final WorkingTime currentWorkingTime = workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(person, LocalDate.now(clock)).orElse(null);
+        final WorkingTime currentWorkingTime = workingTimeService.getWorkingTime(person, LocalDate.now(clock)).orElse(null);
         final FederalState defaultFederalState = settingsService.getSettings().getWorkingTimeSettings().getFederalState();
 
-        model.addAttribute("workingTimeHistories", map(currentWorkingTime, workingTimeHistories));
+        model.addAttribute("workingTimeHistories", toWorkingTimeHistoryDtos(currentWorkingTime, workingTimeHistories));
         model.addAttribute("weekDays", DayOfWeek.values());
         model.addAttribute("federalStateTypes", FederalState.federalStatesTypesByCountry());
         model.addAttribute("defaultFederalState", defaultFederalState);
     }
 
-    private List<WorkingTimeHistoryDto> map(WorkingTime currentWorkingTime, List<WorkingTime> workingTimes) {
+    private List<WorkingTimeHistoryDto> toWorkingTimeHistoryDtos(WorkingTime currentWorkingTime, List<WorkingTime> workingTimes) {
         return workingTimes.stream()
             .map(toWorkingTimeHistoryDto(currentWorkingTime))
             .collect(toList());

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -602,8 +602,8 @@ person.form.workingTime.valid-from=Gütig ab
 person.form.workingTime.valid-from-to=Gültig von {0} bis {1}
 person.form.workingTime.weekDays=Wochentage
 person.form.workingTime.error.mandatory=Es muss mindestens ein Wochentag ausgewählt werden.
-person.form.workingTime.federalState.description=Wenn die systemweite Einstellung der Feiertagsregelung ({0} - {1}) für diesen Benutzer unzutreffend ist, kann eine abweichende Feiertagsregelung eingestellt werden, um spezifische Feiertage zu berücksichtigen.
-person.form.workingTime.federalState.default=Systemweite Einstellung ({0} - {1})
+person.form.workingTime.federalState.description=Wenn die systemweite Einstellung der Feiertagsregelung ({0}) für diesen Benutzer unzutreffend ist, kann eine abweichende Feiertagsregelung eingestellt werden, um spezifische Feiertage zu berücksichtigen.
+person.form.workingTime.federalState.default=Systemweite Einstellung ({0})
 
 # Departments
 person.form.departments.title=Zugeordnete Abteilungen
@@ -626,7 +626,7 @@ person.account.annualVacation.title=Urlaubsanspruch für
 person.account.workingTime.title=Arbeitszeiten
 person.account.workingTime.none=Keine Angabe möglich.
 person.account.workingTime.validity=seit
-person.account.workingTime.federalState=angestellt in
+person.account.workingTime.federalState=anhand von
 person.account.federalState.title=Feiertagsregelung
 # action
 person.account.action.create.success=Der Benutzer wurde erfolgreich angelegt.
@@ -815,9 +815,13 @@ settings.action.update.success=Die Einstellungen wurden gespeichert.
 settings.action.update.error=Die Einstellungen konnten nicht aktualisiert werden. Bitte die fehlerhaften Eingaben korrigieren und erneut auf "Speichern" klicken.
 
 # Countries
+country.general=Allgemein
 country.de=Deutschland
 country.at=Österreich
 country.ch=Schweiz
+
+# No Federal States
+federalState.NONE=Keine Feiertagesregelung
 
 # Federal States Germany
 federalState.GERMANY_BADEN_WUERTTEMBERG=Baden-Württemberg

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -597,8 +597,8 @@ person.form.workingTime.valid-from=Valid since
 person.form.workingTime.valid-from-to=Validity period from {0} to {1}
 person.form.workingTime.weekDays=Weekdays
 person.form.workingTime.error.mandatory=At least one weekday must be selected.
-person.form.workingTime.federalState.description=If the system-wide public holiday regulation ({0} - {1}) setting does not match for this user, it's possible to override.
-person.form.workingTime.federalState.default=System-wide setting ({0} - {1})
+person.form.workingTime.federalState.description=If the system-wide public holiday regulation ({0}) setting does not match for this user, it's possible to override.
+person.form.workingTime.federalState.default=System-wide setting ({0})
 
 # Departments
 person.form.departments.title=Departments assigned
@@ -621,7 +621,7 @@ person.account.annualVacation.title=Vacation entitlement for
 person.account.workingTime.title=Working time
 person.account.workingTime.none=No information available.
 person.account.workingTime.validity=since
-person.account.workingTime.federalState=hired in
+person.account.workingTime.federalState=based on
 person.account.federalState.title=Public holiday regulation
 # action
 person.account.action.create.success=The user was created successfully.
@@ -809,9 +809,13 @@ settings.action.update.success=The settings have been updated.
 settings.action.update.error=The settings could not be updated. Please correct the incorrect entries and click on "Save" again.
 
 # Countries
+country.general=General
 country.de=Germany
 country.at=Austria
 country.ch=Switzerland
+
+# No Federal States
+federalState.NONE=No public holiday regulation
 
 # Federal States Germany
 federalState.GERMANY_BADEN_WUERTTEMBERG=Baden-Württemberg

--- a/src/main/webapp/WEB-INF/jsp/person/person_detail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/person/person_detail.jsp
@@ -314,14 +314,23 @@
                         </uv:box-icon>
                     </jsp:attribute>
                     <jsp:body>
-                        <p>
-                            <span class="tw-block tw-mb-1 tw-text-sm">
-                                <spring:message code="person.account.workingTime.federalState"/>
-                            </span>
-                            <span class="tw-text-base tw-font-medium">
-                                <spring:message code="country.${federalState.country}"/> - <spring:message code="federalState.${federalState}"/>
-                            </span>
-                        </p>
+                        <c:choose>
+                            <c:when test="${federalState == 'NONE'}">
+                                <span class="tw-text-base tw-font-medium">
+                                    <spring:message code="federalState.NONE"/>
+                                </span>
+                            </c:when>
+                            <c:otherwise>
+                                <p>
+                                    <span class="tw-block tw-mb-1 tw-text-sm">
+                                        <spring:message code="person.account.workingTime.federalState"/>
+                                    </span>
+                                    <span class="tw-text-base tw-font-medium">
+                                        <spring:message code="country.${federalState.country}"/> - <spring:message code="federalState.${federalState}"/>
+                                    </span>
+                                </p>
+                            </c:otherwise>
+                        </c:choose>
                     </jsp:body>
                 </uv:box>
             </div>

--- a/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/settings/settings_form.jsp
@@ -723,6 +723,12 @@
 
                                     <div class="col-md-8">
                                         <uv:select id="federalStateType" name="workingTimeSettings.federalState">
+                                            <c:set var="countryLabelGeneral"><spring:message code="country.general" /></c:set>
+                                            <optgroup label="${countryLabelGeneral}">
+                                                <option value="NONE" ${settings.workingTimeSettings.federalState == "NONE" ? 'selected="selected"' : ''}>
+                                                    <spring:message code="federalState.NONE"/>
+                                                </option>
+                                            </optgroup>
                                             <c:forEach items="${federalStateTypes}" var="federalStatesByCountry">
                                                 <c:set var="countryLabel"><spring:message code="country.${federalStatesByCountry.key}" /></c:set>
                                                 <optgroup label="${countryLabel}">

--- a/src/main/webapp/WEB-INF/jsp/workingtime/workingtime_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/workingtime/workingtime_form.jsp
@@ -66,8 +66,16 @@
                         <span class="help-block tw-text-sm">
                             <icon:information-circle className="tw-w-4 tw-h-4" solid="true" />
                             <spring:message code="federalState.${defaultFederalState}" var="defaultFederalStateName"/>
-                            <spring:message code="country.${defaultFederalState.country}" var="defaultCountryName"/>
-                            <spring:message code="person.form.workingTime.federalState.description" arguments="${defaultCountryName}, ${defaultFederalStateName}"/>
+                            <c:choose>
+                                <c:when test="${defaultFederalState == 'NONE'}">
+                                    <c:set var="defaultFederalCountryAndStateName">${defaultFederalStateName}</c:set>
+                                </c:when>
+                                <c:otherwise>
+                                    <spring:message code="country.${defaultFederalState.country}" var="defaultCountryName"/>
+                                    <c:set var="defaultFederalCountryAndStateName">${defaultCountryName} - ${defaultFederalStateName}</c:set>
+                                </c:otherwise>
+                            </c:choose>
+                            <spring:message code="person.form.workingTime.federalState.description" arguments="${defaultFederalCountryAndStateName}"/>
                         </span>
                         <span class="help-block tw-text-sm">
                             <icon:information-circle className="tw-w-4 tw-h-4" solid="true" />
@@ -83,16 +91,20 @@
 
                             <div class="col-md-9">
                                 <uv:select id="federalStateType" name="federalState">
-                                    <optgroup label="">
-                                        <option value="">
-                                            <spring:message code="person.form.workingTime.federalState.default" arguments="${defaultCountryName}, ${defaultFederalStateName}" />
+                                    <c:set var="countryLabelGeneral"><spring:message code="country.general"/></c:set>
+                                    <optgroup label="${countryLabelGeneral}">
+                                        <option value="" ${workingTime.defaultFederalState == true ? 'selected="selected"' : ''}>
+                                            <spring:message code="person.form.workingTime.federalState.default" arguments="${defaultFederalCountryAndStateName}" />
+                                        </option>
+                                        <option value="NONE" ${workingTime.defaultFederalState == false && workingTime.federalState == "NONE" ? 'selected="selected"' : ''}>
+                                            <spring:message code="federalState.NONE"/>
                                         </option>
                                     </optgroup>
                                     <c:forEach items="${federalStateTypes}" var="federalStatesByCountry">
                                         <c:set var="countryLabel"><spring:message code="country.${federalStatesByCountry.key}" /></c:set>
                                         <optgroup label="${countryLabel}">
                                             <c:forEach items="${federalStatesByCountry.value}" var="federalStateType">
-                                                <option value="${federalStateType}" ${settings.workingTimeSettings.federalState == federalStateType ? 'selected="selected"' : ''}>
+                                                <option value="${federalStateType}" ${workingTime.defaultFederalState == false && workingTime.federalState == federalStateType ? 'selected="selected"' : ''}>
                                                     <spring:message code="federalState.${federalStateType}"/>
                                                 </option>
                                             </c:forEach>
@@ -169,7 +181,14 @@
                                                 </c:forEach>
 
                                                 <span class="tw-block">
-                                                    <spring:message code="country.${workingTimeHistory.country}"/> - <spring:message code="federalState.${workingTimeHistory.federalState}"/>
+                                                    <c:choose>
+                                                        <c:when test="${workingTimeHistory.federalState == 'NONE'}">
+                                                            <spring:message code="federalState.NONE"/>
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <spring:message code="country.${workingTimeHistory.country}"/> - <spring:message code="federalState.${workingTimeHistory.federalState}"/>
+                                                        </c:otherwise>
+                                                    </c:choose>
                                                 </span>
 
                                                 <c:set var="lastDate"><uv:date date="${workingTimeHistory.validFrom.minusDays(1)}"/></c:set>

--- a/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
@@ -179,7 +179,7 @@ public final class TestDataCreator {
         final Person person = new Person();
         person.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
 
         List<DayOfWeek> workingDays = List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         workingTime.setWorkingDays(workingDays, FULL);

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerSecurityIT.java
@@ -14,12 +14,16 @@ import org.synyx.urlaubsverwaltung.department.Department;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
+import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeWriteService;
 
 import java.time.LocalDate;
-import java.time.Month;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -35,12 +39,14 @@ class AbsenceApiControllerSecurityIT extends TestContainersBase {
 
     @MockBean
     private PersonService personService;
-
     @MockBean
     private DepartmentService departmentService;
-
     @MockBean
     private AbsenceService absenceService;
+    @MockBean
+    private WorkingTimeService workingTimeService;
+    @MockBean
+    private WorkingTimeWriteService workingTimeWriteService;
 
     @Test
     void getAbsencesWithoutBasicAuthIsUnauthorized() throws Exception {
@@ -94,7 +100,7 @@ class AbsenceApiControllerSecurityIT extends TestContainersBase {
         final List<Department> departments = List.of(department);
         when(departmentService.getManagedDepartmentsOfDepartmentHead(departmentHead)).thenReturn(departments);
 
-        when(absenceService.getOpenAbsences(person, LocalDate.of(2016, Month.JANUARY, 1), LocalDate.of(2016, Month.DECEMBER, 31)))
+        when(absenceService.getOpenAbsences(person, LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(emptyList());
 
         perform(get("/api/persons/1/absences")
@@ -152,7 +158,7 @@ class AbsenceApiControllerSecurityIT extends TestContainersBase {
         person.setUsername("user");
         when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
 
-        when(absenceService.getOpenAbsences(person, LocalDate.of(2016, Month.JANUARY, 1), LocalDate.of(2016, Month.DECEMBER, 31)))
+        when(absenceService.getOpenAbsences(person, LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(emptyList());
 
         perform(get("/api/persons/1/absences")
@@ -179,8 +185,10 @@ class AbsenceApiControllerSecurityIT extends TestContainersBase {
         final Person person = new Person();
         when(personService.getPersonByID(1)).thenReturn(Optional.of(person));
 
-        when(absenceService.getOpenAbsences(person, LocalDate.of(2016, Month.JANUARY, 1), LocalDate.of(2016, Month.DECEMBER, 31)))
-            .thenReturn(emptyList());
+        final LocalDate startDate = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2016, DECEMBER, 31);
+        when(workingTimeService.getFederalStatesByPersonAndDateRange(person, new DateRange(startDate, endDate))).thenReturn(Map.of());
+        when(absenceService.getOpenAbsences(person, startDate, endDate)).thenReturn(emptyList());
 
         perform(get("/api/persons/1/absences")
             .param("from", "2016-01-01")

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceServiceImplTest.java
@@ -197,7 +197,7 @@ class AbsenceServiceImplTest {
         final LocalDate start = LocalDate.of(2021, MAY, 1);
         final LocalDate end = LocalDate.of(2021, MAY, 31);
 
-        final WorkingTime workingTime = new WorkingTime(person, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
 
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
         when(workingTimeService.getSystemDefaultFederalState()).thenReturn(GERMANY_BADEN_WUERTTEMBERG);
@@ -229,7 +229,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -265,7 +265,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -325,10 +325,10 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTimePastToNow = new WorkingTime(batman, start, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTimePastToNow = new WorkingTime(batman, start, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTimePastToNow.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
 
-        final WorkingTime workingTimeFuture = new WorkingTime(batman, start.plusDays(10), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTimeFuture = new WorkingTime(batman, start.plusDays(10), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTimeFuture.setWorkingDays(List.of(WEDNESDAY, THURSDAY, FRIDAY), FULL);
 
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTimePastToNow, workingTimeFuture));
@@ -362,7 +362,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
         final SickNote sickNote = new SickNote();
@@ -395,7 +395,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
         final SickNote sickNote = new SickNote();
@@ -453,7 +453,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -506,7 +506,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -541,7 +541,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
         final SickNote sickNote = new SickNote();
@@ -574,7 +574,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -625,7 +625,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 
@@ -680,7 +680,7 @@ class AbsenceServiceImplTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(batman, start.minusDays(1), GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY), FULL);
         when(workingTimeService.getByPersons(any())).thenReturn(List.of(workingTime));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
@@ -93,7 +93,7 @@ class VacationDaysServiceTest {
         List<DayOfWeek> workingDays = List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         workingTime.setWorkingDays(workingDays, FULL);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         when(settingsService.getSettings()).thenReturn(new Settings());
@@ -163,7 +163,7 @@ class VacationDaysServiceTest {
         List<DayOfWeek> workingDays = List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         workingTime.setWorkingDays(workingDays, FULL);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         when(settingsService.getSettings()).thenReturn(new Settings());

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
@@ -90,7 +90,7 @@ class VacationDaysServiceTest {
         final LocalDate firstMilestone = LocalDate.of(2012, JANUARY, 1);
         final LocalDate lastMilestone = LocalDate.of(2012, MARCH, 31);
 
-        final WorkingTime workingTime = new WorkingTime(person, firstMilestone, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, firstMilestone, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(firstMilestone, lastMilestone), workingTime));
 
@@ -156,7 +156,7 @@ class VacationDaysServiceTest {
         final LocalDate firstMilestone = LocalDate.of(2012, APRIL, 1);
         final LocalDate lastMilestone = LocalDate.of(2012, DECEMBER, 31);
 
-        final WorkingTime workingTime = new WorkingTime(person, firstMilestone, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, firstMilestone, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(firstMilestone, lastMilestone), workingTime));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
@@ -224,7 +224,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -246,7 +246,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -268,7 +268,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -291,7 +291,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -310,7 +310,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -329,7 +329,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -348,7 +348,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -372,7 +372,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -417,7 +417,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -439,7 +439,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -459,7 +459,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -480,7 +480,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -501,7 +501,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -523,7 +523,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class)))
             .thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class),
             any(Person.class))).thenReturn(BigDecimal.ZERO);
@@ -542,7 +542,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         appForm.setDayLength(FULL);
         appForm.setStartDate(LocalDate.now(UTC));
@@ -564,7 +564,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         appForm.setDayLength(NOON);
         appForm.setStartDate(LocalDate.now(UTC));
@@ -589,7 +589,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class),
             any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(OverlapCase.FULLY_OVERLAPPING);
@@ -608,7 +608,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -626,7 +626,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -656,7 +656,7 @@ class ApplicationForLeaveFormValidatorTest {
     void ensureHoursIsNotMandatoryForOvertimeIfOvertimeFunctionIsDeactivated() {
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -678,7 +678,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -699,7 +699,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -728,7 +728,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -747,7 +747,7 @@ class ApplicationForLeaveFormValidatorTest {
         final Settings settings = setupOvertimeSettings();
         settings.getOvertimeSettings().setMinimumOvertimeReduction(4);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
 
         final VacationType overtimeVacationType = new VacationType(1, true, OVERTIME, "message_key", true);
@@ -768,7 +768,7 @@ class ApplicationForLeaveFormValidatorTest {
         final Settings settings = setupOvertimeSettings();
         settings.getOvertimeSettings().setMinimumOvertimeReduction(4);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
 
         final VacationType overtimeVacationType = new VacationType(1, true, OVERTIME, "message_key", true);
@@ -788,7 +788,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -808,7 +808,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -828,7 +828,7 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(overtimeService.getLeftOvertimeForPerson(any(Person.class))).thenReturn(Duration.ofHours(10));
@@ -845,7 +845,7 @@ class ApplicationForLeaveFormValidatorTest {
     void ensureNoErrorMessageForMandatoryIfHoursIsNullBecauseOfTypeMismatch() {
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -869,14 +869,14 @@ class ApplicationForLeaveFormValidatorTest {
         setupOvertimeSettings();
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             eq(appForm.getStartDate()))).thenReturn(Optional.empty());
 
         sut.validate(appForm, errors);
 
         verify(errors).reject("application.error.noValidWorkingTime");
 
-        verify(workingTimeService).getByPersonAndValidityDateEqualsOrMinorDate(appForm.getPerson(), appForm.getStartDate());
+        verify(workingTimeService).getWorkingTime(appForm.getPerson(), appForm.getStartDate());
         verifyNoInteractions(workDaysCountService);
         verifyNoInteractions(overlapService);
         verifyNoInteractions(calculationService);
@@ -893,7 +893,7 @@ class ApplicationForLeaveFormValidatorTest {
 
         when(errors.hasErrors()).thenReturn(FALSE);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             eq(appForm.getStartDate())))
             .thenReturn(Optional.empty());
 
@@ -901,7 +901,7 @@ class ApplicationForLeaveFormValidatorTest {
 
         verify(errors).reject("application.error.noValidWorkingTime");
 
-        verify(workingTimeService).getByPersonAndValidityDateEqualsOrMinorDate(appForm.getPerson(), appForm.getStartDate());
+        verify(workingTimeService).getWorkingTime(appForm.getPerson(), appForm.getStartDate());
         verifyNoInteractions(workDaysCountService);
         verifyNoInteractions(overlapService);
         verifyNoInteractions(calculationService);
@@ -919,7 +919,7 @@ class ApplicationForLeaveFormValidatorTest {
     void ensureErrorDueToMinimumOvertimeReached() {
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -939,7 +939,7 @@ class ApplicationForLeaveFormValidatorTest {
     void ensureNoErrorDueToExactMinimumOvertimeReached() {
 
         when(errors.hasErrors()).thenReturn(FALSE);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
 
@@ -958,7 +958,7 @@ class ApplicationForLeaveFormValidatorTest {
         final Person person = new Person();
         person.setId(1);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
 
@@ -982,7 +982,7 @@ class ApplicationForLeaveFormValidatorTest {
     @Test
     void ensureAlreadyAbsentOnChristmasEveMorning() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1009,7 +1009,7 @@ class ApplicationForLeaveFormValidatorTest {
 
         setupOvertimeSettings();
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1033,7 +1033,7 @@ class ApplicationForLeaveFormValidatorTest {
     @Test
     void ensureAlreadyAbsentOnChristmasEveNoon() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1059,7 +1059,7 @@ class ApplicationForLeaveFormValidatorTest {
     @EnumSource(value = DayLength.class, names = {"FULL", "NOON", "MORNING"})
     void ensureAlreadyAbsentOnChristmasEveForGivenDayLengthRequest(final DayLength dayLength) {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1085,7 +1085,7 @@ class ApplicationForLeaveFormValidatorTest {
     @Test
     void ensureAlreadyAbsentOnNewYearsEveMorning() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1110,7 +1110,7 @@ class ApplicationForLeaveFormValidatorTest {
     @Test
     void ensureAlreadyAbsentOnNewYearsEveMorningIsNotTriggered() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
@@ -1135,7 +1135,7 @@ class ApplicationForLeaveFormValidatorTest {
     @Test
     void ensureAlreadyAbsentOnNewYearsEveNoon() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
         when(settingsService.getSettings()).thenReturn(createSettingsForNewYearsEveWithAbsence(NOON));
@@ -1161,7 +1161,7 @@ class ApplicationForLeaveFormValidatorTest {
     @EnumSource(value = DayLength.class, names = {"FULL", "NOON", "MORNING"})
     void ensureAlreadyAbsentOnNewYearsEveForGivenDayLengthRequest(final DayLength dayLength) {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class))).thenReturn(ONE);
         when(overlapService.checkOverlap(any(Application.class))).thenReturn(NO_OVERLAPPING);
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.account.Account;
 import org.synyx.urlaubsverwaltung.account.AccountInteractionService;
 import org.synyx.urlaubsverwaltung.account.AccountService;
@@ -43,6 +44,7 @@ import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.util.DateUtil.getFirstDayOfYear;
@@ -72,17 +74,9 @@ class CalculationServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final PublicHolidaysService publicHolidaysService = new PublicHolidaysServiceImpl(settingsService, Map.of("de", getHolidayManager()));
         final WorkDaysCountService workDaysCountService = new WorkDaysCountService(publicHolidaysService, workingTimeService);
-
-        // create working time object (MON-FRI)
-        final WorkingTime workingTime = new WorkingTime(new Person(), LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
-        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
-
-        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class)))
-            .thenReturn(Optional.of(workingTime));
 
         sut = new CalculationService(vacationDaysService, accountService, accountInteractionService, workDaysCountService,
             new OverlapService(null, null), applicationService);
@@ -90,13 +84,21 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndEnoughDaysLeftAreNegativeEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
+        final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
+        final LocalDate endDate = LocalDate.of(2012, AUGUST, 21);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
+
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
-        applicationForLeaveToCheckSaved.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheckSaved.setEndDate(LocalDate.of(2012, AUGUST, 21));
+        applicationForLeaveToCheckSaved.setStartDate(startDate);
+        applicationForLeaveToCheckSaved.setEndDate(endDate);
         applicationForLeaveToCheckSaved.setPerson(person);
         applicationForLeaveToCheckSaved.setDayLength(FULL);
 
@@ -104,8 +106,8 @@ class CalculationServiceTest {
 
         final Application applicationForLeaveToCheck = new Application();
         applicationForLeaveToCheck.setId(10);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(startDate);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -115,13 +117,21 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndEnoughDaysLeftAreNeutralEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+
+        final LocalDate startDate = LocalDate.of(2012, AUGUST, 19);
+        final LocalDate endDate = LocalDate.of(2012, AUGUST, 25);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
         applicationForLeaveToCheckSaved.setStartDate(LocalDate.of(2012, AUGUST, 23));
-        applicationForLeaveToCheckSaved.setEndDate(LocalDate.of(2012, AUGUST, 25));
+        applicationForLeaveToCheckSaved.setEndDate(endDate);
         applicationForLeaveToCheckSaved.setPerson(person);
         applicationForLeaveToCheckSaved.setDayLength(FULL);
 
@@ -129,7 +139,7 @@ class CalculationServiceTest {
 
         final Application applicationForLeaveToCheck = new Application();
         applicationForLeaveToCheck.setId(10);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 19));
+        applicationForLeaveToCheck.setStartDate(startDate);
         applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 21));
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
@@ -140,13 +150,21 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndEnoughDaysLeftArePositiveEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
+        final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
+        final LocalDate endDate = LocalDate.of(2012, AUGUST, 21);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
+
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
-        applicationForLeaveToCheckSaved.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheckSaved.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheckSaved.setStartDate(startDate);
+        applicationForLeaveToCheckSaved.setEndDate(startDate);
         applicationForLeaveToCheckSaved.setPerson(person);
         applicationForLeaveToCheckSaved.setDayLength(FULL);
 
@@ -154,8 +172,8 @@ class CalculationServiceTest {
 
         final Application applicationForLeaveToCheck = new Application();
         applicationForLeaveToCheck.setId(10);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 21));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -180,13 +198,21 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationDifferentYearAndEnoughDaysLeftAreNegativeEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
+        final LocalDate startDate = LocalDate.of(2012, DECEMBER, 28);
+        final LocalDate endDate = LocalDate.of(2013, JANUARY, 4);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
+
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
-        applicationForLeaveToCheckSaved.setStartDate(LocalDate.of(2012, DECEMBER, 28));
-        applicationForLeaveToCheckSaved.setEndDate(LocalDate.of(2013, JANUARY, 4));
+        applicationForLeaveToCheckSaved.setStartDate(startDate);
+        applicationForLeaveToCheckSaved.setEndDate(endDate);
         applicationForLeaveToCheckSaved.setPerson(person);
         applicationForLeaveToCheckSaved.setDayLength(FULL);
 
@@ -205,12 +231,20 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationDifferentYearAndEnoughDaysLeftAreNeutralEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
+        final LocalDate startDate = LocalDate.of(2012, DECEMBER, 29);
+        final LocalDate endDate = LocalDate.of(2013, JANUARY, 5);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
+
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
-        applicationForLeaveToCheckSaved.setStartDate(LocalDate.of(2012, DECEMBER, 29));
+        applicationForLeaveToCheckSaved.setStartDate(startDate);
         applicationForLeaveToCheckSaved.setEndDate(LocalDate.of(2013, JANUARY, 4));
         applicationForLeaveToCheckSaved.setPerson(person);
         applicationForLeaveToCheckSaved.setDayLength(FULL);
@@ -220,7 +254,7 @@ class CalculationServiceTest {
         final Application applicationForLeaveToCheck = new Application();
         applicationForLeaveToCheck.setId(10);
         applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, DECEMBER, 30));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2013, JANUARY, 5));
+        applicationForLeaveToCheck.setEndDate(endDate);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -230,8 +264,16 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationDifferentYearAndEnoughDaysLeftArePositiveEditing() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+
+        final LocalDate startDate = LocalDate.of(2012, DECEMBER, 28);
+        final LocalDate endDate = LocalDate.of(2013, JANUARY, 7);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheckSaved = new Application();
         applicationForLeaveToCheckSaved.setId(10);
@@ -244,8 +286,8 @@ class CalculationServiceTest {
 
         final Application applicationForLeaveToCheck = new Application();
         applicationForLeaveToCheck.setId(10);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, DECEMBER, 28));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2013, JANUARY, 7));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -285,12 +327,18 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndEnoughDaysLeft() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = new Application();
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -319,12 +367,18 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndNotEnoughDaysLeft() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = new Application();
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -353,12 +407,18 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationSameYearAndExactEnoughDaysLeft() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = new Application();
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -387,12 +447,18 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationOneDayIsToMuch() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
 
         final LocalDate validFrom = LocalDate.of(2012, JANUARY, 1);
         final LocalDate validTo = LocalDate.of(2012, DECEMBER, 31);
@@ -422,12 +488,19 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationRemainingVacationDaysLeftNotUsedAfterApril() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate startDate = LocalDate.of(2012, AUGUST, 6);
+        final LocalDate endDate = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, endDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheck = new Application();
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 6));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -456,23 +529,36 @@ class CalculationServiceTest {
 
     @Test
     void testPersonWithoutHolidayAccount() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
 
         assertThat(sut.checkApplication(applicationForLeaveToCheck)).isFalse();
     }
 
     @Test
     void testCheckApplicationOneDayIsOkay() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
 
         // enough vacation days for this application for leave, but none would be left
         final LocalDate validFrom = LocalDate.of(2012, JANUARY, 1);
@@ -503,12 +589,18 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationLastYear() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate date = LocalDate.of(2012, AUGUST, 20);
+
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
         final Application applicationForLeaveToCheck = new Application();
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 20));
+        applicationForLeaveToCheck.setStartDate(date);
+        applicationForLeaveToCheck.setEndDate(date);
         applicationForLeaveToCheck.setPerson(person);
         applicationForLeaveToCheck.setDayLength(FULL);
 
@@ -537,12 +629,19 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationOneDayIsOkayOverAYear() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate startDate = LocalDate.of(2012, DECEMBER, 30);
+        final LocalDate endDate = LocalDate.of(2013, JANUARY, 2);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, DECEMBER, 30));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2013, JANUARY, 2));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
 
         prepareSetupWith10DayAnnualVacation(person, 5, 4);
 
@@ -551,12 +650,19 @@ class CalculationServiceTest {
 
     @Test
     void testCheckApplicationOneDayIsNotOkayOverAYear() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate startDate = LocalDate.of(2012, DECEMBER, 30);
+        final LocalDate endDate = LocalDate.of(2013, JANUARY, 2);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, DECEMBER, 30));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2013, JANUARY, 2));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
 
         final LocalDate validFrom = LocalDate.of(2012, JANUARY, 1);
         final LocalDate validTo = LocalDate.of(2012, DECEMBER, 31);
@@ -588,13 +694,20 @@ class CalculationServiceTest {
      */
     @Test
     void testCheckApplicationNextYearUsingRemainingAlready() {
+        when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
+        final LocalDate endDate = LocalDate.of(2012, AUGUST, 30);
+
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
+        when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
         final Application applicationForLeaveToCheck = createApplicationStub(person);
         // nine days
-        applicationForLeaveToCheck.setStartDate(LocalDate.of(2012, AUGUST, 20));
-        applicationForLeaveToCheck.setEndDate(LocalDate.of(2012, AUGUST, 30));
+        applicationForLeaveToCheck.setStartDate(startDate);
+        applicationForLeaveToCheck.setEndDate(endDate);
 
         final Optional<Account> account2012 = Optional.of(new Account(person, getFirstDayOfYear(2012), getLastDayOfYear(2012), TEN, ZERO, ZERO, ""));
         when(accountService.getHolidaysAccount(2012, person)).thenReturn(account2012);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
@@ -91,7 +91,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
         final LocalDate endDate = LocalDate.of(2012, AUGUST, 21);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -124,7 +124,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, AUGUST, 19);
         final LocalDate endDate = LocalDate.of(2012, AUGUST, 25);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -157,7 +157,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
         final LocalDate endDate = LocalDate.of(2012, AUGUST, 21);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -205,7 +205,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, DECEMBER, 28);
         final LocalDate endDate = LocalDate.of(2013, JANUARY, 4);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -238,7 +238,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, DECEMBER, 29);
         final LocalDate endDate = LocalDate.of(2013, JANUARY, 5);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -271,7 +271,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, DECEMBER, 28);
         final LocalDate endDate = LocalDate.of(2013, JANUARY, 7);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -332,7 +332,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -372,7 +372,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -412,7 +412,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -452,7 +452,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -494,7 +494,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, AUGUST, 6);
         final LocalDate endDate = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, endDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, endDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -534,7 +534,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -552,7 +552,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -594,7 +594,7 @@ class CalculationServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate date = LocalDate.of(2012, AUGUST, 20);
 
-        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, date, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(date, date), workingTime));
 
@@ -635,7 +635,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, DECEMBER, 30);
         final LocalDate endDate = LocalDate.of(2013, JANUARY, 2);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -656,7 +656,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, DECEMBER, 30);
         final LocalDate endDate = LocalDate.of(2013, JANUARY, 2);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
@@ -700,7 +700,7 @@ class CalculationServiceTest {
         final LocalDate startDate = LocalDate.of(2012, AUGUST, 20);
         final LocalDate endDate = LocalDate.of(2012, AUGUST, 30);
 
-        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/CalculationServiceTest.java
@@ -81,7 +81,7 @@ class CalculationServiceTest {
         final WorkingTime workingTime = new WorkingTime(new Person(), LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         sut = new CalculationService(vacationDaysService, accountService, accountInteractionService, workDaysCountService,

--- a/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/availability/api/FreeTimeAbsenceProviderTest.java
@@ -42,7 +42,7 @@ class FreeTimeAbsenceProviderTest {
     @Test
     void ensurePersonIsNotAvailableOnFreeDays() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final LocalDate firstSundayIn2016 = LocalDate.of(2016, 1, 3);
         final TimedAbsenceSpans emptyTimedAbsenceSpans = new TimedAbsenceSpans(new ArrayList<>());
@@ -58,7 +58,7 @@ class FreeTimeAbsenceProviderTest {
 
         final LocalDate firstSundayIn2016 = LocalDate.of(2016, 1, 3);
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(person, firstSundayIn2016)).thenReturn(Optional.empty());
+        when(workingTimeService.getWorkingTime(person, firstSundayIn2016)).thenReturn(Optional.empty());
 
         final TimedAbsenceSpans knownAbsences = new TimedAbsenceSpans(new ArrayList<>());
         assertThatThrownBy(() -> sut.addAbsence(knownAbsences, person, firstSundayIn2016))
@@ -68,7 +68,7 @@ class FreeTimeAbsenceProviderTest {
     @Test
     void ensureDoesNotCallNextProviderIfAlreadyAbsentForWholeDay() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final LocalDate firstSundayIn2016 = LocalDate.of(2016, 1, 3);
         final TimedAbsenceSpans timedAbsenceSpans = new TimedAbsenceSpans(new ArrayList<>());
@@ -80,7 +80,7 @@ class FreeTimeAbsenceProviderTest {
     @Test
     void ensureCallsHolidayAbsenceProviderIfNotAbsentForFreeTime() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
+        when(workingTimeService.getWorkingTime(any(Person.class), any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final LocalDate standardWorkingDay = LocalDate.of(2016, 1, 4);
         final TimedAbsenceSpans emptyTimedAbsenceSpans = new TimedAbsenceSpans(new ArrayList<>());

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -15,7 +15,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -56,7 +55,7 @@ class DepartmentServiceImplTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
-    private final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+    private final Clock clock = Clock.fixed(Instant.now(), UTC);
 
     @BeforeEach
     void setUp() {
@@ -316,7 +315,7 @@ class DepartmentServiceImplTest {
 
         final Department updatedDepartment = sut.update(department);
 
-        assertThat(department.getLastModification()).isToday(); // department constructor currently sets the modification date
+        assertThat(department.getLastModification()).isEqualTo(LocalDate.now(clock)); // department constructor currently sets the modification date
         assertThat(updatedDepartment.getLastModification()).isEqualTo(expectedModificationDate);
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
@@ -49,9 +49,11 @@ class OvertimeServiceImplTest {
     @Mock
     private SettingsService settingsService;
 
+    private final Clock clock = Clock.systemUTC();
+
     @BeforeEach
     void setUp() {
-        sut = new OvertimeServiceImpl(overtimeRepository, commentDAO, applicationService, overtimeMailService, settingsService, Clock.systemUTC());
+        sut = new OvertimeServiceImpl(overtimeRepository, commentDAO, applicationService, overtimeMailService, settingsService, clock);
     }
 
     // Record overtime -------------------------------------------------------------------------------------------------
@@ -73,7 +75,7 @@ class OvertimeServiceImplTest {
         final Person author = new Person();
 
         final Overtime overtime = sut.record(new Overtime(), Optional.empty(), author);
-        assertThat(overtime.getLastModificationDate()).isToday();
+        assertThat(overtime.getLastModificationDate()).isEqualTo(LocalDate.now(clock));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteValidatorTest.java
@@ -55,7 +55,7 @@ class SickNoteValidatorTest {
     void ensureValidDatesHaveNoErrors() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -203,7 +203,7 @@ class SickNoteValidatorTest {
     void ensureAUStartDateMustBeBeforeAUEndDateToHaveAValidPeriod() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -222,7 +222,7 @@ class SickNoteValidatorTest {
     void ensureValidAUPeriodHasNoErrors() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -241,7 +241,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDays() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -260,7 +260,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDaysStart() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -279,7 +279,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDaysEnd() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -298,7 +298,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDaysStartOverlapping() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -317,7 +317,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDaysEndOverlapping() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -336,7 +336,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodMultipleDaysNoneOverlapping() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -356,7 +356,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodOneDay() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
             LocalDate.of(2013, NOVEMBER, 1),
@@ -374,7 +374,7 @@ class SickNoteValidatorTest {
     void ensureAUPeriodMustBeWithinSickNotePeriodButIsNotForOneDay() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -392,7 +392,7 @@ class SickNoteValidatorTest {
     @Test
     void ensureSickNoteMustNotHaveAnyOverlapping() {
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),
@@ -414,13 +414,13 @@ class SickNoteValidatorTest {
             LocalDate.of(2015, MARCH, 10),
             FULL);
 
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.empty());
 
         final Errors errors = new BeanPropertyBindingResult(sickNote, "sickNote");
         sut.validate(sickNote, errors);
         assertThat(errors.getGlobalErrors().get(0).getCode()).isEqualTo("sicknote.error.noValidWorkingTime");
-        verify(workingTimeService).getByPersonAndValidityDateEqualsOrMinorDate(sickNote.getPerson(), startDate);
+        verify(workingTimeService).getWorkingTime(sickNote.getPerson(), startDate);
     }
 
     @Test
@@ -441,7 +441,7 @@ class SickNoteValidatorTest {
     void ensureInvalidAUBPeriodWithValidPeriodIsNotValid() {
 
         when(overlapService.checkOverlap(any(SickNote.class))).thenReturn(NO_OVERLAPPING);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(any(Person.class),
+        when(workingTimeService.getWorkingTime(any(Person.class),
             any(LocalDate.class))).thenReturn(Optional.of(createWorkingTime()));
 
         final SickNote sickNote = createSickNote(new Person("muster", "Muster", "Marlene", "muster@example.org"),

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
@@ -43,6 +43,7 @@ import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_SACHS
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_SACHSEN_ANHALT;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_SCHLESWIG_HOLSTEIN;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_THUERINGEN;
+import static org.synyx.urlaubsverwaltung.workingtime.FederalState.NONE;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_AARGAU;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_APPENZELL_AUSSERRHODEN;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_APPENZELL_INNERRHODEN;
@@ -67,8 +68,8 @@ import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_T
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_URI;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_WAADT;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_WALLIS;
-import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_ZUG;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_ZUERICH;
+import static org.synyx.urlaubsverwaltung.workingtime.FederalState.SWITZERLAND_ZUG;
 
 /**
  * Unit test for {@link FederalState}.
@@ -77,6 +78,7 @@ class FederalStateTest {
 
     private static Stream<Arguments> provideFederalStateCode() {
         return Stream.of(
+            Arguments.of(NONE, "none", null),
             Arguments.of(GERMANY_BADEN_WUERTTEMBERG, "bw", null),
             Arguments.of(GERMANY_BAYERN, "by", null),
             Arguments.of(GERMANY_BAYERN_MUENCHEN, "by", "mu"),
@@ -142,7 +144,10 @@ class FederalStateTest {
     @MethodSource("provideFederalStateCode")
     void ensureCorrectCode(FederalState federalState, String region, String subregion) {
         final String[] codes = federalState.getCodes();
-        if (subregion == null) {
+        if (federalState == NONE) {
+            assertThat(codes)
+                .isEmpty();
+        } else if (subregion == null) {
             assertThat(codes)
                 .hasSize(1)
                 .contains(region);
@@ -155,6 +160,7 @@ class FederalStateTest {
 
     private static Stream<Arguments> provideFederalStateCountry() {
         return Stream.of(
+            Arguments.of(NONE, "none"),
             Arguments.of(GERMANY_BADEN_WUERTTEMBERG, "de"),
             Arguments.of(GERMANY_BAYERN, "de"),
             Arguments.of(GERMANY_BAYERN_MUENCHEN, "de"),

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -433,7 +433,7 @@ class WorkDaysCountServiceTest {
     }
 
     public static WorkingTime createWorkingTime(Person person, LocalDate validFrom, DayOfWeek... daysOfWeek) {
-        final WorkingTime workingTime = new WorkingTime(person, validFrom, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, validFrom, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setWorkingDays(List.of(daysOfWeek), FULL);
         return workingTime;
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
-import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysServiceImpl;
 import org.synyx.urlaubsverwaltung.settings.Settings;
@@ -35,9 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
-import static org.synyx.urlaubsverwaltung.TestDataCreator.createVacationTypeEntity;
-import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.HOLIDAY;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
 import static org.synyx.urlaubsverwaltung.period.DayLength.NOON;
@@ -75,11 +71,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for full days
-        application.setDayLength(FULL);
-
         final LocalDate startDate = LocalDate.of(2010, 12, 17);
         final LocalDate endDate = LocalDate.of(2010, 12, 31);
 
@@ -92,7 +83,7 @@ class WorkDaysCountServiceTest {
         //   Weekends : 2 (18-19 and 25-26 - already public holidays)) => 2
         // total days: 15
         // netto days: 10 (considering public holidays and weekends)
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(FULL, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(TEN);
     }
 
@@ -102,11 +93,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for full days
-        application.setDayLength(FULL);
-
         final LocalDate startDate = LocalDate.of(2009, 12, 17);
         final LocalDate endDate = LocalDate.of(2009, 12, 31);
 
@@ -119,7 +105,7 @@ class WorkDaysCountServiceTest {
         //   Weekends : 2 (19-20 and 26-27 - one is already public holidays)) => 3
         // total days: 15
         // netto days: 9 (considering public holidays and weekends)
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(FULL, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(9));
     }
 
@@ -150,19 +136,14 @@ class WorkDaysCountServiceTest {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final Person person = new Person();
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for half days morning
-        application.setDayLength(MORNING);
-
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate startDate = LocalDate.of(2011, 1, 4);
         final LocalDate endDate = LocalDate.of(2011, 1, 4);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(MORNING, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(0.5));
     }
 
@@ -172,18 +153,13 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for half days morning
-        application.setDayLength(MORNING);
-
         final LocalDate startDate = LocalDate.of(2011, 1, 4);
         final LocalDate endDate = LocalDate.of(2011, 1, 8);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(MORNING, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(1.5));
     }
 
@@ -192,19 +168,14 @@ class WorkDaysCountServiceTest {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
 
-        final Person person = new Person();
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for half days noon
-        application.setDayLength(NOON);
-
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final LocalDate startDate = LocalDate.of(2011, 1, 4);
         final LocalDate endDate = LocalDate.of(2011, 1, 4);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(NOON, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(0.5));
     }
 
@@ -214,11 +185,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for half days noon
-        application.setDayLength(NOON);
-
         final LocalDate startDate = LocalDate.of(2011, 1, 4);
         final LocalDate endDate = LocalDate.of(2011, 1, 8);
 
@@ -226,7 +192,7 @@ class WorkDaysCountServiceTest {
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
 
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(NOON, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(1.5));
     }
 
@@ -236,11 +202,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
-        // testing for full days
-        application.setDayLength(FULL);
-
         // start date is Sunday, end date Saturday
         final LocalDate startDate = LocalDate.of(2011, 1, 2);
         final LocalDate endDate = LocalDate.of(2011, 1, 8);
@@ -248,7 +209,7 @@ class WorkDaysCountServiceTest {
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(FULL, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(4));
     }
 
@@ -258,8 +219,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
         // Labour Day (1st May)
         final LocalDate startDate = LocalDate.of(2009, 4, 27);
         final LocalDate endDate = LocalDate.of(2009, 5, 2);
@@ -267,10 +226,7 @@ class WorkDaysCountServiceTest {
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        // testing for full days
-        application.setDayLength(FULL);
-
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(FULL, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(4));
     }
 
@@ -280,8 +236,6 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
-
         // start date and end date are not in the same year
         final LocalDate startDate = LocalDate.of(2011, 12, 26);
         final LocalDate endDate = LocalDate.of(2012, 1, 15);
@@ -289,10 +243,7 @@ class WorkDaysCountServiceTest {
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
 
-        // testing for full days
-        application.setDayLength(FULL);
-
-        final BigDecimal workDaysCount = sut.getWorkDaysCount(application.getDayLength(), startDate, endDate, person);
+        final BigDecimal workDaysCount = sut.getWorkDaysCount(FULL, startDate, endDate, person);
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(13));
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -77,7 +77,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for full days
         application.setDayLength(FULL);
@@ -104,7 +104,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for full days
         application.setDayLength(FULL);
@@ -131,7 +131,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         // testing for half days morning
@@ -153,7 +153,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for half days morning
         application.setDayLength(MORNING);
@@ -174,7 +174,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for half days noon
         application.setDayLength(NOON);
@@ -195,7 +195,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         // testing for half days noon
@@ -217,7 +217,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         // testing for full days
@@ -240,7 +240,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for full days
         application.setDayLength(FULL);
@@ -262,7 +262,7 @@ class WorkDaysCountServiceTest {
         final Application application = createApplication(person, createVacationTypeEntity(HOLIDAY));
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // testing for full days
         application.setDayLength(FULL);
@@ -283,7 +283,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
         workingTime.setWorkingDays(List.of(MONDAY, WEDNESDAY, FRIDAY, SATURDAY), FULL);
 
         final LocalDate startDate = LocalDate.of(2013, DECEMBER, 16);
@@ -301,7 +301,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
         workingTime.setWorkingDays(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY), FULL);
 
         final LocalDate startDate = LocalDate.of(2013, DECEMBER, 16);
@@ -319,7 +319,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // monday
         final LocalDate startDate = LocalDate.of(2013, NOVEMBER, 25);
@@ -337,7 +337,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // saturday
         final LocalDate startDate = LocalDate.of(2013, NOVEMBER, 23);
@@ -355,7 +355,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         // saturday
         final LocalDate startDate = LocalDate.of(2013, NOVEMBER, 23);
@@ -373,7 +373,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         final LocalDate date = LocalDate.of(2013, DECEMBER, 24);
 
@@ -389,7 +389,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         final LocalDate date = LocalDate.of(2013, DECEMBER, 24);
@@ -406,7 +406,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class)))
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class)))
             .thenReturn(Optional.of(workingTime));
 
         final LocalDate date = LocalDate.of(2013, DECEMBER, 31);
@@ -423,7 +423,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         final LocalDate date = LocalDate.of(2013, DECEMBER, 31);
 
@@ -439,7 +439,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         final LocalDate from = LocalDate.of(2013, DECEMBER, 23);
         final LocalDate to = LocalDate.of(2014, JANUARY, 2);
@@ -456,7 +456,7 @@ class WorkDaysCountServiceTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
         final WorkingTime workingTime = createWorkingTime();
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
 
         final LocalDate from = LocalDate.of(2013, DECEMBER, 23);
         final LocalDate to = LocalDate.of(2014, JANUARY, 2);

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
@@ -279,7 +279,7 @@ class WorkingTimeServiceImplTest {
         when(workingTimeRepository.findByPersonAndValidityDateEqualsOrMinorDate(batman, date))
             .thenReturn(workingTimeEntity);
 
-        final Optional<WorkingTime> actualWorkingTime = sut.getByPersonAndValidityDateEqualsOrMinorDate(batman, date);
+        final Optional<WorkingTime> actualWorkingTime = sut.getWorkingTime(batman, date);
 
         assertThat(actualWorkingTime).isNotEmpty();
         assertThat(actualWorkingTime.get().getPerson()).isEqualTo(batman);
@@ -309,7 +309,7 @@ class WorkingTimeServiceImplTest {
 
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final Optional<WorkingTime> actualWorkingTime = sut.getByPersonAndValidityDateEqualsOrMinorDate(batman, date);
+        final Optional<WorkingTime> actualWorkingTime = sut.getWorkingTime(batman, date);
 
         assertThat(actualWorkingTime).isNotEmpty();
         assertThat(actualWorkingTime.get().getPerson()).isEqualTo(batman);
@@ -322,7 +322,7 @@ class WorkingTimeServiceImplTest {
         when(workingTimeRepository.findByPersonAndValidityDateEqualsOrMinorDate(any(), any()))
             .thenReturn(null);
 
-        final Optional<WorkingTime> actualWorkingTime = sut.getByPersonAndValidityDateEqualsOrMinorDate(new Person(), LocalDate.now());
+        final Optional<WorkingTime> actualWorkingTime = sut.getWorkingTime(new Person(), LocalDate.now());
 
         assertThat(actualWorkingTime).isEmpty();
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeTest.java
@@ -36,7 +36,7 @@ class WorkingTimeTest {
         final Person person = new Person();
         person.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
         assertThat(workingTime.getMonday()).isEqualTo(ZERO);
         assertThat(workingTime.getTuesday()).isEqualTo(ZERO);
         assertThat(workingTime.getWednesday()).isEqualTo(ZERO);
@@ -54,13 +54,13 @@ class WorkingTimeTest {
 
         final List<DayOfWeek> workingDays = List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY);
 
-        final WorkingTime workingEveryDay = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingEveryDay = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
         workingEveryDay.setWorkingDays(workingDays, FULL);
 
         assertThat(workingEveryDay.getWorkingDays())
             .containsExactly(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY);
 
-        final WorkingTime workingNoDay = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingNoDay = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
         workingNoDay.setWorkingDays(workingDays, ZERO);
 
         assertThat(workingNoDay.getWorkingDays()).isEmpty();
@@ -80,7 +80,7 @@ class WorkingTimeTest {
         final Person person = new Person();
         person.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setDayLengthForWeekDay(dayOfWeek, dayLength);
         assertThat(workingTime.isWorkingDay(dayOfWeek)).isTrue();
     }
@@ -91,7 +91,7 @@ class WorkingTimeTest {
         final Person person = new Person();
         person.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.MIN, GERMANY_BADEN_WUERTTEMBERG, false);
         workingTime.setDayLengthForWeekDay(dayOfWeek, ZERO);
         assertThat(workingTime.isWorkingDay(dayOfWeek)).isFalse();
     }
@@ -104,8 +104,8 @@ class WorkingTimeTest {
         final Person robin = new Person();
         robin.setId(2);
 
-        final WorkingTime workingTimeBatman = new WorkingTime(batman, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG);
-        final WorkingTime workingTimeRobin = new WorkingTime(robin, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTimeBatman = new WorkingTime(batman, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG, false);
+        final WorkingTime workingTimeRobin = new WorkingTime(robin, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG, false);
 
         assertThat(workingTimeBatman)
             .isEqualTo(workingTimeBatman)
@@ -117,8 +117,8 @@ class WorkingTimeTest {
         final Person batman = new Person();
         batman.setId(1);
 
-        final WorkingTime workingTimeOne = new WorkingTime(batman, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG);
-        final WorkingTime workingTimeTwo = new WorkingTime(batman, LocalDate.of(2021, JUNE, 13), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTimeOne = new WorkingTime(batman, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG, false);
+        final WorkingTime workingTimeTwo = new WorkingTime(batman, LocalDate.of(2021, JUNE, 13), GERMANY_BADEN_WUERTTEMBERG, false);
 
         assertThat(workingTimeOne)
             .isEqualTo(workingTimeOne)
@@ -130,7 +130,7 @@ class WorkingTimeTest {
         final Person person = new Person();
         person.setId(1);
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2021, JUNE, 12), GERMANY_BADEN_WUERTTEMBERG, false);
 
         assertThat(workingTime.hashCode()).isEqualTo(4141357);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
@@ -80,7 +80,7 @@ class WorkingTimeViewControllerTest {
         final Person person = new Person();
         when(personService.getPersonByID(KNOWN_PERSON_ID)).thenReturn(Optional.of(person));
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020,10,2), GERMANY_BERLIN);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020,10,2), GERMANY_BERLIN, false);
         workingTime.setWorkingDays(List.of(MONDAY), DayLength.FULL);
         when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
         when(workingTimeService.getByPerson(person)).thenReturn(List.of(workingTime));

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
@@ -82,7 +82,7 @@ class WorkingTimeViewControllerTest {
 
         final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020,10,2), GERMANY_BERLIN);
         workingTime.setWorkingDays(List.of(MONDAY), DayLength.FULL);
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
         when(workingTimeService.getByPerson(person)).thenReturn(List.of(workingTime));
 
         perform(get("/web/person/" + KNOWN_PERSON_ID + "/workingtime"))
@@ -103,7 +103,7 @@ class WorkingTimeViewControllerTest {
         when(personService.getPersonByID(KNOWN_PERSON_ID)).thenReturn(Optional.of(person));
 
         when(settingsService.getSettings()).thenReturn(new Settings());
-        when(workingTimeService.getByPersonAndValidityDateEqualsOrMinorDate(eq(person), any(LocalDate.class))).thenReturn(Optional.empty());
+        when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.empty());
 
         perform(get("/web/person/" + KNOWN_PERSON_ID + "/workingtime"))
             .andExpect(model().attribute("workingTime", equalTo(new WorkingTimeForm())));


### PR DESCRIPTION
closes #1427
closes #2530
closes #2532
closes #2533

First idea is to add a "NONE" federalState enum and return empty optional/list from the public holiday service. Then "everything" should be automatically a normal workday. This "NONE" can be configured in the settings globally or for each person.

- [x] Add seperate tickets for that all FIXMEs
- [x] Fix #2530
- [x] Fix #2532
- [x] Fix #2533
- [x] introduce "NONE"
