### PR TITLE
Add end date of sick pay days in notification

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailService.java
@@ -7,11 +7,14 @@ import org.synyx.urlaubsverwaltung.mail.Mail;
 import org.synyx.urlaubsverwaltung.mail.MailService;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_OFFICE;
 
@@ -23,12 +26,14 @@ class SickNoteMailService {
     private final SettingsService settingsService;
     private final SickNoteService sickNoteService;
     private final MailService mailService;
+    private final Clock clock;
 
     @Autowired
-    SickNoteMailService(SettingsService settingsService, SickNoteService sickNoteService, MailService mailService) {
+    SickNoteMailService(SettingsService settingsService, SickNoteService sickNoteService, MailService mailService, Clock clock) {
         this.settingsService = settingsService;
         this.sickNoteService = sickNoteService;
         this.mailService = mailService;
+        this.clock = clock;
     }
 
     /**
@@ -40,27 +45,35 @@ class SickNoteMailService {
 
         LOG.info("Found {} sick notes reaching end of sick pay", sickNotes.size());
 
-        final String subjectMessageKey = "subject.sicknote.endOfSickPay";
-        final String templateName = "sicknote_end_of_sick_pay";
         final Integer maximumSickPayDays = settingsService.getSettings().getSickNoteSettings().getMaximumSickPayDays();
 
         for (SickNote sickNote : sickNotes) {
 
-            Map<String, Object> model = new HashMap<>();
+            // we need to subtract 1 day, because the start date is inclusive
+            final LocalDate lastDayOfSickPayDays = sickNote.getStartDate()
+                .plus(maximumSickPayDays.longValue(), DAYS)
+                .minusDays(1);
+            final boolean isLastDayOfSickPayDaysInPast = lastDayOfSickPayDays.isBefore(LocalDate.now(clock));
+
+            final Map<String, Object> model = new HashMap<>();
             model.put("maximumSickPayDays", maximumSickPayDays);
+            model.put("endOfSickPayDays", lastDayOfSickPayDays);
+            model.put("isLastDayOfSickPayDaysInPast", isLastDayOfSickPayDaysInPast);
+            model.put("sickNotePayFrom", sickNote.getStartDate());
+            model.put("sickNotePayTo", lastDayOfSickPayDays);
             model.put("sickNote", sickNote);
 
             final Mail toSickNotePerson = Mail.builder()
                 .withRecipient(sickNote.getPerson())
-                .withSubject(subjectMessageKey)
-                .withTemplate(templateName, model)
+                .withSubject("subject.sicknote.endOfSickPay")
+                .withTemplate("sicknote_end_of_sick_pay", model)
                 .build();
             mailService.send(toSickNotePerson);
 
             final Mail toOffice = Mail.builder()
                 .withRecipient(NOTIFICATION_OFFICE)
-                .withSubject(subjectMessageKey)
-                .withTemplate(templateName, model)
+                .withSubject("subject.sicknote.endOfSickPay.office", sickNote.getPerson().getNiceName())
+                .withTemplate("sicknote_end_of_sick_pay_office", model)
                 .build();
             mailService.send(toOffice);
             sickNoteService.setEndOfSickPayNotificationSend(sickNote);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -726,7 +726,8 @@ subject.application.cancellationRequest.declined.management=Stornierungsantrag a
 
 # sick notes
 subject.sicknote.converted=Deine Krankmeldung wurde in eine Abwesenheit umgewandelt
-subject.sicknote.endOfSickPay=Ende der Lohnfortzahlung
+subject.sicknote.endOfSickPay=Ende deiner Lohnfortzahlung
+subject.sicknote.endOfSickPay.office=Ende der Lohnfortzahlung von {0}
 # overtime
 subject.overtime.created=Es wurden Überstunden eingetragen
 # accounts

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -705,6 +705,7 @@ subject.application.cancellationRequest.declined.management=Το αίτημα α
 # sick notes
 subject.sicknote.converted=Το σημείωμα ασθενείας σας έχει μετατραπεί σε άδεια
 subject.sicknote.endOfSickPay=Τέλος πληρωμής ασθενείας
+subject.sicknote.endOfSickPay.office=Τέλος πληρωμής ασθενείας
 # overtime
 subject.overtime.created=Καταγράφηκαν υπερωρίες
 # accounts

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -722,7 +722,8 @@ subject.application.cancellationRequest.declined.management=Cancellation request
 
 # sick notes
 subject.sicknote.converted=Your sick note has been turned into a absence
-subject.sicknote.endOfSickPay=End of sick payment
+subject.sicknote.endOfSickPay=End of your sick payment
+subject.sicknote.endOfSickPay.office=End of {0} sick payment
 # overtime
 subject.overtime.created=Overtime was registered
 # accounts

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/sicknote_end_of_sick_pay_office.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/sicknote_end_of_sick_pay_office.ftl
@@ -1,6 +1,6 @@
 Hallo ${recipient.niceName},
 
-dein Anspruch auf Lohnfortzahlung von ${maximumSickPayDays} Tag(en) <#if isLastDayOfSickPayDaysInPast>endete<#else>endet</#if> am ${endOfSickPayDays.format("dd.MM.yyyy")}.
+der Anspruch auf Lohnfortzahlung von ${sickNote.person.niceName} von ${maximumSickPayDays} Tag(en) <#if isLastDayOfSickPayDaysInPast>endete<#else>endet</#if> am ${endOfSickPayDays.format("dd.MM.yyyy")}.
 
     ${baseLinkURL}web/sicknote/${sickNote.id?c}
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceIT.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +28,8 @@ import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 @SpringBootTest(properties = {"spring.mail.port=3025", "spring.mail.host=localhost"})
 @Transactional
 class SickNoteMailServiceIT extends TestContainersBase {
+
+    private static final String EMAIL_LINE_BREAK = "\r\n";
 
     @RegisterExtension
     public final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
@@ -45,8 +46,8 @@ class SickNoteMailServiceIT extends TestContainersBase {
     void sendEndOfSickPayNotification() throws MessagingException, IOException {
 
         final Person office = new Person("office", "Muster", "Marlene", "office@example.org");
-        office.setPermissions(singletonList(OFFICE));
-        office.setNotifications(singletonList(NOTIFICATION_OFFICE));
+        office.setPermissions(List.of(OFFICE));
+        office.setNotifications(List.of(NOTIFICATION_OFFICE));
         personService.save(office);
 
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
@@ -54,8 +55,8 @@ class SickNoteMailServiceIT extends TestContainersBase {
         final SickNote sickNote = new SickNote();
         sickNote.setId(1);
         sickNote.setPerson(person);
-        sickNote.setStartDate(LocalDate.of(2020, 2, 1));
-        sickNote.setEndDate(LocalDate.of(2020, 4, 1));
+        sickNote.setStartDate(LocalDate.of(2022, 2, 1));
+        sickNote.setEndDate(LocalDate.of(2022, 4, 1));
 
         final List<SickNote> sickNotes = List.of(sickNote);
         when(sickNoteService.getSickNotesReachingEndOfSickPay()).thenReturn(sickNotes);
@@ -63,7 +64,7 @@ class SickNoteMailServiceIT extends TestContainersBase {
         sickNoteMailService.sendEndOfSickPayNotification();
 
         // Where both mails sent?
-        MimeMessage[] inboxOffice = greenMail.getReceivedMessagesForDomain(office.getEmail());
+        final MimeMessage[] inboxOffice = greenMail.getReceivedMessagesForDomain(office.getEmail());
         assertThat(inboxOffice.length).isOne();
 
         final MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(person.getEmail());
@@ -71,28 +72,50 @@ class SickNoteMailServiceIT extends TestContainersBase {
 
         // check email of user
         final Message msgUser = inbox[0];
-        assertThat(msgUser.getSubject()).isEqualTo("Ende der Lohnfortzahlung");
+        assertThat(msgUser.getSubject()).isEqualTo("Ende deiner Lohnfortzahlung");
 
         final String content = (String) msgUser.getContent();
-        assertThat(content).contains("Hallo Lieschen Müller");
-        assertThat(content).contains("Die Krankmeldung von Lieschen Müller");
-        assertThat(content).contains("(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage).");
-        assertThat(content).contains("für den Zeitraum 01.02.2020 - 01.04.2020 erreicht in Kürze die 42 Tage Grenze");
-        assertThat(content).contains("Für Details siehe:");
-        assertThat(content).contains("web/sicknote/1");
+        assertThat(content).contains("Hallo Lieschen Müller," + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "dein Anspruch auf Lohnfortzahlung von 42 Tag(en) endete am 14.03.2022." + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "    https://localhost:8080/web/sicknote/1" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "Informationen zur Krankmeldung:" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "    Mitarbeiter:                  Lieschen Müller" + EMAIL_LINE_BREAK +
+            "    Zeitraum:                     01.02.2022 bis 01.04.2022" + EMAIL_LINE_BREAK +
+            "    Anspruch auf Lohnfortzahlung: 01.02.2022 bis 14.03.2022" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "Hinweis:" + EMAIL_LINE_BREAK +
+            "Der Anspruch auf Lohnfortzahlung durch den Arbeitgeber im Krankheitsfall besteht für maximal 42 Tage" + EMAIL_LINE_BREAK +
+            "(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage)." + EMAIL_LINE_BREAK +
+            "Danach wird für gesetzlich Krankenversicherte in der Regel Krankengeld von der Krankenkasse gezahlt.");
 
         // check email of office
-        Message msgOffice = inboxOffice[0];
-        assertThat(msgOffice.getSubject()).isEqualTo("Ende der Lohnfortzahlung");
+        final Message msgOffice = inboxOffice[0];
+        assertThat(msgOffice.getSubject()).isEqualTo("Ende der Lohnfortzahlung von Lieschen Müller");
 
         // check content of office email
-        String contentOfficeMail = (String) msgOffice.getContent();
-        assertThat(contentOfficeMail).contains("Hallo Marlene Muster");
-        assertThat(contentOfficeMail).contains("Die Krankmeldung von Lieschen Müller");
-        assertThat(contentOfficeMail).contains("(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage).");
-        assertThat(contentOfficeMail).contains("für den Zeitraum 01.02.2020 - 01.04.2020 erreicht in Kürze die 42 Tage Grenze");
-        assertThat(contentOfficeMail).contains("Für Details siehe:");
-        assertThat(contentOfficeMail).contains("web/sicknote/1");
+        final String contentOfficeMail = (String) msgOffice.getContent();
+        assertThat(contentOfficeMail).contains("Hallo Marlene Muster," + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "der Anspruch auf Lohnfortzahlung von Lieschen Müller von 42 Tag(en) endete am 14.03.2022." + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "    https://localhost:8080/web/sicknote/1" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "Informationen zur Krankmeldung:" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "    Mitarbeiter:                  Lieschen Müller" + EMAIL_LINE_BREAK +
+            "    Zeitraum:                     01.02.2022 bis 01.04.2022" + EMAIL_LINE_BREAK +
+            "    Anspruch auf Lohnfortzahlung: 01.02.2022 bis 14.03.2022" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "" + EMAIL_LINE_BREAK +
+            "Hinweis:" + EMAIL_LINE_BREAK +
+            "Der Anspruch auf Lohnfortzahlung durch den Arbeitgeber im Krankheitsfall besteht für maximal 42 Tage" + EMAIL_LINE_BREAK +
+            "(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage)." + EMAIL_LINE_BREAK +
+            "Danach wird für gesetzlich Krankenversicherte in der Regel Krankengeld von der Krankenkasse gezahlt.");
 
         verify(sickNoteService).setEndOfSickPayNotificationSend(sickNote);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
@@ -14,6 +14,8 @@ import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.sicknote.settings.SickNoteSettings;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +42,7 @@ class SickNoteMailServiceTest {
 
     @BeforeEach
     void setUp() {
-        sut = new SickNoteMailService(settingsService, sickNoteService, mailService);
+        sut = new SickNoteMailService(settingsService, sickNoteService, mailService, Clock.systemUTC());
     }
 
     @Test
@@ -52,21 +54,33 @@ class SickNoteMailServiceTest {
         final SickNote sickNoteA = new SickNote();
         sickNoteA.setId(1);
         sickNoteA.setPerson(person);
+        sickNoteA.setStartDate(LocalDate.of(2022, 4, 1));
+        sickNoteA.setEndDate(LocalDate.of(2022, 4, 13));
 
         final SickNote sickNoteB = new SickNote();
         sickNoteB.setId(2);
         sickNoteB.setPerson(person);
+        sickNoteB.setStartDate(LocalDate.of(2022, 4, 10));
+        sickNoteB.setEndDate(LocalDate.of(2022, 4, 20));
 
         when(sickNoteService.getSickNotesReachingEndOfSickPay()).thenReturn(asList(sickNoteA, sickNoteB));
 
         prepareSettingsWithMaximumSickPayDays(5);
 
-        Map<String, Object> modelA = new HashMap<>();
+        final Map<String, Object> modelA = new HashMap<>();
         modelA.put("maximumSickPayDays", 5);
+        modelA.put("endOfSickPayDays", LocalDate.of(2022,4,5));
+        modelA.put("isLastDayOfSickPayDaysInPast", true);
+        modelA.put("sickNotePayFrom", sickNoteA.getStartDate());
+        modelA.put("sickNotePayTo", LocalDate.of(2022,4,5));
         modelA.put("sickNote", sickNoteA);
 
-        Map<String, Object> modelB = new HashMap<>();
+        final Map<String, Object> modelB = new HashMap<>();
         modelB.put("maximumSickPayDays", 5);
+        modelB.put("endOfSickPayDays", LocalDate.of(2022,4,14));
+        modelB.put("isLastDayOfSickPayDaysInPast", false);
+        modelB.put("sickNotePayFrom", sickNoteB.getStartDate());
+        modelB.put("sickNotePayTo", LocalDate.of(2022,4,14));
         modelB.put("sickNote", sickNoteB);
 
         sut.sendEndOfSickPayNotification();
@@ -79,16 +93,16 @@ class SickNoteMailServiceTest {
         assertThat(mails.get(0).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay");
         assertThat(mails.get(0).getTemplateModel()).isEqualTo(modelA);
         assertThat(mails.get(1).getMailNotificationRecipients()).hasValue(NOTIFICATION_OFFICE);
-        assertThat(mails.get(1).getSubjectMessageKey()).isEqualTo("subject.sicknote.endOfSickPay");
-        assertThat(mails.get(1).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay");
+        assertThat(mails.get(1).getSubjectMessageKey()).isEqualTo("subject.sicknote.endOfSickPay.office");
+        assertThat(mails.get(1).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay_office");
         assertThat(mails.get(1).getTemplateModel()).isEqualTo(modelA);
         assertThat(mails.get(2).getMailAddressRecipients()).hasValue(List.of(sickNoteB.getPerson()));
         assertThat(mails.get(2).getSubjectMessageKey()).isEqualTo("subject.sicknote.endOfSickPay");
         assertThat(mails.get(2).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay");
         assertThat(mails.get(2).getTemplateModel()).isEqualTo(modelB);
         assertThat(mails.get(3).getMailNotificationRecipients()).hasValue(NOTIFICATION_OFFICE);
-        assertThat(mails.get(3).getSubjectMessageKey()).isEqualTo("subject.sicknote.endOfSickPay");
-        assertThat(mails.get(3).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay");
+        assertThat(mails.get(3).getSubjectMessageKey()).isEqualTo("subject.sicknote.endOfSickPay.office");
+        assertThat(mails.get(3).getTemplateName()).isEqualTo("sicknote_end_of_sick_pay_office");
         assertThat(mails.get(3).getTemplateModel()).isEqualTo(modelB);
 
         verify(sickNoteService).setEndOfSickPayNotificationSend(sickNoteA);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
@@ -78,7 +78,7 @@ class SickNoteMailServiceTest {
         final Map<String, Object> modelB = new HashMap<>();
         modelB.put("maximumSickPayDays", 5);
         modelB.put("endOfSickPayDays", LocalDate.of(2022,4,14));
-        modelB.put("isLastDayOfSickPayDaysInPast", false);
+        modelB.put("isLastDayOfSickPayDaysInPast", true);
         modelB.put("sickNotePayFrom", sickNoteB.getStartDate());
         modelB.put("sickNotePayTo", LocalDate.of(2022,4,14));
         modelB.put("sickNote", sickNoteB);
@@ -118,7 +118,6 @@ class SickNoteMailServiceTest {
         sut.sendEndOfSickPayNotification();
         verifyNoInteractions(mailService);
     }
-
 
     private void prepareSettingsWithRemindForWaitingApplications(Boolean isActive) {
         Settings settings = new Settings();


### PR DESCRIPTION
closes #2821

Benachrichtigung sieht dann so aus

Für Office:
```
Hallo Marlene Muster,

der Anspruch auf Lohnfortzahlung von Anne Roth von 42 Tag(en) endete am 14.03.2022.

    http://localhost:8080/web/sicknote/25

Informationen zur Krankmeldung:

    Mitarbeiter:                  Anne Roth
    Zeitraum:                     01.02.2022 bis 24.03.2022
    Anspruch auf Lohnfortzahlung: 01.02.2022 bis 14.03.2022


Hinweis:
Der Anspruch auf Lohnfortzahlung durch den Arbeitgeber im Krankheitsfall besteht für maximal 42 Tage
(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage).
Danach wird für gesetzlich Krankenversicherte in der Regel Krankengeld von der Krankenkasse gezahlt.
```

für die Mitarbeitenden:

```
Hallo Anne Roth,

dein Anspruch auf Lohnfortzahlung von 42 Tag(en) endete am 14.03.2022.

    http://localhost:8080/web/sicknote/25

Informationen zur Krankmeldung:

    Mitarbeiter:                  Anne Roth
    Zeitraum:                     01.02.2022 bis 24.03.2022
    Anspruch auf Lohnfortzahlung: 01.02.2022 bis 14.03.2022


Hinweis:
Der Anspruch auf Lohnfortzahlung durch den Arbeitgeber im Krankheitsfall besteht für maximal 42 Tage
(fortlaufende Kalendertage ohne Rücksicht auf die Arbeitstage des erkrankten Arbeitnehmers, Sonn- oder Feiertage).
Danach wird für gesetzlich Krankenversicherte in der Regel Krankengeld von der Krankenkasse gezahlt.
```