### PR TITLE
Set VEVENT to transparent if attendee is not the person of the calender

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailService.java
@@ -69,7 +69,7 @@ class ApplicationMailService {
 
     void sendAllowedNotification(Application application, ApplicationComment applicationComment) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT);
+        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, application.getPerson());
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -344,7 +344,7 @@ class ApplicationMailService {
      */
     void notifyHolidayReplacementAboutDirectlyAllowedApplication(HolidayReplacementEntity holidayReplacement, Application application) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, AbsenceType.HOLIDAY_REPLACEMENT);
+        final ByteArrayResource calendarFile = generateCalendar(application, AbsenceType.HOLIDAY_REPLACEMENT, holidayReplacement.getPerson());
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -395,7 +395,7 @@ class ApplicationMailService {
      */
     void notifyHolidayReplacementAllow(HolidayReplacementEntity holidayReplacement, Application application) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, AbsenceType.HOLIDAY_REPLACEMENT);
+        final ByteArrayResource calendarFile = generateCalendar(application, AbsenceType.HOLIDAY_REPLACEMENT, holidayReplacement.getPerson());
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -422,7 +422,7 @@ class ApplicationMailService {
      */
     void notifyHolidayReplacementAboutCancellation(HolidayReplacementEntity holidayReplacement, Application application) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED);
+        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED, holidayReplacement.getPerson());
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -587,7 +587,8 @@ class ApplicationMailService {
      */
     void sendCancelledDirectlyConfirmationByApplicant(Application application, ApplicationComment comment) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED);
+        final Person recipient = application.getPerson();
+        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED, recipient);
 
         final Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -597,7 +598,7 @@ class ApplicationMailService {
 
         // send cancelled by office information to the applicant
         final Mail mailToApplicant = Mail.builder()
-            .withRecipient(application.getPerson())
+            .withRecipient(recipient)
             .withSubject("subject.application.cancelledDirectly.user")
             .withTemplate("cancelled_directly_confirmation_applicant", model)
             .withAttachment(CALENDAR_ICS, calendarFile)
@@ -638,7 +639,7 @@ class ApplicationMailService {
      */
     void sendCancelledConfirmationByManagement(Application application, ApplicationComment comment) {
 
-        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED);
+        final ByteArrayResource calendarFile = generateCalendar(application, DEFAULT, CANCELLED, application.getPerson());
 
         Map<String, Object> model = new HashMap<>();
         model.put(APPLICATION, application);
@@ -837,13 +838,13 @@ class ApplicationMailService {
         return messageSource.getMessage(key, args, GERMAN);
     }
 
-    private ByteArrayResource generateCalendar(Application application, AbsenceType absenceType) {
-        return generateCalendar(application, absenceType, PUBLISHED);
+    private ByteArrayResource generateCalendar(Application application, AbsenceType absenceType, Person recipient) {
+        return generateCalendar(application, absenceType, PUBLISHED, recipient);
     }
 
-    private ByteArrayResource generateCalendar(Application application, AbsenceType absenceType, ICalType iCalType) {
+    private ByteArrayResource generateCalendar(Application application, AbsenceType absenceType, ICalType iCalType, Person recipient) {
         final Absence absence = new Absence(application.getPerson(), application.getPeriod(), getAbsenceTimeConfiguration(), absenceType);
-        return iCalService.getSingleAppointment(absence, iCalType);
+        return iCalService.getSingleAppointment(absence, iCalType, recipient);
     }
 
     private AbsenceTimeConfiguration getAbsenceTimeConfiguration() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CompanyCalendarService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CompanyCalendarService.java
@@ -79,7 +79,7 @@ class CompanyCalendarService {
         final LocalDate sinceDate = LocalDate.now(clock).minus(companyCalendar.getCalendarPeriod());
         final List<Absence> absences = absenceService.getOpenAbsencesSince(sinceDate);
 
-        return iCalService.getCalendar(title, absences);
+        return iCalService.getCalendar(title, absences, person);
     }
 
     @Transactional

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarService.java
@@ -104,7 +104,7 @@ class DepartmentCalendarService {
 
         final List<Absence> absences = absenceService.getOpenAbsencesSince(department.getMembers(), sinceDate);
 
-        return iCalService.getCalendar(title, absences);
+        return iCalService.getCalendar(title, absences, person);
     }
 
     @Transactional

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/PersonCalendarService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/PersonCalendarService.java
@@ -83,7 +83,7 @@ class PersonCalendarService {
         final LocalDate sinceDate = LocalDate.now(clock).minus(personCalendar.getCalendarPeriod());
         final List<Absence> absences = absenceService.getOpenAbsencesSince(List.of(person), sinceDate);
 
-        return iCalService.getCalendar(title, absences);
+        return iCalService.getCalendar(title, absences, person);
     }
 
     @Transactional

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceTest.java
@@ -77,7 +77,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final ByteArrayResource attachment = new ByteArrayResource("".getBytes());
-        when(iCalService.getSingleAppointment(any(), any())).thenReturn(attachment);
+        when(iCalService.getSingleAppointment(any(), any(), any())).thenReturn(attachment);
 
         when(messageSource.getMessage(any(), any(), any())).thenReturn("something");
 
@@ -360,7 +360,7 @@ class ApplicationMailServiceTest {
         model.put("dayLength", "FULL");
 
         final ByteArrayResource attachment = new ByteArrayResource("".getBytes());
-        when(iCalService.getSingleAppointment(any(), any())).thenReturn(attachment);
+        when(iCalService.getSingleAppointment(any(), any(), any())).thenReturn(attachment);
 
         sut.notifyHolidayReplacementAllow(replacementEntity, application);
 
@@ -459,7 +459,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final ByteArrayResource attachment = new ByteArrayResource("".getBytes());
-        when(iCalService.getSingleAppointment(any(), any())).thenReturn(attachment);
+        when(iCalService.getSingleAppointment(any(), any(), any())).thenReturn(attachment);
 
         final DayLength dayLength = FULL;
         when(messageSource.getMessage(eq(dayLength.name()), any(), any())).thenReturn("FULL");
@@ -802,7 +802,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final ByteArrayResource attachment = new ByteArrayResource("".getBytes());
-        when(iCalService.getSingleAppointment(any(), any())).thenReturn(attachment);
+        when(iCalService.getSingleAppointment(any(), any(), any())).thenReturn(attachment);
 
         final DayLength dayLength = FULL;
         when(messageSource.getMessage(eq(dayLength.name()), any(), any())).thenReturn("FULL");
@@ -889,7 +889,7 @@ class ApplicationMailServiceTest {
         when(settingsService.getSettings()).thenReturn(settings);
 
         final ByteArrayResource attachment = new ByteArrayResource("".getBytes());
-        when(iCalService.getSingleAppointment(any(), any())).thenReturn(attachment);
+        when(iCalService.getSingleAppointment(any(), any(), any())).thenReturn(attachment);
 
         final Person person = new Person();
         final Person office = new Person();

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CompanyCalendarServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CompanyCalendarServiceTest.java
@@ -80,7 +80,7 @@ class CompanyCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.company.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender der Firma");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar.ics");
-        when(iCalService.getCalendar("Abwesenheitskalender der Firma", absences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender der Firma", absences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForAll(10, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarServiceTest.java
@@ -116,7 +116,7 @@ class DepartmentCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.department.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender der Abteilung DepartmentName");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar");
-        when(iCalService.getCalendar("Abwesenheitskalender der Abteilung DepartmentName", fullDayAbsences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender der Abteilung DepartmentName", fullDayAbsences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForDepartment(1, 10, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/ICalServiceTest.java
@@ -42,22 +42,27 @@ class ICalServiceTest {
     @Test
     void getCalendarForPersonAndNoAbsenceFound() {
 
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of());
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(), null);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
             .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
             .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
             .contains("X-WR-CALNAME:Abwesenheitskalender")
-            .contains("REFRESH-INTERVAL:P1D");
+            .contains("REFRESH-INTERVAL:P1D")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void getCalendarForPersonForOneFullDay() {
 
-        final Absence fullDayAbsence = absence(new Person("muster", "Muster", "Marlene", "muster@example.org"), toDateTime("2019-03-26"), toDateTime("2019-03-26"), FULL);
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
 
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(fullDayAbsence));
+        final Absence fullDayAbsence = absence(person, toDateTime("2019-03-26"), toDateTime("2019-03-26"), FULL);
+
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(fullDayAbsence), person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -70,15 +75,20 @@ class ICalServiceTest {
             .contains("X-MICROSOFT-CDO-ALLDAYEVENT:TRUE")
             .contains("DTSTART;VALUE=DATE:20190326")
 
-            .contains("ORGANIZER:mailto:no-reply@example.org");
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void getCalendarForPersonForHalfDayMorning() {
 
-        final Absence morningAbsence = absence(new Person("muster", "Muster", "Marlene", "muster@example.org"), toDateTime("2019-04-26"), toDateTime("2019-04-26"), MORNING);
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
 
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(morningAbsence));
+        final Absence morningAbsence = absence(person, toDateTime("2019-04-26"), toDateTime("2019-04-26"), MORNING);
+
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(morningAbsence), person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -91,15 +101,20 @@ class ICalServiceTest {
             .contains("DTSTART:20190426T080000Z")
             .contains("DTEND:20190426T120000Z")
 
-            .contains("ORGANIZER:mailto:no-reply@example.org");
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void getCalendarForPersonForMultipleFullDays() {
 
-        final Absence manyFullDayAbsence = absence(new Person("muster", "Muster", "Marlene", "muster@example.org"), toDateTime("2019-03-26"), toDateTime("2019-04-01"), FULL);
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
 
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(manyFullDayAbsence));
+        final Absence manyFullDayAbsence = absence(person, toDateTime("2019-03-26"), toDateTime("2019-04-01"), FULL);
+
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(manyFullDayAbsence), person);
 
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
@@ -114,15 +129,20 @@ class ICalServiceTest {
             .contains("DTSTART;VALUE=DATE:20190326")
             .contains("DTEND;VALUE=DATE:20190402")
 
-            .contains("ORGANIZER:mailto:no-reply@example.org");
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void getCalendarForPersonForHalfDayNoon() {
 
-        final Absence noonAbsence = absence(new Person("muster", "Muster", "Marlene", "muster@example.org"), toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
 
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(noonAbsence));
+        final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
+
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(noonAbsence), person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -135,19 +155,23 @@ class ICalServiceTest {
             .contains("DTSTART:20190526T120000Z")
             .contains("DTEND:20190526T160000Z")
 
-            .contains("ORGANIZER:mailto:no-reply@example.org");
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void getCalendarPublishEvent() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
+
         final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
 
         final CalendarProperties calendarProperties = new CalendarProperties();
         calendarProperties.setOrganizer("no-reply@example.org");
         final ICalService sut = new ICalService(calendarProperties);
-        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(noonAbsence));
+        final ByteArrayResource calendar = sut.getCalendar("Abwesenheitskalender", List.of(noonAbsence), person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -156,25 +180,29 @@ class ICalServiceTest {
             .contains("X-WR-CALNAME:Abwesenheitskalender")
             .contains("REFRESH-INTERVAL:P1D")
 
-            .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
+            .contains("UID:BB2267885BD8DF263E88D3062853E8A7")
             .contains("SUMMARY:Marlene Muster abwesend")
             .contains("DTSTART:20190526T120000Z")
             .contains("DTEND:20190526T160000Z")
             .contains("ORGANIZER:mailto:no-reply@example.org")
-            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
+            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void cancelSingleAppointment() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
+
         final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
 
         final CalendarProperties calendarProperties = new CalendarProperties();
         calendarProperties.setOrganizer("no-reply@example.org");
         final ICalService sut = new ICalService(calendarProperties);
 
-        final ByteArrayResource calendar = sut.getSingleAppointment(noonAbsence, CANCELLED);
+        final ByteArrayResource calendar = sut.getSingleAppointment(noonAbsence, CANCELLED, person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -185,24 +213,27 @@ class ICalServiceTest {
             .contains("SUMMARY:Marlene Muster abwesend")
             .contains("DTSTART:20190526T120000Z")
             .contains("DTEND:20190526T160000Z")
-            .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
+            .contains("UID:BB2267885BD8DF263E88D3062853E8A7")
             .contains("SEQUENCE:1")
 
             .contains("ORGANIZER:mailto:no-reply@example.org")
-            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
+            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
     }
 
     @Test
     void singleAppointment() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
         final Absence noonAbsence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), NOON);
 
         final CalendarProperties calendarProperties = new CalendarProperties();
         calendarProperties.setOrganizer("no-reply@example.org");
         final ICalService sut = new ICalService(calendarProperties);
 
-        final ByteArrayResource calendar = sut.getSingleAppointment(noonAbsence, PUBLISHED);
+        final ByteArrayResource calendar = sut.getSingleAppointment(noonAbsence, PUBLISHED, person);
         assertThat(convertCalendar(calendar))
             .contains("VERSION:2.0")
             .contains("CALSCALE:GREGORIAN")
@@ -212,7 +243,41 @@ class ICalServiceTest {
             .contains("SUMMARY:Marlene Muster abwesend")
             .contains("DTSTART:20190526T120000Z")
             .contains("DTEND:20190526T160000Z")
-            .contains("UID:497ED5D042F718878138A3E2F8C3C35C")
+            .contains("UID:BB2267885BD8DF263E88D3062853E8A7")
+
+            .contains("ORGANIZER:mailto:no-reply@example.org")
+            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org")
+
+            .doesNotContain("TRANS:TRANSPARENT");
+    }
+
+    @Test
+    void appointmentOfOtherPerson() {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1);
+
+        final Person recipient = new Person();
+        recipient.setId(2);
+
+        final Absence absence = absence(person, toDateTime("2019-05-26"), toDateTime("2019-05-26"), FULL);
+
+        final CalendarProperties calendarProperties = new CalendarProperties();
+        calendarProperties.setOrganizer("no-reply@example.org");
+        final ICalService sut = new ICalService(calendarProperties);
+
+        final ByteArrayResource calendar = sut.getSingleAppointment(absence, PUBLISHED, recipient);
+        assertThat(convertCalendar(calendar))
+            .contains("VERSION:2.0")
+            .contains("CALSCALE:GREGORIAN")
+            .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
+            .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
+
+            .contains("SUMMARY:Marlene Muster abwesend")
+            .contains("X-MICROSOFT-CDO-ALLDAYEVENT:TRUE")
+            .contains("DTSTART;VALUE=DATE:20190526")
+            .contains("TRANSP:TRANSPARENT")
+            .contains("UID:22D8DC26F4271C049ED5601345B58D9C")
 
             .contains("ORGANIZER:mailto:no-reply@example.org")
             .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
@@ -229,21 +294,21 @@ class ICalServiceTest {
         calendarProperties.setOrganizer("no-reply@example.org");
         final ICalService sut = new ICalService(calendarProperties);
 
-        final ByteArrayResource calendar = sut.getSingleAppointment(holidayReplacement, PUBLISHED);
+        final ByteArrayResource calendar = sut.getSingleAppointment(holidayReplacement, PUBLISHED, person);
         assertThat(convertCalendar(calendar))
-            .contains("VERSION:2.0")
-            .contains("CALSCALE:GREGORIAN")
-            .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
-            .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
+                .contains("VERSION:2.0")
+                .contains("CALSCALE:GREGORIAN")
+                .contains("PRODID:-//Urlaubsverwaltung//iCal4j 1.0//DE")
+                .contains("X-MICROSOFT-CALSCALE:GREGORIAN")
 
-            .contains("SUMMARY:Vertretung für Marlene Muster")
-            .contains("X-MICROSOFT-CDO-ALLDAYEVENT:TRUE")
-            .contains("DTSTART;VALUE=DATE:20190526")
-            .contains("TRANSP:TRANSPARENT")
-            .contains("UID:D2A4772AEB3FD20D5F6997FCD8F28719")
+                .contains("SUMMARY:Vertretung für Marlene Muster")
+                .contains("X-MICROSOFT-CDO-ALLDAYEVENT:TRUE")
+                .contains("DTSTART;VALUE=DATE:20190526")
+                .contains("TRANSP:TRANSPARENT")
+                .contains("UID:D2A4772AEB3FD20D5F6997FCD8F28719")
 
-            .contains("ORGANIZER:mailto:no-reply@example.org")
-            .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
+                .contains("ORGANIZER:mailto:no-reply@example.org")
+                .contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=Marlene Muster:mailto:muster@example.org");
     }
 
     private Absence absence(Person person, LocalDate start, LocalDate end, DayLength length) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/PersonCalendarServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/PersonCalendarServiceTest.java
@@ -78,7 +78,7 @@ class PersonCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.person.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender von Marlene Muster");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar.ics");
-        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", fullDayAbsences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", fullDayAbsences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForPerson(1, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);
@@ -101,7 +101,7 @@ class PersonCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.person.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender von Marlene Muster");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar.ics");
-        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", morningAbsences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", morningAbsences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForPerson(1, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);
@@ -124,7 +124,7 @@ class PersonCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.person.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender von Marlene Muster");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar.ics");
-        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", manyFullDayAbsences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", manyFullDayAbsences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForPerson(1, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);
@@ -147,7 +147,7 @@ class PersonCalendarServiceTest {
 
         when(messageSource.getMessage(eq("calendar.person.title"), any(), eq(GERMAN))).thenReturn("Abwesenheitskalender von Marlene Muster");
         final ByteArrayResource iCal = new ByteArrayResource(new byte[]{}, "calendar.ics");
-        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", noonAbsences)).thenReturn(iCal);
+        when(iCalService.getCalendar("Abwesenheitskalender von Marlene Muster", noonAbsences, person)).thenReturn(iCal);
 
         final ByteArrayResource calendar = sut.getCalendarForPerson(1, "secret", GERMAN);
         assertThat(calendar).isEqualTo(iCal);


### PR DESCRIPTION
This will result in free / not busy state to busy time searches.

see: https://www.kanzaki.com/docs/ical/transp.html

- [x] add tests

closes: #3306

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
