### PR TITLE
Added property to customize the generated url for calendar sharing

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarProperties.java
@@ -26,6 +26,8 @@ public class CalendarProperties {
     @NotEmpty
     private String organizer;
 
+    private String url;
+
     /**
      * Defines a refresh interval for iCal Feed.
      * This property specifies a suggested minimum interval for polling for changes of the calendar data from
@@ -51,6 +53,12 @@ public class CalendarProperties {
 
     public void setOrganizer(String organizer) {
         this.organizer = organizer;
+    }
+
+    public String getUrl() { return url; }
+
+    public void setUrl(String url) {
+        this.url = url;
     }
 
     public Duration getRefreshInterval() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
@@ -54,10 +54,12 @@ class CalendarSharingViewControllerTest {
     private DepartmentService departmentService;
     @Mock
     private CalendarAccessibleService calendarAccessibleService;
+    @Mock
+    private CalendarProperties calendarProperties;
 
     @BeforeEach
     void setUp() {
-        sut = new CalendarSharingViewController(personCalendarService, departmentCalendarService, companyCalendarService, personService, departmentService, calendarAccessibleService);
+        sut = new CalendarSharingViewController(personCalendarService, departmentCalendarService, companyCalendarService, personService, departmentService, calendarAccessibleService, calendarProperties);
     }
 
     @Test


### PR DESCRIPTION
If the server running the application is located behind a reverse proxy, the automatically generated url for the calendar sharing could be not reachable from outside, e.g. when the server runs on a non-standard TCP port but the proxy listens to 80 or 443 ports.

The following property can now be used in the application.properties file to override the standard automatic generation of the url:
```
uv.calendar.url=http://external.url.of.urlaubsverwaltung/
```

if the property is missing in the file, the standard logic will be used to generate the url

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
