### PR TITLE
fix Benutzerliste anzeigen nach Session Timeout

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
@@ -10,9 +10,7 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.synyx.urlaubsverwaltung.account.Account;
@@ -86,7 +84,6 @@ public class PersonsViewController {
                                  @SortDefault(sort = "person.firstName", direction = Sort.Direction.ASC)
                              })
                              Pageable pageable,
-                             @RequestHeader(name = "Turbo-Frame", required = false) String turboFrame,
                              Model model) throws UnknownDepartmentException {
 
         final int currentYear = Year.now(clock).getValue();
@@ -135,13 +132,8 @@ public class PersonsViewController {
         model.addAttribute("selectedYear", selectedYear);
         model.addAttribute("active", active);
         model.addAttribute("query", query);
-        model.addAttribute("turboFrameRequested", StringUtils.hasText(turboFrame));
 
-        if (turboFrame == null || turboFrame.isBlank()) {
-            return "thymeleaf/person/persons";
-        } else {
-            return "thymeleaf/person/persons::#" + turboFrame;
-        }
+        return "thymeleaf/person/persons";
     }
 
     private Page<Person> getRelevantActivePersons(Person signedInUser, PageableSearchQuery personPageableSearchQuery) {

--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -35,6 +35,7 @@
     <meta name="msapplication-TileImage" th:content="@{/favicons/ms-icon-144x144.png}" />
     <meta th:if="${theme != 'dark'}" name="theme-color" content="#fafafa" />
     <meta th:if="${theme == 'dark'}" name="theme-color" content="#18181b" />
+    <meta name="turbo-root" th:content="@{/web}" />
 
     <link rel="stylesheet" type="text/css" asset:href="common.css" />
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />

--- a/src/main/resources/templates/thymeleaf/person/persons.html
+++ b/src/main/resources/templates/thymeleaf/person/persons.html
@@ -169,26 +169,24 @@
       </div>
 
       <turbo-frame id="frame-persons">
-        <th:block th:if="${turboFrameRequested}">
-          <turbo-stream target="persons-filter" action="replace">
-            <template th:insert="::#persons-filter"></template>
-          </turbo-stream>
-          <turbo-stream target="persons-form-query-inputs" action="replace">
-            <template th:insert="::#persons-form-query-inputs"></template>
-          </turbo-stream>
-          <turbo-stream target="persons-form-sort-inputs" action="replace">
-            <template th:insert="::#persons-form-sort-inputs"></template>
-          </turbo-stream>
-          <turbo-stream target="persons-pagination" action="replace">
-            <template th:insert="::#persons-pagination"></template>
-          </turbo-stream>
-          <turbo-stream target="persons-form-size-inputs" action="replace">
-            <template th:insert="::#persons-form-size-inputs"></template>
-          </turbo-stream>
-          <turbo-stream target="pagination-size-hint" action="replace">
-            <template th:insert="::#pagination-size-hint"></template>
-          </turbo-stream>
-        </th:block>
+        <turbo-stream target="persons-filter" action="replace">
+          <template th:insert="::#persons-filter"></template>
+        </turbo-stream>
+        <turbo-stream target="persons-form-query-inputs" action="replace">
+          <template th:insert="::#persons-form-query-inputs"></template>
+        </turbo-stream>
+        <turbo-stream target="persons-form-sort-inputs" action="replace">
+          <template th:insert="::#persons-form-sort-inputs"></template>
+        </turbo-stream>
+        <turbo-stream target="persons-pagination" action="replace">
+          <template th:insert="::#persons-pagination"></template>
+        </turbo-stream>
+        <turbo-stream target="persons-form-size-inputs" action="replace">
+          <template th:insert="::#persons-form-size-inputs"></template>
+        </turbo-stream>
+        <turbo-stream target="pagination-size-hint" action="replace">
+          <template th:insert="::#pagination-size-hint"></template>
+        </turbo-stream>
         <p th:if="${#lists.isEmpty(personPage.content)}" class="tw-mt-16" th:text="#{persons.none}"></p>
         <th:block th:if="${not #lists.isEmpty(personPage.content)}">
           <p class="text-right visible-print">

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
@@ -91,19 +91,6 @@ class PersonsViewControllerTest {
     }
 
     @Test
-    void ensurePersonsPageTurboFrameRenderedWhenHeaderIsSet() throws Exception {
-
-        final Person signedInUser = personWithRole(USER, BOSS);
-        when(personService.getSignedInUser()).thenReturn(signedInUser);
-
-        final PageImpl<Person> page = new PageImpl<>(List.of());
-        when(personService.getActivePersons(defaultPersonSearchQuery())).thenReturn(page);
-
-        perform(get("/web/person").header("Turbo-Frame", "persons-frame"))
-            .andExpect(view().name("thymeleaf/person/persons::#persons-frame"));
-    }
-
-    @Test
     void showPersonWithActiveTrueForUserWithRoleOfficeCallsCorrectService() throws Exception {
 
         final Person signedInUser = personWithRole(USER, OFFICE);


### PR DESCRIPTION
closes #3252

- Turbo soll nur `/web` kontrollieren -> `/login` wird mit einem kompletten Seitenreload geladen und angezeigt
- immer komplette Seite rendern -> ansonsten wird nach einem erneuten Login und redirect nur das eine `turbo-frame` gerendert. Der Header wird nach dem Login nochmal mitgeschickt, obwohl wir die komplette Seite brauchen.
