### PR TITLE
Sets calendar entry for holiday replacement to free/available

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/Absence.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/Absence.java
@@ -76,8 +76,12 @@ public class Absence {
         return isAllDay;
     }
 
+    public boolean isHolidayReplacement() {
+        return absenceType == HOLIDAY_REPLACEMENT;
+    }
+
     public String getEventSubject() {
-        if (absenceType == HOLIDAY_REPLACEMENT) {
+        if (isHolidayReplacement()) {
             return format("Vertretung für %s", person.getNiceName());
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/ICalService.java
@@ -12,6 +12,7 @@ import net.fortuna.ical4j.model.property.Organizer;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.RefreshInterval;
 import net.fortuna.ical4j.model.property.Sequence;
+import net.fortuna.ical4j.model.property.Transp;
 import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.model.property.XProperty;
 import net.fortuna.ical4j.validate.ValidationException;
@@ -36,6 +37,7 @@ import static java.util.Date.from;
 import static net.fortuna.ical4j.model.parameter.Role.REQ_PARTICIPANT;
 import static net.fortuna.ical4j.model.property.CalScale.GREGORIAN;
 import static net.fortuna.ical4j.model.property.Method.CANCEL;
+import static net.fortuna.ical4j.model.property.Transp.VALUE_TRANSPARENT;
 import static net.fortuna.ical4j.model.property.Version.VERSION_2_0;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.calendar.ICalType.CANCELLED;
@@ -129,6 +131,10 @@ public class ICalService {
 
         event.getProperties().add(new Uid(generateUid(absence)));
         event.getProperties().add(generateAttendee(absence));
+
+        if (absence.isHolidayReplacement()) {
+            event.getProperties().add(new Transp(VALUE_TRANSPARENT));
+        }
 
         if (method == CANCELLED) {
             event.getProperties().add(new Sequence(1));

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -216,8 +216,40 @@ class ICalServiceTest {
             .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
     }
 
+    @Test
+    void holidayReplacement() {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+
+        final Absence holidayReplacement = holidayReplacement(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), FULL);
+
+        final CalendarProperties calendarProperties = new CalendarProperties();
+        calendarProperties.setOrganizer("no-reply@example.org");
+        final ICalService sut = new ICalService(calendarProperties);
+
+        final ByteArrayResource calendar = sut.getSingleAppointment(holidayReplacement, PUBLISHED);
+        assertThat(convertCalendar(calendar))
+            .contains("VERSION:2.0")
+            .contains("CALSCALE:GREGORIAN")
+            .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
+            .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
+
+            .contains("SUMMARY:Vertretung für Marlene Muster")
+            .contains("X-MICROSOFT-CDO-ALLDAYEVENT:TRUE")
+            .contains("DTSTART;VALUE=DATE:20190526")
+            .contains("TRANSP:TRANSPARENT")
+            .contains("UID:D2A4772AEB3FD20D5F6997FCD8F28719")
+
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
+    }
+
     private Absence absence(Person person, LocalDate start, LocalDate end, DayLength length) {
         return absence(person, start, end, length, AbsenceType.DEFAULT);
+    }
+
+    private Absence holidayReplacement(Person person, LocalDate start, LocalDate end, DayLength length) {
+        return absence(person, start, end, length, AbsenceType.HOLIDAY_REPLACEMENT);
     }
 
     private Absence absence(Person person, LocalDate start, LocalDate end, DayLength length, AbsenceType absenceType) {


### PR DESCRIPTION
Adds TRANSP:TRANSPARENT attribute to VEvent of holiday replacement

https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.7

Example:
[holidayReplacement.ics.txt](https://github.com/synyx/urlaubsverwaltung/files/8398793/holidayReplacement.ics.txt)

Tested with:

- [x] Thunderbird
- [x] Nextcloud
- [x] Outlook 365
- [x] Morgen
- [x] Apple Calendar (iPhone)

closes #2794

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
